### PR TITLE
fix: enforce mutual exclusion for system message sources (v0.7.3)

### DIFF
--- a/genai-lite-docs/llm-service.md
+++ b/genai-lite-docs/llm-service.md
@@ -504,6 +504,34 @@ const response = await llmService.sendMessage({
 | `thinkingTagFallback` | object | - | Thinking tag configuration (see [Thinking Tag Fallback](#thinking-tag-fallback)) |
 | `systemMessageFallback` | object | - | System message format when model lacks native support (see below) |
 
+### System Messages
+
+You can provide system messages in two ways:
+
+1. **Using the `systemMessage` field:**
+   ```typescript
+   await llmService.sendMessage({
+     providerId: 'openai',
+     modelId: 'gpt-4.1-mini',
+     systemMessage: 'You are a helpful assistant.',
+     messages: [{ role: 'user', content: 'Hello' }]
+   });
+   ```
+
+2. **Using `role: 'system'` in the messages array** (OpenAI-style):
+   ```typescript
+   await llmService.sendMessage({
+     providerId: 'openai',
+     modelId: 'gpt-4.1-mini',
+     messages: [
+       { role: 'system', content: 'You are a helpful assistant.' },
+       { role: 'user', content: 'Hello' }
+     ]
+   });
+   ```
+
+> **Important:** You cannot use both approaches simultaneously. If you provide both a `systemMessage` field and system role messages in the messages array, an error will be returned.
+
 ### System Message Fallback
 
 Some models (e.g., Gemma) don't support native system instructions. When `supportsSystemMessage: false` is set for a model, genai-lite automatically prepends system content to the first user message.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-lite",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-lite",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.56.0",
@@ -81,6 +81,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1768,6 +1769,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2813,6 +2815,7 @@
       "integrity": "sha512-9QE0RS4WwTj/TtTC4h/eFVmFAhGNVerSB9XpJh8sqaXlP73ILcPcZ7JWjjEtJJe2m8QyBLKKfPQuK+3F+Xij/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.4",
         "@jest/types": "30.0.1",
@@ -4575,6 +4578,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4972,6 +4976,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -1044,6 +1044,11 @@ export function getDefaultSettingsForModel(
     }
   }
 
+  // Override supportsSystemMessage from ModelInfo if explicitly set
+  if (modelInfo && modelInfo.supportsSystemMessage !== undefined) {
+    mergedSettings.supportsSystemMessage = modelInfo.supportsSystemMessage;
+  }
+
   // Filter out undefined values and ensure required fields
   return Object.fromEntries(
     Object.entries(mergedSettings).filter(([_, value]) => value !== undefined)

--- a/src/shared/adapters/systemMessageUtils.test.ts
+++ b/src/shared/adapters/systemMessageUtils.test.ts
@@ -27,15 +27,12 @@ describe("systemMessageUtils", () => {
       expect(result.useNativeSystemMessage).toBe(true);
     });
 
-    it("should combine request.systemMessage and inline messages", () => {
-      const result = collectSystemContent(
-        "You are helpful",
-        ["Be concise"],
-        true
+    it("should throw error when both systemMessage and inline messages are provided", () => {
+      expect(() =>
+        collectSystemContent("You are helpful", ["Be concise"], true)
+      ).toThrow(
+        "Cannot use both systemMessage field and system role messages in the messages array"
       );
-
-      expect(result.combinedSystemContent).toBe("You are helpful\n\nBe concise");
-      expect(result.useNativeSystemMessage).toBe(true);
     });
 
     it("should return undefined when no system content provided", () => {
@@ -53,10 +50,10 @@ describe("systemMessageUtils", () => {
     });
 
     it("should handle empty strings in inline messages", () => {
-      const result = collectSystemContent("Base", ["", "Additional"], true);
+      const result = collectSystemContent(undefined, ["", "Additional"], true);
 
       // Empty strings are included (could be filtered if needed)
-      expect(result.combinedSystemContent).toBe("Base\n\n\n\nAdditional");
+      expect(result.combinedSystemContent).toBe("\n\nAdditional");
     });
   });
 
@@ -245,21 +242,16 @@ describe("systemMessageUtils", () => {
       expect(result.systemContent.useNativeSystemMessage).toBe(true);
     });
 
-    it("should combine request.systemMessage with inline system messages", () => {
+    it("should throw error when both systemMessage and inline system messages are provided", () => {
       const messages: GenericMessage[] = [
         { role: "system", content: "Additional instruction" },
         { role: "user", content: "Hello" },
       ];
 
-      const result = processMessagesForSystemSupport(
-        messages,
-        "Base instruction",
-        true
-      );
-
-      expect(result.nonSystemMessages).toHaveLength(1);
-      expect(result.systemContent.combinedSystemContent).toBe(
-        "Base instruction\n\nAdditional instruction"
+      expect(() =>
+        processMessagesForSystemSupport(messages, "Base instruction", true)
+      ).toThrow(
+        "Cannot use both systemMessage field and system role messages in the messages array"
       );
     });
 


### PR DESCRIPTION
## Summary

- Throw error when both `systemMessage` field and `role:'system'` messages are provided simultaneously, preventing silent merge confusion
- Fix bug where `supportsSystemMessage` from ModelInfo wasn't flowing to request settings in `getDefaultSettingsForModel()`
- Add comprehensive tests for ModelInfo settings propagation
- Document both system message approaches and their mutual exclusivity

## Changes

### Bug Fix
Previously, using both approaches would silently merge them together. Now an error is returned:
```
Cannot use both systemMessage field and system role messages in the messages array. Use one or the other.
```

### Config Fix
`supportsSystemMessage: false` from Gemma's ModelInfo now correctly flows to request settings.

### Tests
- Added tests for mutual exclusion behavior
- Added generic test to catch future ModelInfo→LLMSettings propagation bugs

## Test plan
- [x] All 649 tests pass
- [x] Build succeeds
- [x] Gemma model correctly gets `supportsSystemMessage: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)