### PR TITLE
fix: handle system messages for models without system instruction support

### DIFF
--- a/genai-lite-docs/llm-service.md
+++ b/genai-lite-docs/llm-service.md
@@ -12,6 +12,7 @@ Complete guide to text generation and chat completions using genai-lite's LLMSer
 - [Self-Contained Templates](#self-contained-templates-with-metadata) - Templates with embedded settings
 - [Model Presets](#model-presets) - Pre-configured model settings
 - [Advanced Settings](#advanced-settings) - Fine-tuning model behavior
+  - [System Message Fallback](#system-message-fallback) - Handling models without system message support
 - [Error Handling](#error-handling) - Handling failures
 - [Related Documentation](#related-documentation) - Provider info, utilities
 
@@ -501,6 +502,39 @@ const response = await llmService.sendMessage({
 | `stopSequences` | string[] | `[]` | Stop generation at these sequences |
 | `reasoning` | object | - | Reasoning configuration (see [Reasoning Mode](#reasoning-mode)) |
 | `thinkingTagFallback` | object | - | Thinking tag configuration (see [Thinking Tag Fallback](#thinking-tag-fallback)) |
+| `systemMessageFallback` | object | - | System message format when model lacks native support (see below) |
+
+### System Message Fallback
+
+Some models (e.g., Gemma) don't support native system instructions. When `supportsSystemMessage: false` is set for a model, genai-lite automatically prepends system content to the first user message.
+
+You can configure how this prepending is formatted:
+
+```typescript
+const response = await llmService.sendMessage({
+  providerId: 'gemini',
+  modelId: 'gemma-3-27b-it',
+  systemMessage: 'You are a helpful assistant.',
+  messages: [{ role: 'user', content: 'Hello' }],
+  settings: {
+    systemMessageFallback: {
+      format: 'xml',           // 'xml' (default), 'separator', or 'plain'
+      tagName: 'system',       // Tag name for xml format (default: 'system')
+      separator: '\n\n---\n\n' // Separator for separator format
+    }
+  }
+});
+```
+
+**Format options:**
+
+| Format | Result |
+|--------|--------|
+| `xml` (default) | `<system>\n{content}\n</system>\n\n{user message}` |
+| `separator` | `{content}{separator}{user message}` |
+| `plain` | `{content}\n\n{user message}` |
+
+This is handled automatically for models with `supportsSystemMessage: false` in their configuration. Most users won't need to configure this manually.
 
 ---
 

--- a/genai-lite-docs/providers-and-models.md
+++ b/genai-lite-docs/providers-and-models.md
@@ -105,6 +105,7 @@ Complete reference of all supported AI providers and models in genai-lite.
 - Unique safety settings structure
 - Gemini models support multimodal (text, images, audio, video)
 - Gemma 3 27B is open-weight and **free** via the Gemini API (no API costs)
+- **Gemma models do not support system instructions** - genai-lite automatically prepends system content to the first user message (see [System Message Fallback](llm-service.md#system-message-fallback))
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-lite",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-lite",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.56.0",
@@ -80,7 +80,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1759,7 +1758,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2805,7 +2803,6 @@
       "integrity": "sha512-9QE0RS4WwTj/TtTC4h/eFVmFAhGNVerSB9XpJh8sqaXlP73ILcPcZ7JWjjEtJJe2m8QyBLKKfPQuK+3F+Xij/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.4",
         "@jest/types": "30.0.1",
@@ -4568,7 +4565,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4966,7 +4962,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/llm/clients/AnthropicClientAdapter.test.ts
+++ b/src/llm/clients/AnthropicClientAdapter.test.ts
@@ -40,6 +40,7 @@ describe('AnthropicClientAdapter', () => {
         user: 'test-user',
         geminiSafetySettings: [],
         supportsSystemMessage: true,
+        systemMessageFallback: { format: 'xml', tagName: 'system', separator: '---' },
         reasoning: {
           enabled: false,
           effort: undefined as any,

--- a/src/llm/clients/AnthropicClientAdapter.ts
+++ b/src/llm/clients/AnthropicClientAdapter.ts
@@ -10,6 +10,10 @@ import type {
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
+import {
+  collectSystemContent,
+  prependSystemToFirstUserMessage,
+} from "../../shared/adapters/systemMessageUtils";
 import { createDefaultLogger } from "../../logging/defaultLogger";
 
 const logger = createDefaultLogger();
@@ -169,18 +173,16 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     systemMessage?: string;
   } {
     const messages: Anthropic.Messages.MessageParam[] = [];
-    let systemMessage = request.systemMessage;
+    const inlineSystemMessages: string[] = [];
+
+    // Check if model supports system messages
+    const supportsSystem = request.settings.supportsSystemMessage !== false;
 
     // Process conversation messages
     for (const message of request.messages) {
       if (message.role === "system") {
-        // Anthropic handles system messages separately
-        // If we already have a system message, append to it
-        if (systemMessage) {
-          systemMessage += "\n\n" + message.content;
-        } else {
-          systemMessage = message.content;
-        }
+        // Collect inline system messages
+        inlineSystemMessages.push(message.content);
       } else if (message.role === "user") {
         messages.push({
           role: "user",
@@ -191,6 +193,39 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
           role: "assistant",
           content: message.content,
         });
+      }
+    }
+
+    // Use shared utility to collect and combine system content
+    const { combinedSystemContent, useNativeSystemMessage } = collectSystemContent(
+      request.systemMessage,
+      inlineSystemMessages,
+      supportsSystem
+    );
+
+    let systemMessage: string | undefined;
+
+    if (combinedSystemContent) {
+      if (useNativeSystemMessage) {
+        // Model supports system messages - use Anthropic's system parameter
+        systemMessage = combinedSystemContent;
+      } else {
+        // Model doesn't support system messages - prepend to first user message
+        const simpleMessages = messages.map((m) => ({
+          role: m.role,
+          content: m.content as string,
+        }));
+        const modifiedIndex = prependSystemToFirstUserMessage(
+          simpleMessages,
+          combinedSystemContent
+        );
+        if (modifiedIndex !== -1) {
+          messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;
+          logger.debug(
+            `Model ${request.modelId} doesn't support system messages - prepended to first user message`
+          );
+        }
+        // Don't set systemMessage - it stays undefined
       }
     }
 

--- a/src/llm/clients/AnthropicClientAdapter.ts
+++ b/src/llm/clients/AnthropicClientAdapter.ts
@@ -217,7 +217,8 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
         }));
         const modifiedIndex = prependSystemToFirstUserMessage(
           simpleMessages,
-          combinedSystemContent
+          combinedSystemContent,
+          request.settings.systemMessageFallback
         );
         if (modifiedIndex !== -1) {
           messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;

--- a/src/llm/clients/GeminiClientAdapter.test.ts
+++ b/src/llm/clients/GeminiClientAdapter.test.ts
@@ -44,6 +44,7 @@ describe('GeminiClientAdapter', () => {
         user: 'test-user',
         geminiSafetySettings: [],
         supportsSystemMessage: true,
+        systemMessageFallback: { format: 'xml', tagName: 'system', separator: '---' },
         reasoning: {
           enabled: false,
           effort: undefined as any,
@@ -164,7 +165,7 @@ describe('GeminiClientAdapter', () => {
         // Instead, it should be prepended to the first user message
         expect(callArgs.contents).toHaveLength(1);
         expect(callArgs.contents[0].role).toBe('user');
-        expect(callArgs.contents[0].parts[0].text).toBe('You are a helpful assistant.\n\nHello');
+        expect(callArgs.contents[0].parts[0].text).toBe('<system>\nYou are a helpful assistant.\n</system>\n\nHello');
       });
 
       it('should handle request.systemMessage when supportsSystemMessage is false', async () => {
@@ -194,7 +195,7 @@ describe('GeminiClientAdapter', () => {
 
         const callArgs = mockGenerateContent.mock.calls[0][0];
         expect(callArgs.config.systemInstruction).toBeUndefined();
-        expect(callArgs.contents[0].parts[0].text).toBe('Base system instruction\n\nHello');
+        expect(callArgs.contents[0].parts[0].text).toBe('<system>\nBase system instruction\n</system>\n\nHello');
       });
 
       it('should combine request.systemMessage and inline system messages when supportsSystemMessage is false', async () => {
@@ -226,7 +227,7 @@ describe('GeminiClientAdapter', () => {
         const callArgs = mockGenerateContent.mock.calls[0][0];
         expect(callArgs.config.systemInstruction).toBeUndefined();
         expect(callArgs.contents[0].parts[0].text).toBe(
-          'Base system instruction\n\nAdditional system content\n\nHello'
+          '<system>\nBase system instruction\n\nAdditional system content\n</system>\n\nHello'
         );
       });
 

--- a/src/llm/clients/GeminiClientAdapter.ts
+++ b/src/llm/clients/GeminiClientAdapter.ts
@@ -180,7 +180,8 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
         }));
         const modifiedIndex = prependSystemToFirstUserMessage(
           simpleContents,
-          combinedSystemContent
+          combinedSystemContent,
+          request.settings.systemMessageFallback
         );
         if (modifiedIndex !== -1) {
           // Update the actual contents array

--- a/src/llm/clients/LlamaCppClientAdapter.test.ts
+++ b/src/llm/clients/LlamaCppClientAdapter.test.ts
@@ -50,6 +50,7 @@ describe('LlamaCppClientAdapter', () => {
         frequencyPenalty: 0.0,
         presencePenalty: 0.0,
         supportsSystemMessage: true,
+        systemMessageFallback: { format: 'xml', tagName: 'system', separator: '---' },
         user: '' as any,
         geminiSafetySettings: [],
         reasoning: {

--- a/src/llm/clients/LlamaCppClientAdapter.ts
+++ b/src/llm/clients/LlamaCppClientAdapter.ts
@@ -335,7 +335,8 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
         }));
         const modifiedIndex = prependSystemToFirstUserMessage(
           simpleMessages,
-          combinedSystemContent
+          combinedSystemContent,
+          request.settings.systemMessageFallback
         );
         if (modifiedIndex !== -1) {
           messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;

--- a/src/llm/clients/LlamaCppClientAdapter.ts
+++ b/src/llm/clients/LlamaCppClientAdapter.ts
@@ -9,6 +9,10 @@ import type {
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
+import {
+  collectSystemContent,
+  prependSystemToFirstUserMessage,
+} from "../../shared/adapters/systemMessageUtils";
 import { LlamaCppServerClient } from "./LlamaCppServerClient";
 import { detectGgufCapabilities } from "../config";
 import { createDefaultLogger } from "../../logging/defaultLogger";
@@ -286,22 +290,16 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest
   ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
     const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+    const inlineSystemMessages: string[] = [];
 
-    // Add system message if provided
-    if (request.systemMessage) {
-      messages.push({
-        role: "system",
-        content: request.systemMessage,
-      });
-    }
+    // Check if model supports system messages
+    const supportsSystem = request.settings.supportsSystemMessage !== false;
 
-    // Add conversation messages
+    // Add conversation messages (collecting system messages separately)
     for (const message of request.messages) {
       if (message.role === "system") {
-        messages.push({
-          role: "system",
-          content: message.content,
-        });
+        // Collect inline system messages
+        inlineSystemMessages.push(message.content);
       } else if (message.role === "user") {
         messages.push({
           role: "user",
@@ -312,6 +310,39 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
           role: "assistant",
           content: message.content,
         });
+      }
+    }
+
+    // Use shared utility to collect and combine system content
+    const { combinedSystemContent, useNativeSystemMessage } = collectSystemContent(
+      request.systemMessage,
+      inlineSystemMessages,
+      supportsSystem
+    );
+
+    if (combinedSystemContent) {
+      if (useNativeSystemMessage) {
+        // Model supports system messages - add as system role at the start
+        messages.unshift({
+          role: "system",
+          content: combinedSystemContent,
+        });
+      } else {
+        // Model doesn't support system messages - prepend to first user message
+        const simpleMessages = messages.map((m) => ({
+          role: m.role,
+          content: m.content as string,
+        }));
+        const modifiedIndex = prependSystemToFirstUserMessage(
+          simpleMessages,
+          combinedSystemContent
+        );
+        if (modifiedIndex !== -1) {
+          messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;
+          logger.debug(
+            `Model ${request.modelId} doesn't support system messages - prepended to first user message`
+          );
+        }
       }
     }
 

--- a/src/llm/clients/MockClientAdapter.test.ts
+++ b/src/llm/clients/MockClientAdapter.test.ts
@@ -23,6 +23,7 @@ describe('MockClientAdapter', () => {
         user: 'test-user',
         geminiSafetySettings: [],
         supportsSystemMessage: true,
+        systemMessageFallback: { format: 'xml', tagName: 'system', separator: '---' },
         reasoning: {
           enabled: false,
           effort: undefined as any,

--- a/src/llm/clients/OpenAIClientAdapter.test.ts
+++ b/src/llm/clients/OpenAIClientAdapter.test.ts
@@ -42,6 +42,7 @@ describe('OpenAIClientAdapter', () => {
         user: 'test-user',
         geminiSafetySettings: [],
         supportsSystemMessage: true,
+        systemMessageFallback: { format: 'xml', tagName: 'system', separator: '---' },
         reasoning: {
           enabled: false,
           effort: undefined as any,

--- a/src/llm/clients/OpenAIClientAdapter.ts
+++ b/src/llm/clients/OpenAIClientAdapter.ts
@@ -10,6 +10,10 @@ import type {
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
+import {
+  collectSystemContent,
+  prependSystemToFirstUserMessage,
+} from "../../shared/adapters/systemMessageUtils";
 import { createDefaultLogger } from "../../logging/defaultLogger";
 
 const logger = createDefaultLogger();
@@ -154,23 +158,16 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest
   ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
     const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+    const inlineSystemMessages: string[] = [];
 
-    // Add system message if provided
-    if (request.systemMessage) {
-      messages.push({
-        role: "system",
-        content: request.systemMessage,
-      });
-    }
+    // Check if model supports system messages
+    const supportsSystem = request.settings.supportsSystemMessage !== false;
 
-    // Add conversation messages
+    // Add conversation messages (collecting system messages separately)
     for (const message of request.messages) {
       if (message.role === "system") {
-        // Handle system messages in conversation
-        messages.push({
-          role: "system",
-          content: message.content,
-        });
+        // Collect inline system messages
+        inlineSystemMessages.push(message.content);
       } else if (message.role === "user") {
         messages.push({
           role: "user",
@@ -181,6 +178,39 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
           role: "assistant",
           content: message.content,
         });
+      }
+    }
+
+    // Use shared utility to collect and combine system content
+    const { combinedSystemContent, useNativeSystemMessage } = collectSystemContent(
+      request.systemMessage,
+      inlineSystemMessages,
+      supportsSystem
+    );
+
+    if (combinedSystemContent) {
+      if (useNativeSystemMessage) {
+        // Model supports system messages - add as system role at the start
+        messages.unshift({
+          role: "system",
+          content: combinedSystemContent,
+        });
+      } else {
+        // Model doesn't support system messages - prepend to first user message
+        const simpleMessages = messages.map((m) => ({
+          role: m.role,
+          content: m.content as string,
+        }));
+        const modifiedIndex = prependSystemToFirstUserMessage(
+          simpleMessages,
+          combinedSystemContent
+        );
+        if (modifiedIndex !== -1) {
+          messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;
+          logger.debug(
+            `Model ${request.modelId} doesn't support system messages - prepended to first user message`
+          );
+        }
       }
     }
 

--- a/src/llm/clients/OpenAIClientAdapter.ts
+++ b/src/llm/clients/OpenAIClientAdapter.ts
@@ -203,7 +203,8 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
         }));
         const modifiedIndex = prependSystemToFirstUserMessage(
           simpleMessages,
-          combinedSystemContent
+          combinedSystemContent,
+          request.settings.systemMessageFallback
         );
         if (modifiedIndex !== -1) {
           messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -69,6 +69,11 @@ export const DEFAULT_LLM_SETTINGS: Required<LLMSettings> = {
   frequencyPenalty: 0.0,
   presencePenalty: 0.0,
   supportsSystemMessage: true,
+  systemMessageFallback: {
+    format: 'xml',
+    tagName: 'system',
+    separator: '---',
+  },
   user: undefined as any, // Will be filtered out when undefined
   geminiSafetySettings: [
     { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_NONE" },

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -72,7 +72,7 @@ export const DEFAULT_LLM_SETTINGS: Required<LLMSettings> = {
   systemMessageFallback: {
     format: 'xml',
     tagName: 'system',
-    separator: '---',
+    separator: '\n\n---\n\n',
   },
   user: undefined as any, // Will be filtered out when undefined
   geminiSafetySettings: [

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -633,6 +633,7 @@ export const SUPPORTED_MODELS: ModelInfo[] = [
     },
   },
   // Google Gemma 3 Models (Open weights, free via Gemini API)
+  // Note: Gemma models don't support system instructions - system content is prepended to user message
   {
     id: "gemma-3-27b-it",
     name: "Gemma 3 27B",
@@ -645,6 +646,7 @@ export const SUPPORTED_MODELS: ModelInfo[] = [
     maxTokens: 8192,
     supportsImages: true,
     supportsPromptCache: false,
+    supportsSystemMessage: false,
   },
 
   // OpenAI Models - GPT-5 Series

--- a/src/llm/services/SettingsManager.test.ts
+++ b/src/llm/services/SettingsManager.test.ts
@@ -48,6 +48,7 @@ describe('SettingsManager', () => {
         presencePenalty: 0,
         user: '',
         supportsSystemMessage: true,
+        systemMessageFallback: {},
         geminiSafetySettings: [],
         reasoning: {
           enabled: false,
@@ -123,6 +124,11 @@ describe('SettingsManager', () => {
         presencePenalty: -0.5,
         user: 'test-user',
         supportsSystemMessage: false,
+        systemMessageFallback: {
+          format: 'plain',
+          tagName: 'context',
+          separator: '===',
+        },
         geminiSafetySettings: [],
         reasoning: {
           enabled: true,
@@ -152,6 +158,7 @@ describe('SettingsManager', () => {
       presencePenalty: 0,
       user: '',
       supportsSystemMessage: true,
+      systemMessageFallback: { format: 'xml', tagName: 'system', separator: '---' },
       geminiSafetySettings: [],
       reasoning: {
         enabled: false,

--- a/src/llm/services/SettingsManager.ts
+++ b/src/llm/services/SettingsManager.ts
@@ -43,6 +43,10 @@ export class SettingsManager {
       supportsSystemMessage:
         requestSettings?.supportsSystemMessage ??
         modelDefaults.supportsSystemMessage,
+      systemMessageFallback: {
+        ...modelDefaults.systemMessageFallback,
+        ...requestSettings?.systemMessageFallback,
+      },
       geminiSafetySettings:
         requestSettings?.geminiSafetySettings ??
         modelDefaults.geminiSafetySettings,

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -108,6 +108,40 @@ export interface LLMThinkingTagFallbackSettings {
 }
 
 /**
+ * Format options for prepending system content when model doesn't support system messages.
+ * - 'xml': Wrap in XML tags (default) - `<system>content</system>\n\n{user message}`
+ * - 'separator': Use a simple separator - `{content}\n\n---\n\n{user message}`
+ * - 'plain': Just prepend with double newline - `{content}\n\n{user message}`
+ */
+export type SystemMessageFallbackFormat = 'xml' | 'separator' | 'plain';
+
+/**
+ * Settings for handling system messages when the model doesn't support them natively.
+ * When a model has `supportsSystemMessage: false`, these settings control how
+ * system content is formatted when prepended to the first user message.
+ */
+export interface SystemMessageFallbackSettings {
+  /**
+   * Format to use when prepending system content to user message.
+   * @default 'xml'
+   */
+  format?: SystemMessageFallbackFormat;
+
+  /**
+   * Tag name to use when format is 'xml'.
+   * @default 'system'
+   * @example tagName: 'instructions' produces `<instructions>content</instructions>`
+   */
+  tagName?: string;
+
+  /**
+   * Separator string to use when format is 'separator'.
+   * @default '---'
+   */
+  separator?: string;
+}
+
+/**
  * Configurable settings for LLM requests
  */
 export interface LLMSettings {
@@ -127,6 +161,11 @@ export interface LLMSettings {
   user?: string;
   /** Whether the LLM supports system message (almost all LLMs do nowadays) */
   supportsSystemMessage?: boolean;
+  /**
+   * Settings for handling system messages when the model doesn't support them.
+   * Controls how system content is formatted when prepended to user messages.
+   */
+  systemMessageFallback?: SystemMessageFallbackSettings;
   /** Gemini-specific safety settings for content filtering */
   geminiSafetySettings?: GeminiSafetySetting[];
   /** Universal reasoning/thinking configuration */

--- a/src/shared/adapters/systemMessageUtils.test.ts
+++ b/src/shared/adapters/systemMessageUtils.test.ts
@@ -1,0 +1,213 @@
+import {
+  collectSystemContent,
+  prependSystemToFirstUserMessage,
+  processMessagesForSystemSupport,
+  type GenericMessage,
+} from "./systemMessageUtils";
+
+describe("systemMessageUtils", () => {
+  describe("collectSystemContent", () => {
+    it("should return combined content with only request.systemMessage", () => {
+      const result = collectSystemContent("You are helpful", [], true);
+
+      expect(result.combinedSystemContent).toBe("You are helpful");
+      expect(result.useNativeSystemMessage).toBe(true);
+    });
+
+    it("should return combined content with only inline system messages", () => {
+      const result = collectSystemContent(
+        undefined,
+        ["Be concise", "Be accurate"],
+        true
+      );
+
+      expect(result.combinedSystemContent).toBe("Be concise\n\nBe accurate");
+      expect(result.useNativeSystemMessage).toBe(true);
+    });
+
+    it("should combine request.systemMessage and inline messages", () => {
+      const result = collectSystemContent(
+        "You are helpful",
+        ["Be concise"],
+        true
+      );
+
+      expect(result.combinedSystemContent).toBe("You are helpful\n\nBe concise");
+      expect(result.useNativeSystemMessage).toBe(true);
+    });
+
+    it("should return undefined when no system content provided", () => {
+      const result = collectSystemContent(undefined, [], true);
+
+      expect(result.combinedSystemContent).toBeUndefined();
+      expect(result.useNativeSystemMessage).toBe(true);
+    });
+
+    it("should set useNativeSystemMessage to false when not supported", () => {
+      const result = collectSystemContent("You are helpful", [], false);
+
+      expect(result.combinedSystemContent).toBe("You are helpful");
+      expect(result.useNativeSystemMessage).toBe(false);
+    });
+
+    it("should handle empty strings in inline messages", () => {
+      const result = collectSystemContent("Base", ["", "Additional"], true);
+
+      // Empty strings are included (could be filtered if needed)
+      expect(result.combinedSystemContent).toBe("Base\n\n\n\nAdditional");
+    });
+  });
+
+  describe("prependSystemToFirstUserMessage", () => {
+    it("should prepend to the first user message", () => {
+      const messages: GenericMessage[] = [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi!" },
+      ];
+
+      const index = prependSystemToFirstUserMessage(messages, "Be helpful");
+
+      expect(index).toBe(0);
+      expect(messages[0].content).toBe("Be helpful\n\nHello");
+      expect(messages[1].content).toBe("Hi!"); // Unchanged
+    });
+
+    it("should find user message even if not first", () => {
+      const messages: GenericMessage[] = [
+        { role: "assistant", content: "Previous response" },
+        { role: "user", content: "Hello" },
+      ];
+
+      const index = prependSystemToFirstUserMessage(messages, "Be helpful");
+
+      expect(index).toBe(1);
+      expect(messages[0].content).toBe("Previous response"); // Unchanged
+      expect(messages[1].content).toBe("Be helpful\n\nHello");
+    });
+
+    it("should return -1 when no user messages exist", () => {
+      const messages: GenericMessage[] = [
+        { role: "assistant", content: "Hi!" },
+      ];
+
+      const index = prependSystemToFirstUserMessage(messages, "Be helpful");
+
+      expect(index).toBe(-1);
+      expect(messages[0].content).toBe("Hi!"); // Unchanged
+    });
+
+    it("should return -1 for empty messages array", () => {
+      const messages: GenericMessage[] = [];
+
+      const index = prependSystemToFirstUserMessage(messages, "Be helpful");
+
+      expect(index).toBe(-1);
+    });
+
+    it("should handle multiline system content", () => {
+      const messages: GenericMessage[] = [{ role: "user", content: "Hello" }];
+
+      prependSystemToFirstUserMessage(messages, "Line 1\nLine 2\nLine 3");
+
+      expect(messages[0].content).toBe("Line 1\nLine 2\nLine 3\n\nHello");
+    });
+  });
+
+  describe("processMessagesForSystemSupport", () => {
+    it("should separate system messages from other messages", () => {
+      const messages: GenericMessage[] = [
+        { role: "system", content: "Be helpful" },
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi!" },
+      ];
+
+      const result = processMessagesForSystemSupport(messages, undefined, true);
+
+      expect(result.nonSystemMessages).toHaveLength(2);
+      expect(result.nonSystemMessages[0].role).toBe("user");
+      expect(result.nonSystemMessages[1].role).toBe("assistant");
+      expect(result.systemContent.combinedSystemContent).toBe("Be helpful");
+      expect(result.systemContent.useNativeSystemMessage).toBe(true);
+    });
+
+    it("should combine request.systemMessage with inline system messages", () => {
+      const messages: GenericMessage[] = [
+        { role: "system", content: "Additional instruction" },
+        { role: "user", content: "Hello" },
+      ];
+
+      const result = processMessagesForSystemSupport(
+        messages,
+        "Base instruction",
+        true
+      );
+
+      expect(result.nonSystemMessages).toHaveLength(1);
+      expect(result.systemContent.combinedSystemContent).toBe(
+        "Base instruction\n\nAdditional instruction"
+      );
+    });
+
+    it("should handle no system messages", () => {
+      const messages: GenericMessage[] = [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi!" },
+      ];
+
+      const result = processMessagesForSystemSupport(messages, undefined, true);
+
+      expect(result.nonSystemMessages).toHaveLength(2);
+      expect(result.systemContent.combinedSystemContent).toBeUndefined();
+    });
+
+    it("should handle multiple system messages", () => {
+      const messages: GenericMessage[] = [
+        { role: "system", content: "First instruction" },
+        { role: "user", content: "Hello" },
+        { role: "system", content: "Second instruction" },
+        { role: "user", content: "Another question" },
+      ];
+
+      const result = processMessagesForSystemSupport(messages, undefined, true);
+
+      expect(result.nonSystemMessages).toHaveLength(2);
+      expect(result.nonSystemMessages[0].content).toBe("Hello");
+      expect(result.nonSystemMessages[1].content).toBe("Another question");
+      expect(result.systemContent.combinedSystemContent).toBe(
+        "First instruction\n\nSecond instruction"
+      );
+    });
+
+    it("should set useNativeSystemMessage based on supportsSystemMessage", () => {
+      const messages: GenericMessage[] = [{ role: "user", content: "Hello" }];
+
+      const supportedResult = processMessagesForSystemSupport(
+        messages,
+        "Be helpful",
+        true
+      );
+      const unsupportedResult = processMessagesForSystemSupport(
+        messages,
+        "Be helpful",
+        false
+      );
+
+      expect(supportedResult.systemContent.useNativeSystemMessage).toBe(true);
+      expect(unsupportedResult.systemContent.useNativeSystemMessage).toBe(false);
+    });
+
+    it("should handle empty messages array", () => {
+      const messages: GenericMessage[] = [];
+
+      const result = processMessagesForSystemSupport(
+        messages,
+        "Be helpful",
+        false
+      );
+
+      expect(result.nonSystemMessages).toHaveLength(0);
+      expect(result.systemContent.combinedSystemContent).toBe("Be helpful");
+      expect(result.systemContent.useNativeSystemMessage).toBe(false);
+    });
+  });
+});

--- a/src/shared/adapters/systemMessageUtils.test.ts
+++ b/src/shared/adapters/systemMessageUtils.test.ts
@@ -87,7 +87,7 @@ describe("systemMessageUtils", () => {
     it("should use custom separator string", () => {
       const result = formatSystemContentForPrepend("Be helpful", "Hello", {
         format: "separator",
-        separator: "===",
+        separator: "\n\n===\n\n",
       });
 
       expect(result).toBe("Be helpful\n\n===\n\nHello");
@@ -131,8 +131,8 @@ describe("systemMessageUtils", () => {
       expect(DEFAULT_SYSTEM_MESSAGE_FORMAT_OPTIONS.tagName).toBe("system");
     });
 
-    it("should have '---' as default separator", () => {
-      expect(DEFAULT_SYSTEM_MESSAGE_FORMAT_OPTIONS.separator).toBe("---");
+    it("should have full separator string with newlines as default", () => {
+      expect(DEFAULT_SYSTEM_MESSAGE_FORMAT_OPTIONS.separator).toBe("\n\n---\n\n");
     });
   });
 

--- a/src/shared/adapters/systemMessageUtils.ts
+++ b/src/shared/adapters/systemMessageUtils.ts
@@ -5,7 +5,8 @@
 /**
  * Format options for prepending system content when model doesn't support system messages.
  * - 'xml': Wrap in XML tags (default) - `<system>content</system>\n\n{user message}`
- * - 'separator': Use a simple separator - `{content}\n\n---\n\n{user message}`
+ * - 'separator': Use a custom separator string - `{content}{separator}{user message}`
+ *   Default separator is `\n\n---\n\n`. Specify full separator including whitespace.
  * - 'plain': Just prepend with double newline - `{content}\n\n{user message}`
  */
 export type SystemMessageFallbackFormat = 'xml' | 'separator' | 'plain';
@@ -29,7 +30,9 @@ export interface SystemMessageFormatOptions {
 
   /**
    * Separator string to use when format is 'separator'.
-   * @default '---'
+   * Include any whitespace/newlines in the separator itself.
+   * @default '\n\n---\n\n'
+   * @example separator: '\n\n===\n\n' produces `content\n\n===\n\nuser message`
    */
   separator?: string;
 }
@@ -58,7 +61,7 @@ export interface GenericMessage {
 export const DEFAULT_SYSTEM_MESSAGE_FORMAT_OPTIONS: Required<SystemMessageFormatOptions> = {
   format: 'xml',
   tagName: 'system',
-  separator: '---',
+  separator: '\n\n---\n\n',
 };
 
 /**
@@ -75,9 +78,13 @@ export const DEFAULT_SYSTEM_MESSAGE_FORMAT_OPTIONS: Required<SystemMessageFormat
  * formatSystemContentForPrepend('Be helpful', 'Hello', { format: 'xml' });
  * // Returns: '<system>\nBe helpful\n</system>\n\nHello'
  *
- * // Separator format
+ * // Separator format (default separator is '\n\n---\n\n')
  * formatSystemContentForPrepend('Be helpful', 'Hello', { format: 'separator' });
  * // Returns: 'Be helpful\n\n---\n\nHello'
+ *
+ * // Custom separator (specify full separator including whitespace)
+ * formatSystemContentForPrepend('Be helpful', 'Hello', { format: 'separator', separator: '\n\n===\n\n' });
+ * // Returns: 'Be helpful\n\n===\n\nHello'
  *
  * // Plain format
  * formatSystemContentForPrepend('Be helpful', 'Hello', { format: 'plain' });
@@ -96,7 +103,7 @@ export function formatSystemContentForPrepend(
       return `<${opts.tagName}>\n${systemContent}\n</${opts.tagName}>\n\n${userContent}`;
 
     case 'separator':
-      return `${systemContent}\n\n${opts.separator}\n\n${userContent}`;
+      return `${systemContent}${opts.separator}${userContent}`;
 
     case 'plain':
     default:
@@ -176,7 +183,7 @@ export function collectSystemContent(
  * prependSystemToFirstUserMessage(messages, 'Be helpful', { format: 'plain' });
  * // messages[0].content = 'Be helpful\n\nHello'
  *
- * // Separator format
+ * // Separator format (default separator is '\n\n---\n\n')
  * prependSystemToFirstUserMessage(messages, 'Be helpful', { format: 'separator' });
  * // messages[0].content = 'Be helpful\n\n---\n\nHello'
  * ```


### PR DESCRIPTION
- Add supportsSystemMessage: false to gemma-3-27b-it model config
- Modify GeminiClientAdapter to check supportsSystemMessage setting
- When not supported, prepend system content to first user message
- Add tests for the system message fallback behavior

Fixes API error: "Developer instruction is not enabled for models/gemma-3-27b-it"

Signed-off-by: Claude <noreply@anthropic.com>