### PR TITLE
feat(chat-demo): add structured output UI and improve model config (v0.8.1)

### DIFF
--- a/examples/chat-demo/package.json
+++ b/examples/chat-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite-chat-demo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Interactive chat demo showcasing genai-lite features",
   "private": true,
   "type": "module",

--- a/examples/chat-demo/server/routes/chat.ts
+++ b/examples/chat-demo/server/routes/chat.ts
@@ -96,6 +96,8 @@ chatRouter.post('/', async (req, res) => {
         model: result.model,
         content: result.choices[0]?.message?.content || '',
         reasoning: result.choices[0]?.reasoning,
+        parsedContent: result.choices[0]?.parsedContent,
+        parseError: result.choices[0]?.parseError,
         finishReason: result.choices[0]?.finish_reason,
         usage: result.usage
       }

--- a/examples/chat-demo/src/components/ChatInterface.tsx
+++ b/examples/chat-demo/src/components/ChatInterface.tsx
@@ -40,6 +40,9 @@ function formatMessagesAsMarkdown(messages: Message[]): string {
       if (msg.reasoning) {
         content += `\n\n### Reasoning\n${msg.reasoning}`;
       }
+      if (msg.parsedContent) {
+        content += `\n\n### Parsed JSON\n\`\`\`json\n${JSON.stringify(msg.parsedContent, null, 2)}\n\`\`\``;
+      }
       return content;
     })
     .join('\n\n---\n\n');
@@ -406,6 +409,8 @@ export function ChatInterface() {
           role: 'assistant',
           content: response.response.content,
           reasoning: response.response.reasoning,
+          parsedContent: response.response.parsedContent,
+          parseError: response.response.parseError,
           timestamp: Date.now(),
         };
         setMessages((prev) => [...prev, assistantMessage]);

--- a/examples/chat-demo/src/components/MessageList.tsx
+++ b/examples/chat-demo/src/components/MessageList.tsx
@@ -26,6 +26,9 @@ export function MessageList({ messages }: MessageListProps) {
       if (message.reasoning) {
         text += `\n\nREASONING: ${message.reasoning}`;
       }
+      if (message.parsedContent) {
+        text += `\n\nPARSED JSON:\n${JSON.stringify(message.parsedContent, null, 2)}`;
+      }
       await navigator.clipboard.writeText(text);
       setCopiedIndex(index);
       setTimeout(() => setCopiedIndex(null), 2000);
@@ -66,6 +69,19 @@ export function MessageList({ messages }: MessageListProps) {
             </details>
           )}
           <div className="message-content">{message.content}</div>
+          {message.parsedContent && (
+            <details className="message-parsed-content" open>
+              <summary>Parsed JSON Response</summary>
+              <pre className="parsed-json">
+                {JSON.stringify(message.parsedContent, null, 2)}
+              </pre>
+            </details>
+          )}
+          {message.parseError && (
+            <div className="parse-error">
+              Parse Error: {message.parseError}
+            </div>
+          )}
         </div>
       ))}
       <div ref={messagesEndRef} />

--- a/examples/chat-demo/src/components/SettingsPanel.tsx
+++ b/examples/chat-demo/src/components/SettingsPanel.tsx
@@ -1,7 +1,62 @@
 // SettingsPanel component - Configure LLM settings (Sidebar version)
 
