### PR TITLE
fix: inject logger into adapters to respect service logLevel (v0.8.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/adapters/image/GenaiElectronImageAdapter.ts
+++ b/src/adapters/image/GenaiElectronImageAdapter.ts
@@ -26,9 +26,8 @@ import type {
   ImageProgressCallback,
 } from '../../types/image';
 import { getCommonMappedErrorDetails } from '../../shared/adapters/errorUtils';
+import type { Logger } from '../../logging/types';
 import { createDefaultLogger } from '../../logging/defaultLogger';
-
-const logger = createDefaultLogger();
 
 /**
  * genai-electron generation status response
@@ -86,11 +85,13 @@ export class GenaiElectronImageAdapter implements ImageProviderAdapter {
   private baseURL: string;
   private timeout: number;
   private pollInterval: number;
+  private logger: Logger;
 
   constructor(config?: ImageProviderAdapterConfig) {
     this.baseURL = config?.baseURL || 'http://localhost:8081';
     this.timeout = config?.timeout || 120000; // 120 seconds for diffusion
     this.pollInterval = 500; // Poll every 500ms
+    this.logger = config?.logger ?? createDefaultLogger();
   }
 
   /**
@@ -108,7 +109,7 @@ export class GenaiElectronImageAdapter implements ImageProviderAdapter {
       // Build request payload
       const payload = this.buildRequestPayload(resolvedPrompt, request, settings);
 
-      logger.debug(`GenaiElectron Image API: Starting generation`, {
+      this.logger.debug(`GenaiElectron Image API: Starting generation`, {
         prompt: resolvedPrompt.substring(0, 100),
         count: payload.count,
         dimensions: `${payload.width}x${payload.height}`,
@@ -118,7 +119,7 @@ export class GenaiElectronImageAdapter implements ImageProviderAdapter {
       // Start generation (returns immediately with ID)
       const generationId = await this.startGeneration(payload);
 
-      logger.info(`GenaiElectron Image API: Generation started with ID: ${generationId}`);
+      this.logger.info(`GenaiElectron Image API: Generation started with ID: ${generationId}`);
 
       // Poll for completion
       const result = await this.pollForCompletion(
@@ -126,12 +127,12 @@ export class GenaiElectronImageAdapter implements ImageProviderAdapter {
         settings.diffusion?.onProgress
       );
 
-      logger.info(`GenaiElectron Image API: Generation complete (${result.timeTaken}ms)`);
+      this.logger.info(`GenaiElectron Image API: Generation complete (${result.timeTaken}ms)`);
 
       // Convert to ImageGenerationResponse
       return this.convertToResponse(result, request);
     } catch (error) {
-      logger.error('GenaiElectron Image API error:', error);
+      this.logger.error('GenaiElectron Image API error:', error);
       throw this.handleError(error, request);
     }
   }

--- a/src/adapters/image/OpenAIImageAdapter.ts
+++ b/src/adapters/image/OpenAIImageAdapter.ts
@@ -24,9 +24,8 @@ import type {
   GeneratedImage,
 } from '../../types/image';
 import { getCommonMappedErrorDetails } from '../../shared/adapters/errorUtils';
+import type { Logger } from '../../logging/types';
 import { createDefaultLogger } from '../../logging/defaultLogger';
-
-const logger = createDefaultLogger();
 
 /**
  * Prompt length limits per model
@@ -54,10 +53,12 @@ export class OpenAIImageAdapter implements ImageProviderAdapter {
 
   private baseURL?: string;
   private timeout: number;
+  private logger: Logger;
 
   constructor(config?: ImageProviderAdapterConfig) {
     this.baseURL = config?.baseURL;
     this.timeout = config?.timeout || 60000;
+    this.logger = config?.logger ?? createDefaultLogger();
   }
 
   /**
@@ -121,7 +122,7 @@ export class OpenAIImageAdapter implements ImageProviderAdapter {
         this.addDalleParams(params, settings);
       }
 
-      logger.debug(`OpenAI Image API call for model: ${request.modelId}`, {
+      this.logger.debug(`OpenAI Image API call for model: ${request.modelId}`, {
         model: params.model,
         promptLength: resolvedPrompt.length,
         n: params.n,
@@ -135,12 +136,12 @@ export class OpenAIImageAdapter implements ImageProviderAdapter {
         throw new Error('OpenAI API returned no images in response');
       }
 
-      logger.info(`OpenAI Image API call successful, generated ${response.data.length} images`);
+      this.logger.info(`OpenAI Image API call successful, generated ${response.data.length} images`);
 
       // Process response
       return await this.processResponse(response, request, isGptImageModel);
     } catch (error) {
-      logger.error('OpenAI Image API error:', error);
+      this.logger.error('OpenAI Image API error:', error);
       throw this.handleError(error, request);
     }
   }

--- a/src/image/ImageService.ts
+++ b/src/image/ImageService.ts
@@ -73,6 +73,7 @@ export class ImageService {
       new OpenAIImageAdapter({
         baseURL: openaiBaseURL,
         timeout: openaiConfig.timeout,
+        logger: this.logger,
       })
     );
 
@@ -84,6 +85,7 @@ export class ImageService {
       new GenaiElectronImageAdapter({
         baseURL: electronBaseURL,
         timeout: electronConfig.timeout,
+        logger: this.logger,
       })
     );
 

--- a/src/llm/LLMService.ts
+++ b/src/llm/LLMService.ts
@@ -108,7 +108,7 @@ export class LLMService {
       adapterConstructors: ADAPTER_CONSTRUCTORS,
       adapterConfigs: ADAPTER_CONFIGS,
     }, this.logger);
-    this.requestValidator = new RequestValidator();
+    this.requestValidator = new RequestValidator(this.logger);
     this.settingsManager = new SettingsManager(this.logger);
     this.modelResolver = new ModelResolver(this.presetManager, this.adapterRegistry, this.logger);
   }

--- a/src/llm/clients/AnthropicClientAdapter.ts
+++ b/src/llm/clients/AnthropicClientAdapter.ts
@@ -14,9 +14,8 @@ import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
+import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
-
-const logger = createDefaultLogger();
 
 /**
  * Client adapter for Anthropic API integration
@@ -30,15 +29,18 @@ const logger = createDefaultLogger();
  */
 export class AnthropicClientAdapter implements ILLMClientAdapter {
   private baseURL?: string;
+  private logger: Logger;
 
   /**
    * Creates a new Anthropic client adapter
    *
    * @param config Optional configuration for the adapter
    * @param config.baseURL Custom base URL for Anthropic-compatible APIs
+   * @param config.logger Custom logger instance
    */
-  constructor(config?: { baseURL?: string }) {
+  constructor(config?: { baseURL?: string; logger?: Logger }) {
     this.baseURL = config?.baseURL;
+    this.logger = config?.logger ?? createDefaultLogger();
   }
 
   /**
@@ -135,8 +137,8 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
         }
       }
 
-      logger.info(`Making Anthropic API call for model: ${request.modelId}`);
-      logger.debug(`Anthropic API parameters:`, {
+      this.logger.info(`Making Anthropic API call for model: ${request.modelId}`);
+      this.logger.debug(`Anthropic API parameters:`, {
         model: messageParams.model,
         temperature: messageParams.temperature,
         max_tokens: messageParams.max_tokens,
@@ -160,7 +162,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
         completion = await anthropic.messages.create(messageParams);
       }
 
-      logger.info(
+      this.logger.info(
         `Anthropic API call successful, response ID: ${completion.id}`
       );
 
@@ -168,7 +170,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
       // Cast to any to handle beta response type differences
       return this.createSuccessResponse(completion as any, request);
     } catch (error) {
-      logger.error("Anthropic API error:", error);
+      this.logger.error("Anthropic API error:", error);
       return this.createErrorResponse(error, request);
     }
   }
@@ -290,7 +292,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
         );
         if (modifiedIndex !== -1) {
           messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;
-          logger.debug(
+          this.logger.debug(
             `Model ${request.modelId} doesn't support system messages - prepended to first user message`
           );
         }
@@ -301,7 +303,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     // Anthropic requires messages to start with 'user' role
     // If the first message is not from user, we need to handle this
     if (messages.length > 0 && messages[0].role !== "user") {
-      logger.warn(
+      this.logger.warn(
         "Anthropic API requires first message to be from user. Adjusting message order."
       );
       // Find the first user message and move it to the front, or create a default one
@@ -349,7 +351,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
         // If roles don't alternate properly, we might need to combine messages
         // or insert a placeholder. For now, we'll skip non-alternating messages
         // and log a warning.
-        logger.warn(
+        this.logger.warn(
           `Skipping message with unexpected role: expected ${expectedRole}, got ${message.role}`
         );
       }

--- a/src/llm/clients/GeminiClientAdapter.ts
+++ b/src/llm/clients/GeminiClientAdapter.ts
@@ -18,9 +18,8 @@ import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
+import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
-
-const logger = createDefaultLogger();
 
 /**
  * Client adapter for Google Gemini API integration
@@ -34,15 +33,18 @@ const logger = createDefaultLogger();
  */
 export class GeminiClientAdapter implements ILLMClientAdapter {
   private baseURL?: string;
+  private logger: Logger;
 
   /**
    * Creates a new Gemini client adapter
    *
    * @param config Optional configuration for the adapter
    * @param config.baseURL Custom base URL (unused for Gemini but kept for consistency)
+   * @param config.logger Custom logger instance
    */
-  constructor(config?: { baseURL?: string }) {
+  constructor(config?: { baseURL?: string; logger?: Logger }) {
     this.baseURL = config?.baseURL;
+    this.logger = config?.logger ?? createDefaultLogger();
   }
 
   /**
@@ -64,8 +66,8 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
       const { contents, generationConfig, safetySettings, systemInstruction } =
         this.formatInternalRequestToGemini(request);
 
-      logger.info(`Making Gemini API call for model: ${request.modelId}`);
-      logger.debug(`Gemini API parameters:`, {
+      this.logger.info(`Making Gemini API call for model: ${request.modelId}`);
+      this.logger.debug(`Gemini API parameters:`, {
         model: request.modelId,
         temperature: generationConfig.temperature,
         maxOutputTokens: generationConfig.maxOutputTokens,
@@ -85,12 +87,12 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
         },
       });
 
-      logger.info(`Gemini API call successful, processing response`);
+      this.logger.info(`Gemini API call successful, processing response`);
 
       // Convert to standardized response format
       return this.createSuccessResponse(result, request);
     } catch (error) {
-      logger.error("Gemini API error:", error);
+      this.logger.error("Gemini API error:", error);
       return this.createErrorResponse(error, request);
     }
   }
@@ -186,7 +188,7 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
         if (modifiedIndex !== -1) {
           // Update the actual contents array
           contents[modifiedIndex].parts[0].text = simpleContents[modifiedIndex].content;
-          logger.debug(
+          this.logger.debug(
             `Model ${request.modelId} doesn't support system instructions - prepended to first user message`
           );
         }

--- a/src/llm/clients/LlamaCppClientAdapter.ts
+++ b/src/llm/clients/LlamaCppClientAdapter.ts
@@ -15,9 +15,8 @@ import {
 } from "../../shared/adapters/systemMessageUtils";
 import { LlamaCppServerClient } from "./LlamaCppServerClient";
 import { detectGgufCapabilities } from "../config";
+import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
-
-const logger = createDefaultLogger();
 
 /**
  * Configuration options for LlamaCppClientAdapter
@@ -27,6 +26,8 @@ export interface LlamaCppClientConfig {
   baseURL?: string;
   /** Whether to check server health before sending requests (default: false) */
   checkHealth?: boolean;
+  /** Logger instance for adapter logging */
+  logger?: Logger;
 }
 
 /**
@@ -70,6 +71,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
   private serverClient: LlamaCppServerClient;
   private cachedModelCapabilities: Partial<ModelInfo> | null = null;
   private detectionAttempted: boolean = false;
+  private logger: Logger;
 
   /**
    * Creates a new llama.cpp client adapter
@@ -80,6 +82,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
     this.baseURL = config?.baseURL || 'http://localhost:8080';
     this.checkHealth = config?.checkHealth || false;
     this.serverClient = new LlamaCppServerClient(this.baseURL);
+    this.logger = config?.logger ?? createDefaultLogger();
   }
 
   /**
@@ -103,11 +106,11 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
 
     // Attempt detection
     try {
-      logger.debug(`Detecting model capabilities from llama.cpp server at ${this.baseURL}`);
+      this.logger.debug(`Detecting model capabilities from llama.cpp server at ${this.baseURL}`);
       const { data } = await this.serverClient.getModels();
 
       if (!data || data.length === 0) {
-        logger.warn('No models loaded in llama.cpp server');
+        this.logger.warn('No models loaded in llama.cpp server');
         this.detectionAttempted = true;
         return null;
       }
@@ -120,14 +123,14 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
       this.detectionAttempted = true;
 
       if (capabilities) {
-        logger.debug(`Cached model capabilities for: ${ggufFilename}`);
+        this.logger.debug(`Cached model capabilities for: ${ggufFilename}`);
       } else {
-        logger.debug(`No known pattern matched for: ${ggufFilename}`);
+        this.logger.debug(`No known pattern matched for: ${ggufFilename}`);
       }
 
       return capabilities;
     } catch (error) {
-      logger.warn('Failed to detect model capabilities:', error);
+      this.logger.warn('Failed to detect model capabilities:', error);
       this.detectionAttempted = true;
       return null;
     }
@@ -142,7 +145,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
   clearModelCache(): void {
     this.cachedModelCapabilities = null;
     this.detectionAttempted = false;
-    logger.debug('Cleared model capabilities cache');
+    this.logger.debug('Cleared model capabilities cache');
   }
 
   /**
@@ -174,7 +177,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
             };
           }
         } catch (healthError) {
-          logger.warn('Health check failed, proceeding with request anyway:', healthError);
+          this.logger.warn('Health check failed, proceeding with request anyway:', healthError);
         }
       }
 
@@ -216,7 +219,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
         };
       }
 
-      logger.debug(`llama.cpp API parameters:`, {
+      this.logger.debug(`llama.cpp API parameters:`, {
         baseURL: this.baseURL,
         model: completionParams.model,
         temperature: completionParams.temperature,
@@ -224,20 +227,20 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
         top_p: completionParams.top_p,
       });
 
-      logger.info(`Making llama.cpp API call for model: ${request.modelId}`);
+      this.logger.info(`Making llama.cpp API call for model: ${request.modelId}`);
 
       // Make the API call
       const completion = await openai.chat.completions.create(completionParams);
 
       // Type guard to ensure we have a non-streaming response
       if ('id' in completion && 'choices' in completion) {
-        logger.info(`llama.cpp API call successful, response ID: ${completion.id}`);
+        this.logger.info(`llama.cpp API call successful, response ID: ${completion.id}`);
         return this.createSuccessResponse(completion as OpenAI.Chat.Completions.ChatCompletion, request);
       } else {
         throw new Error('Unexpected streaming response from llama.cpp server');
       }
     } catch (error) {
-      logger.error("llama.cpp API error:", error);
+      this.logger.error("llama.cpp API error:", error);
 
       // Clear cache on connection errors so we re-detect on next request
       const errorMessage = (error as any)?.message || String(error);
@@ -350,7 +353,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
         );
         if (modifiedIndex !== -1) {
           messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;
-          logger.debug(
+          this.logger.debug(
             `Model ${request.modelId} doesn't support system messages - prepended to first user message`
           );
         }

--- a/src/llm/clients/MistralClientAdapter.ts
+++ b/src/llm/clients/MistralClientAdapter.ts
@@ -13,9 +13,8 @@ import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
+import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
-
-const logger = createDefaultLogger();
 
 /**
  * Configuration options for MistralClientAdapter
@@ -23,6 +22,8 @@ const logger = createDefaultLogger();
 export interface MistralClientConfig {
   /** Base URL of the Mistral API (default: https://api.mistral.ai) */
   baseURL?: string;
+  /** Logger instance for adapter logging */
+  logger?: Logger;
 }
 
 /**
@@ -53,6 +54,7 @@ export interface MistralClientConfig {
  */
 export class MistralClientAdapter implements ILLMClientAdapter {
   private baseURL: string;
+  private logger: Logger;
 
   /**
    * Creates a new Mistral client adapter
@@ -61,6 +63,7 @@ export class MistralClientAdapter implements ILLMClientAdapter {
    */
   constructor(config?: MistralClientConfig) {
     this.baseURL = config?.baseURL || process.env.MISTRAL_API_BASE_URL || 'https://api.mistral.ai';
+    this.logger = config?.logger ?? createDefaultLogger();
   }
 
   /**
@@ -84,7 +87,7 @@ export class MistralClientAdapter implements ILLMClientAdapter {
       // Format messages for Mistral API
       const messages = this.formatMessages(request);
 
-      logger.debug(`Mistral API parameters:`, {
+      this.logger.debug(`Mistral API parameters:`, {
         baseURL: this.baseURL,
         model: request.modelId,
         temperature: request.settings.temperature,
@@ -92,7 +95,7 @@ export class MistralClientAdapter implements ILLMClientAdapter {
         top_p: request.settings.topP,
       });
 
-      logger.info(`Making Mistral API call for model: ${request.modelId}`);
+      this.logger.info(`Making Mistral API call for model: ${request.modelId}`);
 
       // Build request options
       const requestOptions: any = {
@@ -111,7 +114,7 @@ export class MistralClientAdapter implements ILLMClientAdapter {
       // Mistral only supports json_object mode, no schema validation
       if (request.settings.structuredOutput?.schema && request.settings.structuredOutput.enabled !== false) {
         requestOptions.responseFormat = { type: 'json_object' };
-        logger.warn(
+        this.logger.warn(
           `Mistral does not support JSON schema validation. ` +
           `Using json_object mode - schema validation will be client-side only.`
         );
@@ -121,13 +124,13 @@ export class MistralClientAdapter implements ILLMClientAdapter {
       const completion = await mistral.chat.complete(requestOptions);
 
       if (completion && completion.choices && completion.choices.length > 0) {
-        logger.info(`Mistral API call successful, response ID: ${completion.id}`);
+        this.logger.info(`Mistral API call successful, response ID: ${completion.id}`);
         return this.createSuccessResponse(completion, request);
       } else {
         throw new Error('No valid choices in Mistral completion response');
       }
     } catch (error) {
-      logger.error("Mistral API error:", error);
+      this.logger.error("Mistral API error:", error);
       return this.createErrorResponse(error, request);
     }
   }
@@ -213,7 +216,7 @@ export class MistralClientAdapter implements ILLMClientAdapter {
           request.settings.systemMessageFallback
         );
         if (modifiedIndex !== -1) {
-          logger.debug(
+          this.logger.debug(
             `Model ${request.modelId} doesn't support system messages - prepended to first user message`
           );
         }

--- a/src/llm/clients/OpenAIClientAdapter.ts
+++ b/src/llm/clients/OpenAIClientAdapter.ts
@@ -14,9 +14,8 @@ import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
+import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
-
-const logger = createDefaultLogger();
 
 /**
  * Client adapter for OpenAI API integration
@@ -29,15 +28,18 @@ const logger = createDefaultLogger();
  */
 export class OpenAIClientAdapter implements ILLMClientAdapter {
   private baseURL?: string;
+  private logger: Logger;
 
   /**
    * Creates a new OpenAI client adapter
    *
    * @param config Optional configuration for the adapter
    * @param config.baseURL Custom base URL for OpenAI-compatible APIs
+   * @param config.logger Custom logger instance
    */
-  constructor(config?: { baseURL?: string }) {
+  constructor(config?: { baseURL?: string; logger?: Logger }) {
     this.baseURL = config?.baseURL;
+    this.logger = config?.logger ?? createDefaultLogger();
   }
 
   /**
@@ -113,7 +115,7 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
         } as any;
       }
 
-      logger.debug(`OpenAI API parameters:`, {
+      this.logger.debug(`OpenAI API parameters:`, {
         model: completionParams.model,
         temperature: completionParams.temperature,
         max_completion_tokens: completionParams.max_completion_tokens,
@@ -124,21 +126,21 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
         hasUser: !!completionParams.user,
       });
 
-      logger.info(`Making OpenAI API call for model: ${request.modelId}`);
+      this.logger.info(`Making OpenAI API call for model: ${request.modelId}`);
 
       // Make the API call
       const completion = await openai.chat.completions.create(completionParams);
 
       // Type guard to ensure we have a non-streaming response
       if ('id' in completion && 'choices' in completion) {
-        logger.info(`OpenAI API call successful, response ID: ${completion.id}`);
+        this.logger.info(`OpenAI API call successful, response ID: ${completion.id}`);
         // Convert to standardized response format
         return this.createSuccessResponse(completion as OpenAI.Chat.Completions.ChatCompletion, request);
       } else {
         throw new Error('Unexpected streaming response from OpenAI API');
       }
     } catch (error) {
-      logger.error("OpenAI API error:", error);
+      this.logger.error("OpenAI API error:", error);
       return this.createErrorResponse(error, request);
     }
   }
@@ -263,7 +265,7 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
         );
         if (modifiedIndex !== -1) {
           messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;
-          logger.debug(
+          this.logger.debug(
             `Model ${request.modelId} doesn't support system messages - prepended to first user message`
           );
         }

--- a/src/llm/clients/OpenRouterClientAdapter.ts
+++ b/src/llm/clients/OpenRouterClientAdapter.ts
@@ -13,9 +13,8 @@ import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
+import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
-
-const logger = createDefaultLogger();
 
 /**
  * Configuration options for OpenRouterClientAdapter
@@ -27,6 +26,8 @@ export interface OpenRouterClientConfig {
   httpReferer?: string;
   /** Your app's display name for rankings (optional) */
   siteTitle?: string;
+  /** Logger instance for adapter logging */
+  logger?: Logger;
 }
 
 /**
@@ -63,6 +64,7 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
   private baseURL: string;
   private httpReferer?: string;
   private siteTitle?: string;
+  private logger: Logger;
 
   /**
    * Creates a new OpenRouter client adapter
@@ -73,6 +75,7 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
     this.baseURL = config?.baseURL || 'https://openrouter.ai/api/v1';
     this.httpReferer = config?.httpReferer || process.env.OPENROUTER_HTTP_REFERER;
     this.siteTitle = config?.siteTitle || process.env.OPENROUTER_SITE_TITLE;
+    this.logger = config?.logger ?? createDefaultLogger();
   }
 
   /**
@@ -158,7 +161,7 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
         };
       }
 
-      logger.debug(`OpenRouter API parameters:`, {
+      this.logger.debug(`OpenRouter API parameters:`, {
         baseURL: this.baseURL,
         model: completionParams.model,
         temperature: completionParams.temperature,
@@ -167,20 +170,20 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
         hasProviderRouting: !!(completionParams as any).provider,
       });
 
-      logger.info(`Making OpenRouter API call for model: ${request.modelId}`);
+      this.logger.info(`Making OpenRouter API call for model: ${request.modelId}`);
 
       // Make the API call
       const completion = await openai.chat.completions.create(completionParams);
 
       // Type guard to ensure we have a non-streaming response
       if ('id' in completion && 'choices' in completion) {
-        logger.info(`OpenRouter API call successful, response ID: ${completion.id}`);
+        this.logger.info(`OpenRouter API call successful, response ID: ${completion.id}`);
         return this.createSuccessResponse(completion as OpenAI.Chat.Completions.ChatCompletion, request);
       } else {
         throw new Error('Unexpected streaming response from OpenRouter');
       }
     } catch (error) {
-      logger.error("OpenRouter API error:", error);
+      this.logger.error("OpenRouter API error:", error);
       return this.createErrorResponse(error, request);
     }
   }
@@ -270,7 +273,7 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
         );
         if (modifiedIndex !== -1) {
           messages[modifiedIndex].content = simpleMessages[modifiedIndex].content;
-          logger.debug(
+          this.logger.debug(
             `Model ${request.modelId} doesn't support system messages - prepended to first user message`
           );
         }

--- a/src/llm/services/RequestValidator.ts
+++ b/src/llm/services/RequestValidator.ts
@@ -6,15 +6,24 @@ import type {
   ModelInfo,
   StructuredOutputSettings
 } from "../types";
+import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
-
-const logger = createDefaultLogger();
 import { validateLLMSettings } from "../config";
 
 /**
  * Validates LLM requests including structure, messages, and settings
  */
 export class RequestValidator {
+  private logger: Logger;
+
+  /**
+   * Creates a new RequestValidator
+   *
+   * @param logger Optional logger instance
+   */
+  constructor(logger?: Logger) {
+    this.logger = logger ?? createDefaultLogger();
+  }
   /**
    * Validates basic LLM request structure
    *
@@ -192,7 +201,7 @@ export class RequestValidator {
 
       // Warn (but don't error) if strict mode requested but not supported
       if (structuredOutput.strict !== false && modelInfo.structuredOutput.strictMode === false) {
-        logger.warn(
+        this.logger.warn(
           `Model ${request.modelId} does not support strict mode for structured output. ` +
           `Schema validation will be client-side only.`
         );

--- a/src/shared/services/AdapterRegistry.ts
+++ b/src/shared/services/AdapterRegistry.ts
@@ -111,7 +111,9 @@ export class AdapterRegistry<TAdapter, TProviderId extends string> {
       if (AdapterClass) {
         try {
           const adapterConfig = adapterConfigs[provider.id];
-          const adapterInstance = new AdapterClass(adapterConfig);
+          // Inject logger into adapter config
+          const configWithLogger = { ...adapterConfig, logger: this.logger };
+          const adapterInstance = new AdapterClass(configWithLogger);
           this.registerAdapter(providerId, adapterInstance);
           registeredCount++;
           successfullyRegisteredProviders.push(provider.id);

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -375,6 +375,8 @@ export interface ImageProviderAdapterConfig {
   timeout?: number;
   /** Whether to check health before requests */
   checkHealth?: boolean;
+  /** Logger instance for adapter logging */
+  logger?: Logger;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix bug where adapters ignored `logLevel` passed to service constructors
- All LLM and Image adapters now receive injected logger from their parent service
- Setting `logLevel: 'silent'` now properly silences all adapter logging
- Maintains backward compatibility (logger parameter is optional with fallback)

## Changes
- Add `logger?: Logger` to `ImageProviderAdapterConfig` type
- Convert all 6 LLM adapters to use instance loggers
- Convert both Image adapters to use instance loggers  
- Update `AdapterRegistry` to inject logger when instantiating adapters
- Update `ImageService` to pass logger to manually created adapters
- Update `RequestValidator` to accept logger in constructor
- Bump version to 0.8.3

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (684 tests)
- [ ] Manual test: verify `logLevel: 'silent'` silences adapter output

🤖 Generated with [Claude Code](https://claude.com/claude-code)