### PR TITLE
feat: add structured output capability preflight

### DIFF
--- a/genai-lite-docs/llm-service.md
+++ b/genai-lite-docs/llm-service.md
@@ -6,6 +6,7 @@ Complete guide to text generation and chat completions using genai-lite's LLMSer
 
 - [Overview](#overview) - When to use LLMService
 - [Basic Usage](#basic-usage) - Simple message sending
+- [Capability Preflight](#capability-preflight) - Check provider/model support before sending
 - [Streaming Text](#streaming-text) - Token deltas from streaming-capable providers
 - [Structured Output](#structured-output) - Guaranteed JSON responses with schema validation
 - [Reasoning Mode](#reasoning-mode) - Advanced problem-solving with native reasoning
@@ -93,6 +94,54 @@ const presets = llmService.getPresets();
 ```
 
 See [Providers & Models](providers-and-models.md) for all supported providers and models.
+
+---
+
+## Capability Preflight
+
+Use capability APIs when you need to validate a provider/model choice before retrieving an API key or calling a provider adapter.
+
+```typescript
+const capabilities = await llmService.getModelCapabilities(
+  'gemini',
+  'gemma-4-31b-it'
+);
+
+if (capabilities.object !== 'error') {
+  console.log(capabilities.structuredOutput.status); // 'unsupported'
+}
+```
+
+For actual request settings, use `validateRequestCapabilities()`:
+
+```typescript
+const preflight = await llmService.validateRequestCapabilities({
+  providerId: 'gemini',
+  modelId: 'gemma-4-31b-it',
+  settings: {
+    structuredOutput: {
+      name: 'prompt_response',
+      schema: { type: 'object', properties: { answer: { type: 'string' } } }
+    }
+  }
+});
+
+if (preflight.object === 'error') {
+  console.error(preflight.error.code); // 'structured_output_not_supported'
+}
+```
+
+Capability calls are static and side-effect free:
+- no API key lookup
+- no provider adapter call
+- no network I/O
+
+Structured-output support is reported as:
+- `supported`: genai-lite has metadata that native structured output is available.
+- `unsupported`: genai-lite has metadata that native structured output is unavailable.
+- `unknown`: genai-lite has no explicit metadata. This is not treated as failure by default; callers decide whether to allow it, reject it, or use a prompt-text fallback.
+
+`validateRequestCapabilities()` returns the same validation diagnostic shape as `sendMessage()` where possible. For example, Gemini-hosted Gemma models return `type: 'validation_error'` and `code: 'structured_output_not_supported'` when structured output is requested.
 
 ---
 

--- a/genai-lite-docs/providers-and-models.md
+++ b/genai-lite-docs/providers-and-models.md
@@ -5,6 +5,7 @@ Complete reference of all supported AI providers and models in genai-lite.
 ## Contents
 
 - [Overview](#overview)
+- [Capability Lookup Semantics](#capability-lookup-semantics)
 - [LLM Providers](#llm-providers)
 - [Image Generation Providers](#image-generation-providers)
 - [Models with Reasoning Support](#models-with-reasoning-support)
@@ -24,6 +25,19 @@ Complete reference of all supported AI providers and models in genai-lite.
 - genai-electron (local diffusion models)
 
 **Note:** Model IDs include version dates for precise model selection. Always use the exact model ID as shown below.
+
+## Capability Lookup Semantics
+
+`LLMService.getModelCapabilities()` and `LLMService.validateRequestCapabilities()` provide static, no-network capability checks for provider/model selections.
+
+Structured-output capability status is interpreted as:
+- `supported`: the model registry explicitly marks structured output as supported.
+- `unsupported`: the model registry explicitly marks structured output as unsupported.
+- `unknown`: no explicit structured-output metadata is available. This is not automatically rejected by genai-lite; callers decide whether to allow it, reject it, or use a fallback.
+
+Unknown/unregistered models follow the same fallback model policy used by request preparation, but optional capabilities such as structured output are reported as `unknown`.
+
+For llama.cpp, capability preflight does not query the running local server. Runtime requests can still use detected GGUF capabilities, but static preflight reports only registry/fallback information so it remains free of adapter calls and network I/O.
 
 ## LLM Providers
 
@@ -115,7 +129,7 @@ Complete reference of all supported AI providers and models in genai-lite.
 - Gemini models support multimodal (text, images, audio, video)
 - Gemma 3 and Gemma 4 are open-weight and **free** via the Gemini API (no API costs)
 - **Gemma 3 does not support system instructions** - genai-lite automatically prepends system content to the first user message (see [System Message Fallback](llm-service.md#system-message-fallback)). **Gemma 4 does support a native system role** (unlike Gemma 3)
-- **Gemma models do not support structured output (JSON mode)** via Google's API - use OpenRouter instead for JSON output. Reasoning/thinking is not exposed for Gemma on the Gemini API
+- **Gemma models do not support structured output (JSON mode)** via Google's API - capability preflight reports `unsupported`; use OpenRouter instead for JSON output. Reasoning/thinking is not exposed for Gemma on the Gemini API
 - Supports `LLMService.streamMessage()` via `generateContentStream()`; thought parts are emitted as `reasoning_delta` when reasoning output is included
 - Sampling parameters: supports `topK` and `seed`. Does not support `minP`, `repeatPenalty`, or `logprobs`/`topLogprobs` (Gemini's log-probability mechanism has a different shape and is not mapped)
 
@@ -179,6 +193,7 @@ Detected models also receive vendor-recommended sampling defaults automatically.
 - Supports `LLMService.streamMessage()` for content deltas, usage events, and final normalized responses
 - Reasoning on/off for hybrid models is driven by `settings.reasoning.enabled` (requires llama-server `--jinja`); see [Reasoning on/off for Hybrid Models](llamacpp-integration.md#reasoning-onoff-for-hybrid-models)
 - Sampling parameters: supports `topK`, `minP`, `repeatPenalty`, `seed`, and `logprobs`/`topLogprobs`; plus llama.cpp-only `grammar` and `chatTemplateKwargs` via the `llamacpp` namespace
+- Capability preflight is static and does not query `/v1/models`; runtime requests may still apply detected GGUF capabilities
 - Default base URL is `http://127.0.0.1:8080` (not `localhost`) to avoid a Windows IPv6-fallback stall
 - See [llama.cpp Integration](llamacpp-integration.md) for setup
 

--- a/genai-lite-docs/typescript-reference.md
+++ b/genai-lite-docs/typescript-reference.md
@@ -81,6 +81,13 @@ import type {
   StructuredOutputSchema,
   StructuredOutputSchemaProperty,
   ModelStructuredOutputCapabilities,
+  CapabilityStatus,
+  CapabilitySource,
+  StructuredOutputSupport,
+  ModelCapabilities,
+  ModelCapabilitiesResult,
+  LLMRequestCapabilityPreflight,
+  LLMRequestCapabilityValidationResult,
   ModelPreset,
   LLMServiceOptions,
   SendMessageOptions,
@@ -236,6 +243,54 @@ type LLMStreamEvent =
   | { type: 'error'; error: LLMFailureResponse };
 ```
 
+### Capability Types
+
+```typescript
+type CapabilityStatus = 'supported' | 'unsupported' | 'unknown';
+type CapabilitySource = 'registry' | 'detected' | 'fallback';
+
+interface StructuredOutputSupport {
+  status: CapabilityStatus;
+  strictMode?: boolean;
+  notes?: string;
+  source: CapabilitySource;
+}
+
+interface ModelCapabilities {
+  structuredOutput: StructuredOutputSupport;
+}
+
+interface ModelCapabilitiesResult {
+  object: 'model.capabilities';
+  provider: string;
+  model: string;
+  modelInfo: ModelInfo;
+  structuredOutput: StructuredOutputSupport;
+}
+
+interface LLMRequestCapabilityPreflight {
+  providerId?: string;
+  modelId?: string;
+  presetId?: string;
+  settings?: LLMSettings;
+}
+
+type LLMRequestCapabilityValidationResult =
+  | {
+      object: 'capability.validation';
+      valid: true;
+      provider: string;
+      model: string;
+      capabilities: ModelCapabilities;
+    }
+  | (LLMFailureResponse & {
+      valid: false;
+      capabilities?: ModelCapabilities;
+    });
+```
+
+`unknown` means genai-lite has no explicit metadata for that capability. It is not automatically rejected by `validateRequestCapabilities()`; callers decide policy.
+
 ### Settings Types
 
 ```typescript
@@ -388,6 +443,23 @@ interface SendMessageOptions {
 interface StreamMessageOptions {
   signal?: AbortSignal;   // Client-side cancel (provider may still process/bill)
   timeoutMs?: number;     // Overrides the service-level timeoutMs
+}
+
+// Capability methods on LLMService
+class LLMService {
+  getModelCapabilities(
+    providerId: string,
+    modelId: string
+  ): Promise<ModelCapabilitiesResult | LLMFailureResponse>;
+
+  supportsStructuredOutput(
+    providerId: string,
+    modelId: string
+  ): Promise<StructuredOutputSupport | LLMFailureResponse>;
+
+  validateRequestCapabilities(
+    request: LLMRequestCapabilityPreflight
+  ): Promise<LLMRequestCapabilityValidationResult>;
 }
 
 interface RetryPolicy {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-lite",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-lite",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/llm/LLMService.capabilities.test.ts
+++ b/src/llm/LLMService.capabilities.test.ts
@@ -1,0 +1,195 @@
+import { LLMService } from "./LLMService";
+import { LlamaCppClientAdapter } from "./clients/LlamaCppClientAdapter";
+import type { ApiKeyProvider } from "../types";
+import type {
+  LLMFailureResponse,
+  LLMRequestCapabilityPreflight,
+  StructuredOutputSettings,
+} from "./types";
+
+describe("LLMService capability preflight", () => {
+  let mockApiKeyProvider: jest.MockedFunction<ApiKeyProvider>;
+  let service: LLMService;
+
+  const structuredOutput: StructuredOutputSettings = {
+    name: "prompt_response",
+    schema: {
+      type: "object",
+      properties: {
+        answer: { type: "string" },
+      },
+      required: ["answer"],
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiKeyProvider = jest.fn(async (providerId: string) => `mock-key-for-${providerId}`);
+    service = new LLMService(mockApiKeyProvider, { logLevel: "silent" });
+  });
+
+  it("reports gemini:gemma-3-27b-it structured output as unsupported", async () => {
+    const result = await service.validateRequestCapabilities({
+      providerId: "gemini",
+      modelId: "gemma-3-27b-it",
+      settings: { structuredOutput },
+    });
+
+    expect(result.object).toBe("error");
+    expect(result.valid).toBe(false);
+    expect((result as LLMFailureResponse).error).toMatchObject({
+      type: "validation_error",
+      code: "structured_output_not_supported",
+    });
+    expect(result.capabilities?.structuredOutput).toMatchObject({
+      status: "unsupported",
+      source: "registry",
+      notes: "Gemma models do not support JSON mode via Google's API",
+    });
+    expect(mockApiKeyProvider).not.toHaveBeenCalled();
+  });
+
+  it("reports gemini:gemma-4-31b-it structured output as unsupported", async () => {
+    const result = await service.validateRequestCapabilities({
+      providerId: "gemini",
+      modelId: "gemma-4-31b-it",
+      settings: { structuredOutput },
+    });
+
+    expect(result.object).toBe("error");
+    expect(result.valid).toBe(false);
+    expect((result as LLMFailureResponse).error).toMatchObject({
+      type: "validation_error",
+      code: "structured_output_not_supported",
+    });
+    expect(result.capabilities?.structuredOutput.status).toBe("unsupported");
+    expect(mockApiKeyProvider).not.toHaveBeenCalled();
+  });
+
+  it("reports gemini:gemini-2.5-flash structured output as supported and valid", async () => {
+    const result = await service.validateRequestCapabilities({
+      providerId: "gemini",
+      modelId: "gemini-2.5-flash",
+      settings: { structuredOutput },
+    });
+
+    expect(result).toMatchObject({
+      object: "capability.validation",
+      valid: true,
+      provider: "gemini",
+      model: "gemini-2.5-flash",
+      capabilities: {
+        structuredOutput: {
+          status: "supported",
+          source: "registry",
+          strictMode: true,
+        },
+      },
+    });
+    expect(mockApiKeyProvider).not.toHaveBeenCalled();
+  });
+
+  it("reports known models without structuredOutput metadata as unknown without failing preflight", async () => {
+    const capabilities = await service.getModelCapabilities(
+      "anthropic",
+      "claude-3-5-sonnet-20241022"
+    );
+
+    expect(capabilities).toMatchObject({
+      object: "model.capabilities",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet-20241022",
+      structuredOutput: {
+        status: "unknown",
+        source: "registry",
+      },
+    });
+
+    const result = await service.validateRequestCapabilities({
+      providerId: "anthropic",
+      modelId: "claude-3-5-sonnet-20241022",
+      settings: { structuredOutput },
+    });
+
+    expect(result).toMatchObject({
+      object: "capability.validation",
+      valid: true,
+      capabilities: {
+        structuredOutput: {
+          status: "unknown",
+          source: "registry",
+        },
+      },
+    });
+    expect(mockApiKeyProvider).not.toHaveBeenCalled();
+  });
+
+  it("reports unknown models as unknown using fallback metadata", async () => {
+    const capabilities = await service.getModelCapabilities("openai", "future-model");
+
+    expect(capabilities).toMatchObject({
+      object: "model.capabilities",
+      provider: "openai",
+      model: "future-model",
+      structuredOutput: {
+        status: "unknown",
+        source: "fallback",
+      },
+    });
+    expect(mockApiKeyProvider).not.toHaveBeenCalled();
+  });
+
+  it("does not call provider adapters during preflight", async () => {
+    const getModelCapabilitiesSpy = jest.spyOn(
+      LlamaCppClientAdapter.prototype,
+      "getModelCapabilities"
+    );
+
+    const localService = new LLMService(mockApiKeyProvider, { logLevel: "silent" });
+    const result = await localService.validateRequestCapabilities({
+      providerId: "llamacpp",
+      modelId: "llamacpp",
+      settings: { structuredOutput },
+    });
+
+    expect(result.object).toBe("capability.validation");
+    expect(getModelCapabilitiesSpy).not.toHaveBeenCalled();
+    expect(mockApiKeyProvider).not.toHaveBeenCalled();
+
+    getModelCapabilitiesSpy.mockRestore();
+  });
+
+  it("matches sendMessage structured-output diagnostics where possible", async () => {
+    const preflightRequest: LLMRequestCapabilityPreflight = {
+      providerId: "gemini",
+      modelId: "gemma-4-31b-it",
+      settings: { structuredOutput },
+    };
+
+    const preflight = await service.validateRequestCapabilities(preflightRequest);
+    const sendResult = await service.sendMessage({
+      ...preflightRequest,
+      providerId: "gemini",
+      modelId: "gemma-4-31b-it",
+      messages: [{ role: "user", content: "Return JSON." }],
+    });
+
+    expect(preflight.object).toBe("error");
+    expect(sendResult.object).toBe("error");
+    expect((preflight as LLMFailureResponse).error).toMatchObject(
+      (sendResult as LLMFailureResponse).error
+    );
+    expect(mockApiKeyProvider).not.toHaveBeenCalled();
+  });
+
+  it("supports the narrow structured-output helper", async () => {
+    const support = await service.supportsStructuredOutput("gemini", "gemini-2.5-flash");
+
+    expect(support).toMatchObject({
+      status: "supported",
+      source: "registry",
+      strictMode: true,
+    });
+    expect(mockApiKeyProvider).not.toHaveBeenCalled();
+  });
+});

--- a/src/llm/LLMService.ts
+++ b/src/llm/LLMService.ts
@@ -16,6 +16,12 @@ import type {
   ModelContext,
   LLMMessage,
   LLMStreamEvent,
+  LLMRequestCapabilityPreflight,
+  LLMRequestCapabilityValidationResult,
+  ModelCapabilities,
+  ModelCapabilitiesResult,
+  StructuredOutputSupport,
+  CapabilitySource,
 } from "./types";
 import type {
   ILLMClientAdapter,
@@ -28,6 +34,7 @@ import {
   ADAPTER_CONSTRUCTORS,
   ADAPTER_CONFIGS,
   getProviderById,
+  getModelById,
   getModelsByProvider
 } from "./config";
 import { renderTemplate } from "../prompting/template";
@@ -124,6 +131,15 @@ interface PreparedLLMRequest {
   adapterOptions: AdapterRequestOptions;
 }
 
+interface CapabilityValidationContext {
+  providerId: ApiProviderId;
+  modelId: string;
+  modelInfo: ModelInfo;
+  resolvedRequest: LLMChatRequest;
+  finalSettings: Required<LLMSettings>;
+  capabilities: ModelCapabilities;
+}
+
 /**
  * Main process service for LLM operations
  *
@@ -200,6 +216,117 @@ export class LLMService {
 
     this.logger.debug(`Found ${models.length} models for provider: ${providerId}`);
     return [...models]; // Return a copy to prevent external modification
+  }
+
+  /**
+   * Gets static capability metadata for a provider/model pair without retrieving
+   * API keys, calling provider adapters, or performing network I/O.
+   *
+   * Unknown or unregistered models use the same fallback model resolution policy
+   * as sendMessage(), but their optional capabilities are reported as unknown.
+   */
+  async getModelCapabilities(
+    providerId: ApiProviderId,
+    modelId: string
+  ): Promise<ModelCapabilitiesResult | LLMFailureResponse> {
+    this.logger.debug(
+      `LLMService.getModelCapabilities called for provider: ${providerId}, model: ${modelId}`
+    );
+
+    const resolved = await this.modelResolver.resolve(
+      { providerId, modelId },
+      { detectLocalCapabilities: false }
+    );
+    if (resolved.error) {
+      return resolved.error;
+    }
+
+    const resolvedProviderId = resolved.providerId! as ApiProviderId;
+    const resolvedModelId = resolved.modelId!;
+    const modelInfo = resolved.modelInfo!;
+    const source = this.getCapabilitySource(resolvedProviderId, resolvedModelId);
+
+    return {
+      object: "model.capabilities",
+      provider: resolvedProviderId,
+      model: resolvedModelId,
+      modelInfo: { ...modelInfo },
+      structuredOutput: this.getStructuredOutputSupport(modelInfo, source),
+    };
+  }
+
+  /**
+   * Convenience wrapper for checking structured-output support.
+   *
+   * Returns `unknown` when genai-lite has no explicit capability metadata. Callers
+   * should decide whether unknown is acceptable for their use case.
+   */
+  async supportsStructuredOutput(
+    providerId: ApiProviderId,
+    modelId: string
+  ): Promise<StructuredOutputSupport | LLMFailureResponse> {
+    const capabilities = await this.getModelCapabilities(providerId, modelId);
+    if (capabilities.object === "error") {
+      return capabilities;
+    }
+    return capabilities.structuredOutput;
+  }
+
+  /**
+   * Preflights provider/model capability requirements for a request without
+   * retrieving API keys, calling provider adapters, or performing network I/O.
+   *
+   * This checks the effective settings after preset and model defaults are
+   * applied. Unknown/unspecified capabilities are reported as unknown and remain
+   * valid; explicitly unsupported capabilities return the same validation error
+   * shape as sendMessage() where possible.
+   */
+  async validateRequestCapabilities(
+    request: LLMRequestCapabilityPreflight
+  ): Promise<LLMRequestCapabilityValidationResult> {
+    this.logger.debug(
+      `LLMService.validateRequestCapabilities called with presetId: ${request.presetId}, provider: ${request.providerId}, model: ${request.modelId}`
+    );
+
+    try {
+      const validation = await this.resolveAndValidateCapabilities(request, {
+        validateStructure: false,
+        detectLocalCapabilities: false,
+      });
+
+      if ("error" in validation) {
+        return {
+          ...validation.error,
+          valid: false,
+          ...(validation.capabilities && { capabilities: validation.capabilities }),
+        };
+      }
+
+      return {
+        object: "capability.validation",
+        valid: true,
+        provider: validation.context.providerId,
+        model: validation.context.modelId,
+        capabilities: validation.context.capabilities,
+      };
+    } catch (error) {
+      this.logger.error("Error in LLMService.validateRequestCapabilities:", error);
+      return {
+        provider: request.providerId || request.presetId || 'unknown',
+        model: request.modelId || request.presetId || 'unknown',
+        error: {
+          message:
+            error instanceof Error
+              ? error.message
+              : "Unexpected error during capability preflight",
+          code: "UNKNOWN_ERROR",
+          type: "server_error",
+          providerError: error,
+        },
+        object: "error",
+        valid: false,
+      };
+    }
   }
 
   /**
@@ -413,79 +540,162 @@ export class LLMService {
     }
   }
 
-  private async prepareRequest(
-    request: LLMChatRequest | LLMChatRequestWithPreset,
-    callOptions?: StreamMessageOptions
-  ): Promise<{ prepared: PreparedLLMRequest } | { error: LLMFailureResponse }> {
-    // Resolve model information from preset or direct IDs
-    const resolved = await this.modelResolver.resolve(request);
+  private async resolveAndValidateCapabilities(
+    request: LLMChatRequest | LLMChatRequestWithPreset | LLMRequestCapabilityPreflight,
+    options: {
+      validateStructure: boolean;
+      detectLocalCapabilities: boolean;
+    }
+  ): Promise<
+    { context: CapabilityValidationContext } |
+    { error: LLMFailureResponse; capabilities?: ModelCapabilities }
+  > {
+    const resolved = await this.modelResolver.resolve(request, {
+      detectLocalCapabilities: options.detectLocalCapabilities,
+    });
     if (resolved.error) {
       return { error: resolved.error };
     }
 
-    const { providerId, modelId, modelInfo, settings: resolvedSettings } = resolved;
+    const providerId = resolved.providerId! as ApiProviderId;
+    const modelId = resolved.modelId!;
+    const modelInfo = resolved.modelInfo!;
+    const source = this.getCapabilitySource(providerId, modelId);
+    const capabilities = this.buildModelCapabilities(modelInfo, source);
 
-    // Create a proper LLMChatRequest with resolved values
     const resolvedRequest: LLMChatRequest = {
-      ...request,
-      providerId: providerId!,
-      modelId: modelId!,
+      ...(request as Partial<LLMChatRequest>),
+      providerId,
+      modelId,
+      messages: "messages" in request && Array.isArray(request.messages)
+        ? request.messages
+        : [],
     };
 
-    // Validate basic request structure
-    const structureValidationResult = this.requestValidator.validateRequestStructure(resolvedRequest);
-    if (structureValidationResult) {
-      return { error: structureValidationResult };
-    }
-
-    // Validate settings if provided
-    const combinedSettings = { ...resolvedSettings, ...request.settings };
-    if (combinedSettings) {
-      const settingsValidation = this.requestValidator.validateSettings(
-        combinedSettings,
-        providerId!,
-        modelId!
-      );
-      if (settingsValidation) {
-        return { error: settingsValidation };
+    if (options.validateStructure) {
+      const structureValidationResult = this.requestValidator.validateRequestStructure(resolvedRequest);
+      if (structureValidationResult) {
+        return { error: structureValidationResult, capabilities };
       }
     }
 
-    // Apply model-specific defaults and merge with user settings
+    const combinedSettings = {
+      ...(resolved.settings || {}),
+      ...(request.settings || {}),
+    };
+
+    const settingsValidation = this.requestValidator.validateSettings(
+      combinedSettings,
+      providerId,
+      modelId
+    );
+    if (settingsValidation) {
+      return { error: settingsValidation, capabilities };
+    }
+
     const finalSettings = this.settingsManager.mergeSettingsForModel(
-      modelId!,
-      providerId!,
+      modelId,
+      providerId,
       combinedSettings,
       modelInfo
     );
 
-    // Validate reasoning settings for model capabilities
     const reasoningValidation = this.requestValidator.validateReasoningSettings(
-      modelInfo!,
+      modelInfo,
       finalSettings.reasoning,
       resolvedRequest
     );
     if (reasoningValidation) {
-      return { error: reasoningValidation };
+      return { error: reasoningValidation, capabilities };
     }
 
-    // Validate structured output settings for model capabilities
     const structuredOutputValidation = this.requestValidator.validateStructuredOutputSettings(
-      modelInfo!,
+      modelInfo,
       finalSettings.structuredOutput,
       resolvedRequest
     );
     if (structuredOutputValidation) {
-      return { error: structuredOutputValidation };
+      return { error: structuredOutputValidation, capabilities };
     }
 
+    return {
+      context: {
+        providerId,
+        modelId,
+        modelInfo,
+        resolvedRequest,
+        finalSettings,
+        capabilities,
+      },
+    };
+  }
+
+  private buildModelCapabilities(
+    modelInfo: ModelInfo,
+    source: CapabilitySource
+  ): ModelCapabilities {
+    return {
+      structuredOutput: this.getStructuredOutputSupport(modelInfo, source),
+    };
+  }
+
+  private getStructuredOutputSupport(
+    modelInfo: ModelInfo,
+    source: CapabilitySource
+  ): StructuredOutputSupport {
+    if (modelInfo.structuredOutput === undefined) {
+      return {
+        status: "unknown",
+        source,
+      };
+    }
+
+    return {
+      status: modelInfo.structuredOutput.supported ? "supported" : "unsupported",
+      ...(modelInfo.structuredOutput.strictMode !== undefined && {
+        strictMode: modelInfo.structuredOutput.strictMode,
+      }),
+      ...(modelInfo.structuredOutput.notes && {
+        notes: modelInfo.structuredOutput.notes,
+      }),
+      source,
+    };
+  }
+
+  private getCapabilitySource(
+    providerId: ApiProviderId,
+    modelId: string
+  ): CapabilitySource {
+    return getModelById(modelId, providerId) ? "registry" : "fallback";
+  }
+
+  private async prepareRequest(
+    request: LLMChatRequest | LLMChatRequestWithPreset,
+    callOptions?: StreamMessageOptions
+  ): Promise<{ prepared: PreparedLLMRequest } | { error: LLMFailureResponse }> {
+    const validation = await this.resolveAndValidateCapabilities(request, {
+      validateStructure: true,
+      detectLocalCapabilities: true,
+    });
+    if ("error" in validation) {
+      return { error: validation.error };
+    }
+
+    const {
+      providerId,
+      modelId,
+      modelInfo,
+      resolvedRequest,
+      finalSettings,
+    } = validation.context;
+
     // Get provider info for parameter filtering
-    const providerInfo = getProviderById(providerId!);
+    const providerInfo = getProviderById(providerId);
     if (!providerInfo) {
       return {
         error: {
-          provider: providerId!,
-          model: modelId!,
+          provider: providerId,
+          model: modelId,
           error: {
             message: `Provider information not found: ${providerId}`,
             code: "PROVIDER_ERROR",
@@ -499,7 +709,7 @@ export class LLMService {
     // Filter out unsupported parameters
     const filteredSettings = this.settingsManager.filterUnsupportedParameters(
       finalSettings,
-      modelInfo!,
+      modelInfo,
       providerInfo
     );
 
@@ -519,15 +729,15 @@ export class LLMService {
     );
 
     // Get client adapter
-    const clientAdapter = this.adapterRegistry.getAdapter(providerId!);
+    const clientAdapter = this.adapterRegistry.getAdapter(providerId);
 
     try {
-      const apiKey = await this.getApiKey(providerId!);
+      const apiKey = await this.getApiKey(providerId);
       if (!apiKey) {
         return {
           error: {
-            provider: providerId!,
-            model: modelId!,
+            provider: providerId,
+            model: modelId,
             error: {
               message: `API key for provider '${providerId}' could not be retrieved. Ensure your ApiKeyProvider is configured correctly.`,
               code: "API_KEY_ERROR",
@@ -542,8 +752,8 @@ export class LLMService {
       if (clientAdapter.validateApiKey && !clientAdapter.validateApiKey(apiKey)) {
         return {
           error: {
-            provider: providerId!,
-            model: modelId!,
+            provider: providerId,
+            model: modelId,
             error: {
               message: `Invalid API key format for provider '${providerId}'. Please check your API key.`,
               code: "INVALID_API_KEY",
@@ -563,9 +773,9 @@ export class LLMService {
 
       return {
         prepared: {
-          providerId: providerId!,
-          modelId: modelId!,
-          modelInfo: modelInfo!,
+          providerId,
+          modelId,
+          modelInfo,
           resolvedRequest,
           internalRequest,
           clientAdapter,

--- a/src/llm/services/ModelResolver.ts
+++ b/src/llm/services/ModelResolver.ts
@@ -41,6 +41,18 @@ export interface ModelResolution {
 }
 
 /**
+ * Options controlling model resolution side effects.
+ */
+export interface ModelResolutionOptions {
+  /**
+   * Whether resolution may query local provider adapters for dynamic model
+   * capabilities. Defaults to true for sendMessage(), but public capability
+   * preflight uses false so it remains no-network/no-adapter.
+   */
+  detectLocalCapabilities?: boolean;
+}
+
+/**
  * Resolves model information from presets or direct provider/model IDs
  */
 export class ModelResolver {
@@ -60,7 +72,12 @@ export class ModelResolver {
    * @param options Options containing either presetId or providerId/modelId
    * @returns Resolved model info and settings or error response
    */
-  async resolve(options: ModelSelectionOptions): Promise<ModelResolution> {
+  async resolve(
+    options: ModelSelectionOptions,
+    resolutionOptions: ModelResolutionOptions = {}
+  ): Promise<ModelResolution> {
+    const detectLocalCapabilities = resolutionOptions.detectLocalCapabilities !== false;
+
     // If presetId is provided, use it
     if (options.presetId) {
       const preset = this.presetManager.resolvePreset(options.presetId);
@@ -97,7 +114,7 @@ export class ModelResolver {
 
       // Overlay detected GGUF capabilities for llama.cpp presets (the server decides
       // which model is actually loaded, regardless of the preset's modelId)
-      if (preset.providerId === 'llamacpp') {
+      if (preset.providerId === 'llamacpp' && detectLocalCapabilities) {
         const detected = await this.detectLlamaCppCapabilities();
         if (detected) {
           modelInfo = { ...modelInfo, ...detected };
@@ -158,7 +175,7 @@ export class ModelResolver {
     // decides which model is actually loaded, so detected capabilities and vendor
     // default settings must overlay whatever the registry says.
     let detectedCapabilities: Partial<ModelInfo> | undefined;
-    if (options.providerId === 'llamacpp') {
+    if (options.providerId === 'llamacpp' && detectLocalCapabilities) {
       detectedCapabilities = await this.detectLlamaCppCapabilities();
     }
 

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -136,6 +136,42 @@ export interface ModelStructuredOutputCapabilities {
 }
 
 /**
+ * Capability support status for provider/model features.
+ *
+ * `unknown` means genai-lite does not have explicit metadata for the feature.
+ * Callers should decide whether to allow, reject, or fall back for unknown
+ * capabilities.
+ */
+export type CapabilityStatus = "supported" | "unsupported" | "unknown";
+
+/**
+ * Source of a capability decision.
+ */
+export type CapabilitySource = "registry" | "detected" | "fallback";
+
+/**
+ * Structured-output support status for a provider/model pair.
+ */
+export interface StructuredOutputSupport {
+  /** Whether structured output is known supported, known unsupported, or unknown */
+  status: CapabilityStatus;
+  /** Whether strict provider-side schema enforcement is supported, when known */
+  strictMode?: boolean;
+  /** Additional notes from model metadata */
+  notes?: string;
+  /** Where the capability decision came from */
+  source: CapabilitySource;
+}
+
+/**
+ * Capability summary for a provider/model pair.
+ */
+export interface ModelCapabilities {
+  /** Structured-output support status */
+  structuredOutput: StructuredOutputSupport;
+}
+
+/**
  * Message roles supported by LLM APIs
  */
 export type LLMMessageRole = 'user' | 'assistant' | 'system';
@@ -477,6 +513,37 @@ export interface LLMChatRequestWithPreset extends Omit<LLMChatRequest, 'provider
 }
 
 /**
+ * Request used by LLMService.validateRequestCapabilities().
+ *
+ * This intentionally does not require messages: callers often need to validate
+ * provider/model/settings compatibility during configuration, before the final
+ * prompt messages exist.
+ */
+export interface LLMRequestCapabilityPreflight {
+  /** Provider ID (required if not using presetId) */
+  providerId?: ApiProviderId;
+  /** Model ID (required if not using presetId) */
+  modelId?: string;
+  /** Preset ID (alternative to providerId/modelId) */
+  presetId?: string;
+  /** Settings whose provider/model capability requirements should be checked */
+  settings?: LLMSettings;
+}
+
+/**
+ * Result of LLMService.getModelCapabilities().
+ */
+export interface ModelCapabilitiesResult {
+  object: "model.capabilities";
+  provider: ApiProviderId;
+  model: string;
+  /** Resolved model metadata used to derive the capability summary */
+  modelInfo: ModelInfo;
+  /** Structured-output support status for this provider/model pair */
+  structuredOutput: StructuredOutputSupport;
+}
+
+/**
  * Individual choice in an LLM response
  */
 export interface LLMChoice {
@@ -549,6 +616,35 @@ export interface LLMFailureResponse {
   /** The partial response that was generated before the error occurred (if available) */
   partialResponse?: Omit<LLMResponse, 'object'>;
 }
+
+/**
+ * Successful result of LLMService.validateRequestCapabilities().
+ */
+export interface LLMRequestCapabilityValidationSuccess {
+  object: "capability.validation";
+  valid: true;
+  provider: ApiProviderId;
+  model: string;
+  capabilities: ModelCapabilities;
+}
+
+/**
+ * Failure result of LLMService.validateRequestCapabilities().
+ *
+ * The base error envelope intentionally matches LLMFailureResponse so callers
+ * can use the same diagnostic handling as sendMessage().
+ */
+export type LLMRequestCapabilityValidationFailure = LLMFailureResponse & {
+  valid: false;
+  capabilities?: ModelCapabilities;
+};
+
+/**
+ * Result of LLMService.validateRequestCapabilities().
+ */
+export type LLMRequestCapabilityValidationResult =
+  | LLMRequestCapabilityValidationSuccess
+  | LLMRequestCapabilityValidationFailure;
 
 /**
  * Streaming event emitted by LLMService.streamMessage().


### PR DESCRIPTION
Summary: Adds public no-network capability lookup and request preflight APIs for structured output support; keeps unknown capabilities as unknown for caller policy decisions; documents capability semantics and bumps version to 0.13.0. Verification: npm.cmd test; npm.cmd run build.