### PR TITLE
feat: add E2E test suite and bump version to 0.1.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,11 @@ const service = new LLMService(customProvider);
 - Jest with ts-jest for TypeScript support
 - All tests co-located with source files (e.g., `LLMService.test.ts`)
 - 100% test coverage for core functionality
+- **E2E Tests:** Separate suite in `e2e-tests/` that makes real API calls
+  - Run with `npm run test:e2e` (requires `E2E_*_API_KEY` environment variables)
+  - **Use sparingly** - only when modifying provider adapters or LLMService
+  - Costs real money - uses cheapest models but still incurs API charges
+  - Not run in CI by default to avoid costs
 
 **GitHub Automation & CI/CD:**
 - **CI runs automatically** on push/PR to main branch

--- a/README.md
+++ b/README.md
@@ -405,6 +405,26 @@ npm run build
 npm test
 ```
 
+### End-to-End Testing
+
+The project includes an end-to-end test suite that makes real API calls to providers. These tests are separate from the main unit test suite and are not run in CI by default.
+
+To run these tests locally, you must first provide API keys as environment variables with the `E2E_` prefix:
+
+```bash
+export E2E_OPENAI_API_KEY="sk-..."
+export E2E_ANTHROPIC_API_KEY="sk-ant-..."
+export E2E_GEMINI_API_KEY="AIza..."
+```
+
+Then, run the E2E test script:
+
+```bash
+npm run test:e2e
+```
+
+The tests will automatically skip any provider for which an API key is not found.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/e2e-tests/providers.e2e.test.ts
+++ b/e2e-tests/providers.e2e.test.ts
@@ -1,0 +1,71 @@
+import { LLMService, fromEnvironment } from '../src/index';
+import type { ApiKeyProvider } from '../src/types';
+import type { LLMResponse } from '../src/llm/types';
+
+// Test-specific API key provider that looks for E2E-prefixed env vars
+const e2eKeyProvider: ApiKeyProvider = async (providerId: string) => {
+  const envVarName = `E2E_${providerId.toUpperCase()}_API_KEY`;
+  return process.env[envVarName] || null;
+};
+
+const llmService = new LLMService(e2eKeyProvider);
+
+// --- OpenAI Tests ---
+const openaiApiKey = process.env.E2E_OPENAI_API_KEY;
+(openaiApiKey ? describe : describe.skip)('OpenAI E2E', () => {
+  it('should receive a valid response from gpt-4.1-nano', async () => {
+    const response = await llmService.sendMessage({
+      providerId: 'openai',
+      modelId: 'gpt-4.1-nano',
+      messages: [{ role: 'user', content: 'What is 1 + 1? Respond with the numerical answer only.' }],
+      settings: { temperature: 0 }
+    });
+    
+    expect(response.object).toBe('chat.completion');
+    if (response.object === 'chat.completion') {
+      const content = response.choices[0].message.content;
+      expect(content).toBeDefined();
+      expect(content).toContain('2');
+    }
+  });
+});
+
+// --- Anthropic Tests ---
+const anthropicApiKey = process.env.E2E_ANTHROPIC_API_KEY;
+(anthropicApiKey ? describe : describe.skip)('Anthropic E2E', () => {
+  it('should receive a valid response from claude-3-5-haiku-20241022', async () => {
+    const response = await llmService.sendMessage({
+      providerId: 'anthropic',
+      modelId: 'claude-3-5-haiku-20241022',
+      messages: [{ role: 'user', content: 'What is 2 + 2? Respond with the numerical answer only.' }],
+      settings: { temperature: 0 }
+    });
+
+    expect(response.object).toBe('chat.completion');
+    if (response.object === 'chat.completion') {
+      const content = response.choices[0].message.content;
+      expect(content).toBeDefined();
+      expect(content).toContain('4');
+    }
+  });
+});
+
+// --- Gemini Tests ---
+const geminiApiKey = process.env.E2E_GEMINI_API_KEY;
+(geminiApiKey ? describe : describe.skip)('Gemini E2E', () => {
+  it('should receive a valid response from gemini-2.0-flash-lite', async () => {
+    const response = await llmService.sendMessage({
+      providerId: 'gemini',
+      modelId: 'gemini-2.0-flash-lite',
+      messages: [{ role: 'user', content: 'What is 3 + 3? Respond with the numerical answer only.' }],
+      settings: { temperature: 0 }
+    });
+
+    expect(response.object).toBe('chat.completion');
+    if (response.object === 'chat.completion') {
+      const content = response.choices[0].message.content;
+      expect(content).toBeDefined();
+      expect(content).toContain('6');
+    }
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
-  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/e2e-tests/'],
 };

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,0 +1,8 @@
+const baseConfig = require('./jest.config.js');
+
+module.exports = {
+  ...baseConfig,
+  testMatch: ['<rootDir>/e2e-tests/**/*.e2e.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'], // Reset to not ignore itself
+  testTimeout: 30000, // 30 seconds
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -37,7 +37,8 @@
   "scripts": {
     "build": "tsc",
     "test": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:e2e": "npm run build && jest --config jest.e2e.config.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",


### PR DESCRIPTION
## Summary
- Implement comprehensive E2E test suite for real API validation
- Add cost-effective tests for OpenAI, Anthropic, and Gemini providers
- Bump version to 0.1.3

## Changes
This PR adds a dedicated end-to-end test suite that makes real API calls to validate provider adapters:

### New E2E Test Infrastructure
- **`e2e-tests/providers.e2e.test.ts`**: Tests for all major providers using cheapest models
- **`jest.e2e.config.js`**: Separate Jest configuration with 30s timeout for API calls
- **`npm run test:e2e`**: New script to run E2E tests (builds first, then runs tests)

### Key Features
- 🔐 **Secure**: Uses `E2E_*_API_KEY` environment variables to prevent accidental API usage
- 💰 **Cost-conscious**: Uses cheapest models (gpt-4.1-nano, claude-3-5-haiku, gemini-2.0-flash-lite)
- ⏭️ **Selective**: Automatically skips providers without configured API keys
- 🧪 **Simple**: Uses basic arithmetic tests to minimize token usage
- 🚫 **CI-safe**: Not run by default in CI to avoid costs

### Documentation Updates
- Updated `README.md` with E2E testing instructions
- Updated `CLAUDE.md` with E2E test details

## Test Results
All E2E tests pass successfully:
- ✅ OpenAI (gpt-4.1-nano) - 743ms
- ✅ Anthropic (claude-3-5-haiku) - 1097ms  
- ✅ Gemini (gemini-2.0-flash-lite) - 410ms

## Version Bump
- Version updated from 0.1.2 to 0.1.3

🤖 Generated with [Claude Code](https://claude.ai/code)