-import { useState } from 'react';
-import type { LLMSettings, UserVariables, AutomaticVariables } from '../types';
+import { useState, useEffect } from 'react';
+import type { LLMSettings, UserVariables, AutomaticVariables, StructuredOutputSchema } from '../types';
+
+// Default schema for structured output
+const DEFAULT_SCHEMA: StructuredOutputSchema = {
+  type: "object",
+  properties: {
+    answer: { type: "string", description: "The main response" },
+    confidence: { type: "number", description: "Confidence level 0-1" },
+    sources: {
+      type: "array",
+      items: { type: "string" },
+      description: "Referenced sources if any"
+    }
+  },
+  required: ["answer"]
+};
+
+// Preset schemas for quick selection
+const PRESET_SCHEMAS: Record<string, StructuredOutputSchema> = {
+  person: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      age: { type: "integer" },
+      email: { type: "string" }
+    },
+    required: ["name"]
+  },
+  list: {
+    type: "object",
+    properties: {
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            description: { type: "string" }
+          },
+          required: ["title"]
+        }
+      }
+    },
+    required: ["items"]
+  },
+  analysis: {
+    type: "object",
+    properties: {
+      summary: { type: "string" },
+      keyPoints: { type: "array", items: { type: "string" } },
+      sentiment: { type: "string", enum: ["positive", "negative", "neutral"] },
+      score: { type: "number" }
+    },
+    required: ["summary", "keyPoints"]
+  }
+};
 
 interface SettingsPanelProps {
   settings: LLMSettings;
@@ -33,9 +88,61 @@ export function SettingsPanel({
 
   const [newVarKey, setNewVarKey] = useState('');
   const [newVarValue, setNewVarValue] = useState('');
+  const [schemaError, setSchemaError] = useState<string | null>(null);
+  const [schemaText, setSchemaText] = useState(() =>
+    settings.structuredOutput?.schema
+      ? JSON.stringify(settings.structuredOutput.schema, null, 2)
+      : JSON.stringify(DEFAULT_SCHEMA, null, 2)
+  );
+
+  // Sync schemaText when settings.structuredOutput.schema changes externally
+  // (e.g., loaded from localStorage or reset to defaults)
+  useEffect(() => {
+    const currentSchemaStr = settings.structuredOutput?.schema
+      ? JSON.stringify(settings.structuredOutput.schema, null, 2)
+      : JSON.stringify(DEFAULT_SCHEMA, null, 2);
+
+    // Only update if the schema actually changed (avoid cursor jumping)
+    try {
+      const currentParsed = JSON.parse(schemaText);
+      const settingsParsed = settings.structuredOutput?.schema ?? DEFAULT_SCHEMA;
+      if (JSON.stringify(currentParsed) !== JSON.stringify(settingsParsed)) {
+        setSchemaText(currentSchemaStr);
+        setSchemaError(null);
+      }
+    } catch {
+      // If current schemaText is invalid JSON, sync it
+      setSchemaText(currentSchemaStr);
+      setSchemaError(null);
+    }
+  }, [settings.structuredOutput?.schema]);
 
   const updateSetting = <K extends keyof LLMSettings>(key: K, value: LLMSettings[K]) => {
     onSettingsChange({ ...settings, [key]: value });
+  };
+
+  const loadPresetSchema = (presetName: keyof typeof PRESET_SCHEMAS) => {
+    const schema = PRESET_SCHEMAS[presetName];
+    setSchemaText(JSON.stringify(schema, null, 2));
+    setSchemaError(null);
+    updateSetting('structuredOutput', {
+      ...settings.structuredOutput!,
+      schema
+    });
+  };
+
+  const handleSchemaChange = (text: string) => {
+    setSchemaText(text);
+    try {
+      const parsed = JSON.parse(text);
+      setSchemaError(null);
+      updateSetting('structuredOutput', {
+        ...settings.structuredOutput!,
+        schema: parsed
+      });
+    } catch {
+      setSchemaError('Invalid JSON');
+    }
   };
 
   const handleAddVariable = () => {
@@ -156,12 +263,17 @@ export function SettingsPanel({
               <input
                 type="checkbox"
                 checked={settings.reasoning?.enabled ?? false}
-                onChange={(e) =>
-                  updateSetting('reasoning', {
-                    enabled: e.target.checked,
-                    effort: settings.reasoning?.effort ?? 'medium',
-                  })
-                }
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    updateSetting('reasoning', {
+                      enabled: true,
+                      effort: settings.reasoning?.effort ?? 'medium',
+                    });
+                  } else {
+                    // When disabling, only set enabled: false (no effort)
+                    updateSetting('reasoning', { enabled: false });
+                  }
+                }}
                 disabled={disabled}
               />
               Enable Reasoning
@@ -220,6 +332,91 @@ export function SettingsPanel({
                   Require Thinking Tags
                 </label>
                 <span className="setting-hint">Enforce thinking tags when native reasoning is not active</span>
+              </div>
+            )}
+          </div>
+
+          {/* Structured Output Section */}
+          <div className="setting-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={settings.structuredOutput?.enabled ?? false}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    updateSetting('structuredOutput', {
+                      enabled: true,
+                      name: 'response_schema',
+                      schema: DEFAULT_SCHEMA,
+                      strict: true
+                    });
+                    setSchemaText(JSON.stringify(DEFAULT_SCHEMA, null, 2));
+                    setSchemaError(null);
+                  } else {
+                    updateSetting('structuredOutput', undefined);
+                  }
+                }}
+                disabled={disabled}
+              />
+              Enable Structured Output (JSON)
+            </label>
+            <span className="setting-hint">
+              Constrain response to JSON schema (GPT-4.1+, Gemini 2.5, Mistral, llama.cpp)
+            </span>
+
+            {settings.structuredOutput?.enabled && (
+              <div className="structured-output-config">
+                <div className="setting-subgroup">
+                  <label htmlFor="schemaName">Schema Name</label>
+                  <input
+                    id="schemaName"
+                    type="text"
+                    value={settings.structuredOutput.name}
+                    onChange={(e) => updateSetting('structuredOutput', {
+                      ...settings.structuredOutput!,
+                      name: e.target.value
+                    })}
+                    disabled={disabled}
+                    placeholder="response_schema"
+                    className="schema-name-input"
+                  />
+                </div>
+
+                <div className="setting-subgroup">
+                  <label htmlFor="schemaEditor">JSON Schema</label>
+                  <textarea
+                    id="schemaEditor"
+                    value={schemaText}
+                    onChange={(e) => handleSchemaChange(e.target.value)}
+                    disabled={disabled}
+                    rows={8}
+                    className={`schema-textarea ${schemaError ? 'error' : ''}`}
+                  />
+                  {schemaError && <span className="schema-error-text">{schemaError}</span>}
+                </div>
+
+                <div className="schema-presets">
+                  <span>Quick schemas:</span>
+                  <button type="button" onClick={() => loadPresetSchema('person')} disabled={disabled}>Person</button>
+                  <button type="button" onClick={() => loadPresetSchema('list')} disabled={disabled}>List</button>
+                  <button type="button" onClick={() => loadPresetSchema('analysis')} disabled={disabled}>Analysis</button>
+                </div>
+
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={settings.structuredOutput.strict !== false}
+                    onChange={(e) => updateSetting('structuredOutput', {
+                      ...settings.structuredOutput!,
+                      strict: e.target.checked
+                    })}
+                    disabled={disabled}
+                  />
+                  Strict Mode
+                </label>
+                <span className="setting-hint">
+                  Enforce exact schema match (recommended)
+                </span>
               </div>
             )}
           </div>

--- a/examples/chat-demo/src/style.css
+++ b/examples/chat-demo/src/style.css
@@ -779,6 +779,145 @@ body {
   color: var(--text);
 }
 
+/* Structured Output Settings */
+.structured-output-config {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: var(--background);
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.setting-subgroup {
+  margin-bottom: 0.75rem;
+}
+
+.setting-subgroup label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.schema-name-input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.schema-name-input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+}
+
+.schema-textarea {
+  width: 100%;
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  resize: vertical;
+  background: var(--background-alt);
+}
+
+.schema-textarea.error {
+  border-color: var(--error);
+}
+
+.schema-textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+}
+
+.schema-error-text {
+  color: var(--error);
+  font-size: 0.75rem;
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.schema-presets {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+  flex-wrap: wrap;
+}
+
+.schema-presets span {
+  font-size: 0.8rem;
+  color: var(--text-light);
+}
+
+.schema-presets button {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  background: var(--background-alt);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.schema-presets button:hover:not(:disabled) {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+}
+
+.schema-presets button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Parsed JSON Display in Messages */
+.message-parsed-content {
+  margin-top: 0.75rem;
+  background: #f0f9ff;
+  border: 1px solid #bae6fd;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.message-parsed-content summary {
+  padding: 0.5rem 0.75rem;
+  background: #e0f2fe;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: #0369a1;
+}
+
+.message-parsed-content summary:hover {
+  background: #bae6fd;
+}
+
+.parsed-json {
+  padding: 0.75rem;
+  margin: 0;
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: #f8fafc;
+}
+
+.parse-error {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 4px;
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
 /* Message Input */
 .message-input {
   padding: 1rem 1.5rem;

--- a/examples/chat-demo/src/types/index.ts
+++ b/examples/chat-demo/src/types/index.ts
@@ -4,6 +4,8 @@ export interface Message {
   role: 'user' | 'assistant' | 'system';
   content: string;
   reasoning?: string;
+  parsedContent?: unknown;
+  parseError?: string;
   timestamp: number;
 }
 
@@ -31,6 +33,38 @@ export interface Model {
   };
 }
 
+// Structured output schema types (matches library types in src/llm/types.ts)
+export interface StructuredOutputSchemaProperty {
+  type: "string" | "number" | "integer" | "boolean" | "array" | "object" | "null";
+  description?: string;
+  enum?: (string | number | boolean)[];
+  properties?: Record<string, StructuredOutputSchemaProperty>;
+  required?: string[];
+  items?: StructuredOutputSchemaProperty;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+}
+
+export interface StructuredOutputSchema {
+  type: "object" | "array" | "string" | "number" | "boolean";
+  properties?: Record<string, StructuredOutputSchemaProperty>;
+  required?: string[];
+  items?: StructuredOutputSchemaProperty;
+  additionalProperties?: boolean;
+  description?: string;
+}
+
+export interface StructuredOutputSettings {
+  enabled?: boolean;
+  name: string;
+  schema: StructuredOutputSchema;
+  strict?: boolean;
+  autoParse?: boolean;
+}
+
 export interface LLMSettings {
   temperature?: number;
   maxTokens?: number;
@@ -44,6 +78,7 @@ export interface LLMSettings {
     tagName?: string;
     enforce?: boolean;
   };
+  structuredOutput?: StructuredOutputSettings;
 }
 
 export interface ChatRequest {
@@ -58,6 +93,8 @@ export interface ChatResponse {
   response?: {
     content: string;
     reasoning?: string;
+    parsedContent?: unknown;
+    parseError?: string;
     usage?: {
       inputTokens: number;
       outputTokens: number;

--- a/genai-lite-docs/providers-and-models.md
+++ b/genai-lite-docs/providers-and-models.md
@@ -107,6 +107,7 @@ Complete reference of all supported AI providers and models in genai-lite.
 - Gemini models support multimodal (text, images, audio, video)
 - Gemma 3 27B is open-weight and **free** via the Gemini API (no API costs)
 - **Gemma models do not support system instructions** - genai-lite automatically prepends system content to the first user message (see [System Message Fallback](llm-service.md#system-message-fallback))
+- **Gemma models do not support structured output (JSON mode)** via Google's API - use OpenRouter instead for JSON output
 
 ---
 
@@ -209,6 +210,7 @@ Set environment variables for OpenRouter rankings:
 - OpenAI-compatible API format
 - `allowUnknownModels: true` - Use any OpenRouter model ID
 - Free tier models have rate limits
+- **Structured output supported** - Both free tier models support JSON mode/structured output
 - See [openrouter.ai/docs](https://openrouter.ai/docs) for full model list
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -661,6 +661,7 @@ export const SUPPORTED_MODELS: ModelInfo[] = [
   },
   // Google Gemma 3 Models (Open weights, free via Gemini API)
   // Note: Gemma models don't support system instructions - system content is prepended to user message
+  // Note: Gemma models don't support JSON mode/structured output via Google's API
   {
     id: "gemma-3-27b-it",
     name: "Gemma 3 27B",
@@ -674,6 +675,10 @@ export const SUPPORTED_MODELS: ModelInfo[] = [
     supportsImages: true,
     supportsPromptCache: false,
     supportsSystemMessage: false,
+    structuredOutput: {
+      supported: false,
+      notes: "Gemma models do not support JSON mode via Google's API",
+    },
   },
 
   // OpenAI Models - GPT-5 Series

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -944,6 +944,11 @@ export const SUPPORTED_MODELS: ModelInfo[] = [
     maxTokens: 8192,
     supportsImages: true,
     supportsPromptCache: false,
+    structuredOutput: {
+      supported: true,
+      strictMode: true,
+      notes: "Structured output supported via OpenRouter",
+    },
   },
   {
     id: "mistralai/mistral-small-3.1-24b-instruct:free",
@@ -956,6 +961,11 @@ export const SUPPORTED_MODELS: ModelInfo[] = [
     maxTokens: 8192,
     supportsImages: false,
     supportsPromptCache: false,
+    structuredOutput: {
+      supported: true,
+      strictMode: true,
+      notes: "Structured output supported via OpenRouter",
+    },
   },
 ];
 

--- a/src/llm/services/RequestValidator.test.ts
+++ b/src/llm/services/RequestValidator.test.ts
@@ -308,7 +308,7 @@ describe('RequestValidator', () => {
 
       expect(result).not.toBeNull();
       expect(result?.error.code).toBe('structured_output_not_supported');
-      expect(result?.error.message).toContain('does not support structured output');
+      expect(result?.error.message).toContain('Structured output is not available for');
     });
 
     it('should pass validation for models that support structuredOutput', () => {

--- a/src/llm/services/RequestValidator.ts
+++ b/src/llm/services/RequestValidator.ts
@@ -175,11 +175,14 @@ export class RequestValidator {
     // If model has explicit structuredOutput capabilities defined, check them
     if (modelInfo.structuredOutput !== undefined) {
       if (!modelInfo.structuredOutput.supported) {
+        const notes = modelInfo.structuredOutput.notes;
+        const baseMessage = `Structured output is not available for ${request.modelId} on ${request.providerId}`;
+        const message = notes ? `${baseMessage}. ${notes}` : baseMessage;
         return {
           provider: request.providerId!,
           model: request.modelId!,
           error: {
-            message: `Model ${request.modelId} does not support structured output`,
+            message,
             type: 'validation_error',
             code: 'structured_output_not_supported'
           },


### PR DESCRIPTION
## Summary

- Add structured output UI to chat-demo for testing JSON schema responses
- Fix reasoning toggle bug that caused validation errors on non-reasoning models
- Mark Gemma 3 as not supporting structured output on Google's API
- Add structured output support for OpenRouter free tier models
- Improve error messages to include provider name and notes

## Changes

### chat-demo (v1.1.3)
- New structured output settings panel with JSON schema editor
- Preset schemas (Person, List, Analysis) for quick testing
- Display parsed JSON responses in message list
- Fix: reasoning toggle no longer sends `effort` when disabled

### Library (v0.8.1)
- `gemma-3-27b-it` marked as not supporting structured output on Google's API
- `google/gemma-3-27b-it:free` and `mistralai/mistral-small-3.1-24b-instruct:free` on OpenRouter marked as supporting structured output
- Improved error message: "Structured output is not available for {model} on {provider}"
- Updated documentation with structured output notes

## Test plan
- [x] All 684 tests pass
- [x] Tested structured output with llama.cpp, Gemini 2.5 Flash, OpenRouter models
- [x] Verified Gemma 3 validation error on Google's API
- [x] Verified reasoning toggle fix with Gemma 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)