### PR TITLE
fix: real e2e skips, shared strict-schema walker, dead Anthropic reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ genai-lite is a lightweight, standalone Node.js/TypeScript library providing a u
 - **PresetManager<TPreset>** - Generic preset management (extend/replace modes) used by both LLM and Image services
 - **AdapterRegistry<TAdapter, TProviderId>** - Generic adapter registration and management
 - **errorUtils** - Shared error mapping and normalization for all adapters
+- **schemaUtils** - `applyStrictSchemaConstraints()`: injects `additionalProperties: false` into every object schema for providers whose strict structured-output mode requires it (Anthropic and OpenAI). Traverses `properties`, `items` (single and tuple form), `prefixItems`, `$defs`, `definitions`, `anyOf`/`oneOf`/`allOf`, and `not`; never mutates its input; safe against cyclic JS object graphs. `$ref` pointers are deliberately **not** resolved — targets are constrained where defined. OpenAI's extra requirement that `required` list every property is behind the `requireAllProperties` option, which Anthropic must not pass
 - Located in `src/shared/services/` and `src/shared/adapters/`
 - Eliminates ~390 lines of duplicate code between LLM and Image implementations
 
@@ -233,7 +234,8 @@ src/
 │   │   ├── PresetManager.ts      # Generic preset management
 │   │   └── AdapterRegistry.ts    # Generic adapter registration
 │   └── adapters/                 # Shared adapter utilities
-│       └── errorUtils.ts         # Error mapping/normalization
+│       ├── errorUtils.ts         # Error mapping/normalization
+│       └── schemaUtils.ts        # Strict JSON Schema preparation (Anthropic, OpenAI)
 ├── logging/                      # Logging system
 │   ├── types.ts                  # Logger, LogLevel, LoggingConfig interfaces
 │   ├── defaultLogger.ts          # Console logger with level filtering
@@ -265,6 +267,7 @@ src/
   - **Use sparingly** - only when modifying provider adapters or LLMService
   - Costs real money - uses cheapest models but still incurs API charges
   - Not run in CI by default to avoid costs
+  - **Gate unavailable providers with `describe.skip`, never with an early `return`.** A test body that returns without asserting is scored by Jest as **passed**, so `if (!available) return;` reports green tests that verified nothing — this is how an Anthropic request-shape drift stayed hidden. API keys gate at module scope (`(KEY ? describe : describe.skip)`). llama-server needs an async probe, which cannot run at registration time, so `e2e-tests/globalSetup.js` probes it once and publishes `E2E_LLAMACPP_AVAILABLE` for suites to gate on the same way. Set that variable explicitly to force a suite on or off without a live server. Note `describe.skip` still *executes* its callback to register test names, so resolve provider details inside the test bodies, not at describe scope
 
 **Quick Testing with chat-demo:**
 The `examples/chat-demo` application provides a quick way to test library changes interactively. Run `cd examples/chat-demo && npm install && npm run dev` to start the demo server and test features across all providers.

--- a/ISSUE-next-steps.md
+++ b/ISSUE-next-steps.md
@@ -1,7 +1,7 @@
 # ISSUE: Post-v0.9.2 TODO — deferred follow-ups
 
 Created: 2026-07-03
-Updated: 2026-07-26 (v0.13.1 shipped: item 13 resolved; items 16, 17 filed)
+Updated: 2026-07-26 (v0.13.1 shipped; items 13, 14, 17 resolved; item 16 open)
 Status: OPEN
 Package: genai-lite
 
@@ -158,21 +158,41 @@ Note: all "latest" package versions below were checked via `npm view` on
     fail if it regresses; the E2E test no longer converts an incompatibility
     into a pass. See `docs/archive/ISSUE-anthropic-structured-output-compatibility.md`.
     The schema walker's `$defs`/`anyOf` gap was split out to
-    `ISSUE-structured-output-schema-traversal.md`. **Shipped**: merged as
+    `docs/archive/ISSUE-structured-output-schema-traversal.md`. **Shipped**: merged as
     PR #103 (`438db55`), tagged `v0.13.1`, published to npm on 2026-07-26
     (`npm view genai-lite version` → 0.13.1; the published `dist/` was verified
     to contain `output_config` and zero occurrences of `output_format` /
     `anthropic-beta`). The live-API confirmation is **still open** — see item 16.
 
-14. **Anthropic reasoning-path response parsing** (pre-existing, found in the
-    item 4 review). `createSuccessResponse` reads `completion.thinking_content`
-    / `completion.reasoning_details`, which are not Anthropic response fields —
-    thinking arrives as `content` blocks of `type: "thinking"` — and it assumes
-    `content[0].type === 'text'` (throws "Invalid completion structure"
-    otherwise). With `reasoning.enabled` the first block is a thinking block,
-    so the extended-thinking path likely misbehaves. Verify with a paid e2e
-    reasoning run (`npm run test:e2e:reasoning`) and fix the parsing to walk
-    content blocks.
+14. ~~**Anthropic reasoning-path response parsing**~~ **RESOLVED (2026-07-26).**
+    This item was half stale when re-examined: the `content[0].type === 'text'`
+    assumption had already been fixed by the streaming work —
+    `createSuccessResponse` filters *all* text blocks and joins them, throwing
+    only when there are zero, so a thinking-first response was already handled.
+
+    What was still real: `completion.thinking_content` and
+    `completion.reasoning_details` were being read, and neither is an Anthropic
+    response field. Verified against the SDK — `Message` is exactly
+    `id | container | content | model | role | stop_details | stop_reason |
+    stop_sequence | type | usage`, and neither string appears anywhere in the
+    SDK types. `reasoning_details` is an **OpenRouter** concept that was
+    copy-pasted here, where it could never fire. Both dead branches removed;
+    reasoning now comes solely from `thinking` content blocks, covered by mock
+    tests including one asserting those two bogus fields are ignored.
+
+    Adjacent bug fixed in the same function: `mapAnthropicStopReason` had a
+    `content_filter` key that Anthropic never emits (that is OpenAI's
+    vocabulary) and was **missing** two real members of Anthropic's
+    `StopReason` union, so both silently became `"other"`. Now `refusal` maps to
+    `content_filter` (so callers detect a policy-blocked completion with the
+    same check they use for OpenAI and Gemini) and `pause_turn` maps to
+    `"other"` explicitly rather than by fallthrough. ⚠️ **Review the `refusal`
+    mapping** — it changes observable `finish_reason` output for consumers who
+    switch on it. The full union is now covered by tests.
+
+    Still outstanding: the paid reasoning e2e run
+    (`npm run test:e2e:reasoning`) has not been done; the fix above rests on SDK
+    types and mocks.
 
 15. **Dev-only `brace-expansion` advisory, blocked on jest** (2026-07-26,
     v0.13.1). GHSA-mh99-v99m-4gvg (`brace-expansion` OOM DoS) is fixed only in
@@ -236,34 +256,57 @@ Note: all "latest" package versions below were checked via `npm view` on
 
     This is the same silent-skip anti-pattern that v0.13.1 removed from the
     Anthropic block, and it is what let the `output_format` drift hide. It
-    inflates the green count and would mask a real regression. Fix by gating on
-    availability with a real skip (`it.skip` / `describe.skip`, or an
-    `describe.each`-style guard resolved in `beforeAll`) so the pass count only
-    ever reflects assertions that actually ran. Audit the other `e2e-tests/`
-    files for the same helper shape while in there.
+    inflates the green count and would mask a real regression.
+
+    **RESOLVED (2026-07-26).** A `beforeAll` gate is not enough — Jest needs the
+    availability decision *before* it registers tests. New
+    `e2e-tests/globalSetup.js` (wired via `jest.e2e.config.js`) probes
+    llama-server once and publishes `E2E_LLAMACPP_AVAILABLE`, so suites gate with
+    `(AVAILABLE ? describe : describe.skip)` — the same idiom the key-gated blocks
+    already use. `providers.e2e.test.ts` had the identical defect and got the same
+    treatment; `reasoning.e2e.test.ts` had a dead unused copy of the probe helper,
+    now deleted. The auto-parse block resolves its provider inside the test bodies,
+    because `describe.skip` still executes its callback to register test names.
+
+    Verified both directions: with no keys and no server the whole e2e suite now
+    reports **19 skipped, 0 passed** (was 4 vacuous passes), and with
+    `E2E_LLAMACPP_AVAILABLE=true` forced against no server those same 4 tests
+    **fail** instead of passing — proving they actually execute. `globalSetup`
+    honors a pre-set value as an override, which is what makes that check
+    possible. Probe default also moved `localhost` → `127.0.0.1` to match the
+    adapter and avoid the Windows IPv6-fallback stall.
 
 ## Pickup point
 
-Open items: 12 (dual packaging — unblocks Mistral 2.x), 14 (Anthropic
-pre-existing reasoning-path parsing; needs paid e2e verification), 15
-(dev-only audit advisory, blocked on jest upstream), 16 (confirm Anthropic GA
-structured output against the live API), 17 (e2e vacuous passes).
+Open items: 12 (dual packaging — unblocks Mistral 2.x), 15 (dev-only audit
+advisory, blocked on jest upstream), 16 (confirm Anthropic GA structured output
+against the live API). Items 13, 14, and 17 are resolved.
 
-**Resume here (2026-07-26, after v0.13.1 was published):** the next decision is
-item 16 — add credits to the Anthropic account and run
+**Resume here (2026-07-26, post-v0.13.1 cleanup):** everything actionable
+without credits is done. The next decision is **item 16** — add credits to the
+Anthropic account and run
 `npm run test:e2e -- structured-output.e2e.test.ts` to confirm the shipped
-`output_config.format` request shape against the real API. That is the only
-thing gating a clean close of item 13; everything else in 0.13.1 is merged,
-tagged, published, and verified in the published tarball. Item 17 is a small
-independent test-hygiene fix that needs no credits and can be done first.
+`output_config.format` request shape against the real API. Two paid runs are now
+pending and can share one top-up: item 16 (structured output) and the item 14
+reasoning run (`npm run test:e2e:reasoning`).
 
-Also open, unrelated to this work: 6 Dependabot PRs (#93, #95, #98, #100, #101,
-#102). Two are worth a look before the next release — **#101** bumps
-`@anthropic-ai/sdk` 0.110.0 → 0.115.0, and the GA structured-output types were
-verified against 0.110.0, so re-check `MessageCreateParams.output_config` and
-`JSONOutputFormat` survive that jump; **#95** is the Mistral 2.x ESM-only bump
-that item 12 blocks. The stale `dependabot/.../google/genai-2.11.0` branch is
-superseded — v0.13.1 already took `@google/genai` to 2.13.0.
+Unreleased on main since v0.13.1: the item 14 / 17 fixes plus the shared schema
+walker (`src/shared/adapters/schemaUtils.ts`). Two of these change observable
+behavior and want a version bump when next released — the `refusal` →
+`content_filter` finish-reason mapping, and `$defs`/`anyOf` branches now
+receiving `additionalProperties: false` on **both** the Anthropic and OpenAI
+paths.
+
+Dependabot: 6 open PRs (#93, #95, #98, #100, #101, #102). **#101**
+(`@anthropic-ai/sdk` 0.110.0 → 0.115.0) was **verified safe on 2026-07-26** —
+`JSONOutputFormat` and `OutputConfig` are byte-identical to 0.110.0,
+`output_config` is still on `MessageCreateParams`, the error classes
+`errorUtils` matches by constructor name all survive, and the full suite passes
+against it; it is 2 commits behind main so it needs a rebase before merge.
+**#95** is the Mistral 2.x ESM-only bump that item 12 blocks. **#100** is a
+TypeScript 5.9 → 7.0 major and deserves its own verification pass. The stale
+`dependabot/.../google/genai-2.11.0` branch is superseded — v0.13.1 already took
+`@google/genai` to 2.13.0.
 
 **v0.11.0 release state**: items 2, 3 (as deferred+fixes), 4, 5, 8, 9, 10, 11
 shipped via PR #92, merged to main (`800a9c8`), CI green, tagged `v0.11.0`,

--- a/docs/archive/ISSUE-anthropic-structured-output-compatibility.md
+++ b/docs/archive/ISSUE-anthropic-structured-output-compatibility.md
@@ -30,7 +30,7 @@ matching was added.
 Schema preparation is unchanged in behaviour and now pinned by tests: nested
 object properties and array items are traversed, and `$defs` / `anyOf` are
 explicitly documented as *not* traversed. That hardening was split out to
-`ISSUE-structured-output-schema-traversal.md` rather than claimed here.
+`docs/archive/ISSUE-structured-output-schema-traversal.md` rather than claimed here.
 
 Test additions: adapter tests asserting `output_config.format` exactly plus the
 absence of `output_format` and any beta header (non-streaming and streaming),

--- a/docs/archive/ISSUE-structured-output-schema-traversal.md
+++ b/docs/archive/ISSUE-structured-output-schema-traversal.md
@@ -1,9 +1,42 @@
 # ISSUE: Structured-output schema preparation does not traverse `$defs` or `anyOf`/`oneOf`/`allOf`
 
 Created: 2026-07-26
-Status: OPEN
+Status: RESOLVED (2026-07-26)
 Package: genai-lite
 Split out of: `docs/archive/ISSUE-anthropic-structured-output-compatibility.md` (item 3)
+
+## Resolution
+
+Extracted to a shared utility and hardened. `applyStrictSchemaConstraints` in
+`src/shared/adapters/schemaUtils.ts` now traverses `properties`, `items` (single
+and tuple form), `prefixItems`, `$defs`, `definitions`, `anyOf`, `oneOf`,
+`allOf`, and `not`, setting `additionalProperties: false` on every object schema
+it reaches. It never mutates its input.
+
+Answering the scope note: the walker **is** now shared. The near-duplicate
+private `addAdditionalPropertiesFalse` methods in `AnthropicClientAdapter` and
+`OpenAIClientAdapter` were both deleted and both adapters call the shared
+function. OpenAI's extra strictness — `required` must list every property of an
+object — is preserved behind the `requireAllProperties` option, which Anthropic
+does not pass (a regression test asserts Anthropic leaves a partial `required`
+alone). Gemini is unaffected because it converts schemas separately via
+`convertToGeminiSchema`; OpenRouter and llama.cpp forward the raw schema.
+
+Note this also fixes the same untraversed-branch bug on the **OpenAI** path,
+which had the identical limitation.
+
+On `$ref` cycles: the walker deliberately does not resolve `$ref` pointers, so
+a JSON-level `$ref` cycle cannot cause infinite recursion — referenced schemas
+are constrained where they are *defined* (typically under `$defs`), which is
+what the providers validate. The real hazard is a cyclic *JavaScript* object
+graph, which is handled by a `Map` of input node to output copy: each node is
+copied once, revisits reuse that copy, and shared subschemas stay shared.
+Covered by tests for both a self-referencing schema and a subschema referenced
+from two places.
+
+`schemaUtils.test.ts` covers every keyword above plus non-object input and both
+`requireAllProperties` modes; the Anthropic adapter test that used to pin the
+*absence* of traversal now asserts it happens.
 
 ## Summary
 
@@ -60,9 +93,12 @@ they do, the walker belongs in a shared utility rather than in
 
 ## Acceptance criteria
 
-- [ ] Object schemas nested under `$defs` and composition keywords receive
+- [x] Object schemas nested under `$defs` and composition keywords receive
       `additionalProperties: false` in strict mode.
-- [ ] A self-referencing `$ref` does not cause unbounded recursion.
-- [ ] The pinning test in `AnthropicClientAdapter.test.ts` is replaced with a
+- [x] A self-referencing `$ref` does not cause unbounded recursion (refs are
+      never resolved; cyclic JS object graphs are guarded by a copy map).
+- [x] The pinning test in `AnthropicClientAdapter.test.ts` is replaced with a
       positive traversal assertion.
-- [ ] A decision is recorded on whether the walker becomes shared across adapters.
+- [x] A decision is recorded on whether the walker becomes shared across
+      adapters: yes, it is now `src/shared/adapters/schemaUtils.ts`, used by both
+      the Anthropic and OpenAI adapters.

--- a/e2e-tests/globalSetup.js
+++ b/e2e-tests/globalSetup.js
@@ -1,0 +1,56 @@
+/**
+ * Jest globalSetup for the E2E suites.
+ *
+ * Probes optional local services once, before Jest registers any tests, and
+ * publishes the result on `process.env` so suites can gate with
+ * `describe.skip` at *registration* time.
+ *
+ * Why not just check inside the test body? Because a runtime
+ * `if (!available) return;` cannot skip a Jest test — an assertion-free
+ * function is scored as **passed**. That produced green-but-empty results that
+ * inflated the pass count and would mask a real regression (the same
+ * silent-skip failure mode that let an Anthropic request-shape drift go
+ * unnoticed). The availability decision therefore has to happen before the
+ * tests exist.
+ *
+ * Uses 127.0.0.1 rather than localhost to avoid the ~2s per-request
+ * IPv6-fallback stall on Windows, matching the llama.cpp adapter's own default.
+ */
+
+const LLAMACPP_BASE_URL = process.env.LLAMACPP_API_BASE_URL || 'http://127.0.0.1:8080';
+const PROBE_TIMEOUT_MS = 2000;
+
+module.exports = async function globalSetup() {
+  // Honor an explicit override so the gated suites can be forced on or off
+  // without a live server (useful for checking that they really do run, and for
+  // CI environments that provision llama-server out of band).
+  if (process.env.E2E_LLAMACPP_AVAILABLE === 'true' || process.env.E2E_LLAMACPP_AVAILABLE === 'false') {
+    console.log(
+      `[e2e] llama-server availability overridden via E2E_LLAMACPP_AVAILABLE=${process.env.E2E_LLAMACPP_AVAILABLE} (health probe skipped)`
+    );
+    return;
+  }
+
+  let available = false;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    const response = await fetch(`${LLAMACPP_BASE_URL}/health`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    available = response.ok;
+  } catch {
+    available = false;
+  }
+
+  process.env.E2E_LLAMACPP_AVAILABLE = available ? 'true' : 'false';
+
+  console.log(
+    `[e2e] llama-server at ${LLAMACPP_BASE_URL}: ` +
+      (available
+        ? 'AVAILABLE (local suites will run)'
+        : 'NOT AVAILABLE (local suites will be reported as skipped, not passed)')
+  );
+};

--- a/e2e-tests/providers.e2e.test.ts
+++ b/e2e-tests/providers.e2e.test.ts
@@ -2,35 +2,16 @@ import { LLMService, fromEnvironment } from '../src/index';
 import type { ApiKeyProvider } from '../src/types';
 import type { LLMResponse } from '../src/llm/types';
 
-const LLAMACPP_BASE_URL = process.env.LLAMACPP_API_BASE_URL || 'http://localhost:8080';
-
-// Track llama-server availability
-let llamaServerAvailable: boolean | null = null;
-
 /**
- * Check if llama-server is running locally
+ * Whether llama-server answered its health check, probed once in globalSetup
+ * (see e2e-tests/globalSetup.js).
+ *
+ * Read at module scope so the suite can gate with `describe.skip`. Do NOT
+ * reintroduce a runtime `if (!available) return;` inside a test body: Jest
+ * scores an assertion-free function as **passed**, which reports green tests
+ * that verified nothing.
  */
-async function isLlamaServerRunning(): Promise<boolean> {
-  if (llamaServerAvailable !== null) {
-    return llamaServerAvailable;
-  }
-
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 2000);
-
-    const response = await fetch(`${LLAMACPP_BASE_URL}/health`, {
-      signal: controller.signal
-    });
-
-    clearTimeout(timeout);
-    llamaServerAvailable = response.ok;
-    return llamaServerAvailable;
-  } catch {
-    llamaServerAvailable = false;
-    return false;
-  }
-}
+const LLAMACPP_AVAILABLE = process.env.E2E_LLAMACPP_AVAILABLE === 'true';
 
 // Test-specific API key provider that looks for E2E-prefixed env vars
 const e2eKeyProvider: ApiKeyProvider = async (providerId: string) => {
@@ -118,21 +99,8 @@ const geminiApiKey = process.env.E2E_GEMINI_API_KEY;
 });
 
 // --- llama.cpp Tests (FREE - Local Server) ---
-describe('llama.cpp E2E (local, free)', () => {
-  beforeAll(async () => {
-    const available = await isLlamaServerRunning();
-    console.log(`llama-server available: ${available ? 'YES (tests will run)' : 'NO (tests will skip)'}`);
-  });
-
-  const runIfAvailable = (testFn: () => Promise<void>) => async () => {
-    if (!(await isLlamaServerRunning())) {
-      console.log('Skipping - llama-server not running');
-      return;
-    }
-    await testFn();
-  };
-
-  it('should receive a valid response from local llama-server', runIfAvailable(async () => {
+(LLAMACPP_AVAILABLE ? describe : describe.skip)('llama.cpp E2E (local, free)', () => {
+  it('should receive a valid response from local llama-server', async () => {
     const response = await llmService.sendMessage({
       providerId: 'llamacpp',
       modelId: 'local-model',
@@ -146,9 +114,9 @@ describe('llama.cpp E2E (local, free)', () => {
       expect(content).toBeDefined();
       expect(content).toContain('10');
     }
-  }), 60000);
+  }, 60000);
 
-  it('should handle system messages correctly', runIfAvailable(async () => {
+  it('should handle system messages correctly', async () => {
     const response = await llmService.sendMessage({
       providerId: 'llamacpp',
       modelId: 'local-model',
@@ -165,5 +133,5 @@ describe('llama.cpp E2E (local, free)', () => {
       expect(content).toBeDefined();
       expect(content).toContain('56');
     }
-  }), 60000);
+  }, 60000);
 });

--- a/e2e-tests/reasoning.e2e.test.ts
+++ b/e2e-tests/reasoning.e2e.test.ts
@@ -2,35 +2,9 @@ import { LLMService } from '../src/index';
 import type { ApiKeyProvider } from '../src/types';
 import type { LLMResponse } from '../src/llm/types';
 
-const LLAMACPP_BASE_URL = process.env.LLAMACPP_API_BASE_URL || 'http://localhost:8080';
-
-// Track llama-server availability
-let llamaServerAvailable: boolean | null = null;
-
-/**
- * Check if llama-server is running locally
- */
-async function isLlamaServerRunning(): Promise<boolean> {
-  if (llamaServerAvailable !== null) {
-    return llamaServerAvailable;
-  }
-
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 2000);
-
-    const response = await fetch(`${LLAMACPP_BASE_URL}/health`, {
-      signal: controller.signal
-    });
-
-    clearTimeout(timeout);
-    llamaServerAvailable = response.ok;
-    return llamaServerAvailable;
-  } catch {
-    llamaServerAvailable = false;
-    return false;
-  }
-}
+// This suite has no llama.cpp block; llama-server availability is probed once in
+// e2e-tests/globalSetup.js and exposed as E2E_LLAMACPP_AVAILABLE for the suites
+// that need it.
 
 // Test-specific API key provider that looks for E2E-prefixed env vars
 const e2eKeyProvider: ApiKeyProvider = async (providerId: string) => {

--- a/e2e-tests/structured-output.e2e.test.ts
+++ b/e2e-tests/structured-output.e2e.test.ts
@@ -26,35 +26,31 @@ const GEMINI_API_KEY = process.env.E2E_GEMINI_API_KEY;
 const ANTHROPIC_API_KEY = process.env.E2E_ANTHROPIC_API_KEY;
 const MISTRAL_API_KEY = process.env.E2E_MISTRAL_API_KEY;
 const OPENROUTER_API_KEY = process.env.E2E_OPENROUTER_API_KEY;
-const LLAMACPP_BASE_URL = process.env.LLAMACPP_API_BASE_URL || 'http://localhost:8080';
-
-// Track llama-server availability
-let llamaServerAvailable: boolean | null = null;
+const LLAMACPP_BASE_URL = process.env.LLAMACPP_API_BASE_URL || 'http://127.0.0.1:8080';
 
 /**
- * Check if llama-server is running locally
+ * Whether llama-server answered its health check, probed once in globalSetup
+ * (see e2e-tests/globalSetup.js).
+ *
+ * This is read at module scope so suites can gate with `describe.skip`. Do NOT
+ * reintroduce a runtime `if (!available) return;` inside a test body: Jest scores
+ * an assertion-free function as **passed**, so that pattern reports green tests
+ * that verified nothing.
  */
-async function isLlamaServerRunning(): Promise<boolean> {
-  if (llamaServerAvailable !== null) {
-    return llamaServerAvailable;
-  }
+const LLAMACPP_AVAILABLE = process.env.E2E_LLAMACPP_AVAILABLE === 'true';
 
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 2000);
+/** The cheapest cloud provider available, or null if none is configured. */
+const FALLBACK_CLOUD_PROVIDER: { providerId: string; modelId: string } | null =
+  OPENAI_API_KEY ? { providerId: 'openai', modelId: 'gpt-4.1-mini' }
+  : GEMINI_API_KEY ? { providerId: 'gemini', modelId: 'gemini-2.0-flash' }
+  : MISTRAL_API_KEY ? { providerId: 'mistral', modelId: 'mistral-small-latest' }
+  : null;
 
-    const response = await fetch(`${LLAMACPP_BASE_URL}/health`, {
-      signal: controller.signal
-    });
-
-    clearTimeout(timeout);
-    llamaServerAvailable = response.ok;
-    return llamaServerAvailable;
-  } catch {
-    llamaServerAvailable = false;
-    return false;
-  }
-}
+/** Any provider at all that can serve the provider-agnostic behaviour tests. */
+const ANY_PROVIDER: { providerId: string; modelId: string } | null =
+  LLAMACPP_AVAILABLE
+    ? { providerId: 'llamacpp', modelId: 'local-model' }
+    : FALLBACK_CLOUD_PROVIDER;
 
 // Common test schema for extracting person info
 const personSchema: StructuredOutputSettings = {
@@ -87,9 +83,7 @@ describe('Structured Output E2E Tests', () => {
   let llmService: LLMService;
 
   beforeAll(async () => {
-    // Check llama-server availability upfront
-    const llamaAvailable = await isLlamaServerRunning();
-    console.log(`llama-server available: ${llamaAvailable ? 'YES (free tests will run)' : 'NO'}`);
+    console.log(`llama-server available: ${LLAMACPP_AVAILABLE ? 'YES (free tests will run)' : 'NO (llama.cpp suites skipped)'}`);
     console.log(`OpenAI API key: ${OPENAI_API_KEY ? 'YES' : 'NO'}`);
     console.log(`Gemini API key: ${GEMINI_API_KEY ? 'YES' : 'NO'}`);
     console.log(`Anthropic API key: ${ANTHROPIC_API_KEY ? 'YES' : 'NO'}`);
@@ -116,22 +110,8 @@ describe('Structured Output E2E Tests', () => {
   // ============================================
   // llama.cpp (FREE - Local Server)
   // ============================================
-  describe('llama.cpp (local, free)', () => {
-    beforeEach(async () => {
-      const available = await isLlamaServerRunning();
-      if (!available) {
-        console.log('Skipping llama.cpp tests - server not running');
-      }
-    });
-
-    const runIfAvailable = (testFn: () => Promise<void>) => async () => {
-      if (!(await isLlamaServerRunning())) {
-        return; // Skip silently
-      }
-      await testFn();
-    };
-
-    it('should return structured JSON with person schema', runIfAvailable(async () => {
+  (LLAMACPP_AVAILABLE ? describe : describe.skip)('llama.cpp (local, free)', () => {
+    it('should return structured JSON with person schema', async () => {
       const response = await llmService.sendMessage({
         providerId: 'llamacpp',
         modelId: 'local-model',
@@ -153,9 +133,9 @@ describe('Structured Output E2E Tests', () => {
       const parsed = result.choices[0].parsedContent as { name: string; age: number };
       expect(parsed.name).toContain('John');
       expect(typeof parsed.age).toBe('number');
-    }), API_TIMEOUT);
+    }, API_TIMEOUT);
 
-    it('should handle color extraction schema', runIfAvailable(async () => {
+    it('should handle color extraction schema', async () => {
       const response = await llmService.sendMessage({
         providerId: 'llamacpp',
         modelId: 'local-model',
@@ -175,7 +155,7 @@ describe('Structured Output E2E Tests', () => {
 
       const parsed = result.choices[0].parsedContent as { color: string };
       expect(typeof parsed.color).toBe('string');
-    }), API_TIMEOUT);
+    }, API_TIMEOUT);
   });
 
   // ============================================
@@ -399,71 +379,53 @@ describe('Structured Output E2E Tests', () => {
   // ============================================
   // Auto-parse behavior tests
   // ============================================
-  describe('Auto-parse behavior', () => {
-    const runWithAnyProvider = async (testFn: (providerId: string, modelId: string) => Promise<void>) => {
-      // Try llama-server first (free)
-      if (await isLlamaServerRunning()) {
-        await testFn('llamacpp', 'local-model');
-        return;
-      }
-      // Fall back to cheapest available provider
-      if (OPENAI_API_KEY) {
-        await testFn('openai', 'gpt-4.1-mini');
-        return;
-      }
-      if (GEMINI_API_KEY) {
-        await testFn('gemini', 'gemini-2.0-flash');
-        return;
-      }
-      if (MISTRAL_API_KEY) {
-        await testFn('mistral', 'mistral-small-latest');
-        return;
-      }
-      console.log('Skipping test - no provider available');
-    };
-
+  // Provider-agnostic behaviour: runs against llama-server when available,
+  // otherwise the cheapest configured cloud provider. Skipped outright when
+  // neither exists, so these never report as passing without asserting.
+  (ANY_PROVIDER ? describe : describe.skip)('Auto-parse behavior', () => {
+    // Resolved inside the test bodies, not here: `describe.skip` still runs its
+    // callback to register test names, so a non-null assertion at this scope
+    // would throw even when the whole block is skipped.
     it('should auto-parse JSON by default', async () => {
-      await runWithAnyProvider(async (providerId, modelId) => {
-        const response = await llmService.sendMessage({
-          providerId,
-          modelId,
-          messages: [{ role: 'user', content: 'Return {"test": true}' }],
-          settings: {
-            structuredOutput: {
-              name: 'test',
-              schema: { type: 'object', properties: { test: { type: 'boolean' } } }
-            },
-            maxTokens: 50
-          }
-        });
-
-        expect(response.object).toBe('chat.completion');
-        const result = response as LLMResponse;
-        expect(result.choices[0].parsedContent).toBeDefined();
+      const { providerId, modelId } = ANY_PROVIDER!;
+      const response = await llmService.sendMessage({
+        providerId,
+        modelId,
+        messages: [{ role: 'user', content: 'Return {"test": true}' }],
+        settings: {
+          structuredOutput: {
+            name: 'test',
+            schema: { type: 'object', properties: { test: { type: 'boolean' } } }
+          },
+          maxTokens: 50
+        }
       });
+
+      expect(response.object).toBe('chat.completion');
+      const result = response as LLMResponse;
+      expect(result.choices[0].parsedContent).toBeDefined();
     }, API_TIMEOUT);
 
     it('should skip auto-parse when autoParse=false', async () => {
-      await runWithAnyProvider(async (providerId, modelId) => {
-        const response = await llmService.sendMessage({
-          providerId,
-          modelId,
-          messages: [{ role: 'user', content: 'Return {"test": true}' }],
-          settings: {
-            structuredOutput: {
-              name: 'test',
-              schema: { type: 'object', properties: { test: { type: 'boolean' } } },
-              autoParse: false
-            },
-            maxTokens: 50
-          }
-        });
-
-        expect(response.object).toBe('chat.completion');
-        const result = response as LLMResponse;
-        // parsedContent should not be set when autoParse is false
-        expect(result.choices[0].parsedContent).toBeUndefined();
+      const { providerId, modelId } = ANY_PROVIDER!;
+      const response = await llmService.sendMessage({
+        providerId,
+        modelId,
+        messages: [{ role: 'user', content: 'Return {"test": true}' }],
+        settings: {
+          structuredOutput: {
+            name: 'test',
+            schema: { type: 'object', properties: { test: { type: 'boolean' } } },
+            autoParse: false
+          },
+          maxTokens: 50
+        }
       });
+
+      expect(response.object).toBe('chat.completion');
+      const result = response as LLMResponse;
+      // parsedContent should not be set when autoParse is false
+      expect(result.choices[0].parsedContent).toBeUndefined();
     }, API_TIMEOUT);
   });
 });

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -5,4 +5,8 @@ module.exports = {
   testMatch: ['<rootDir>/e2e-tests/**/*.e2e.test.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'], // Reset to not ignore itself
   testTimeout: 30000, // 30 seconds
+  // Probes llama-server once and publishes E2E_LLAMACPP_AVAILABLE so suites can
+  // gate with describe.skip at registration time. See e2e-tests/globalSetup.js
+  // for why a runtime check inside the test body is not good enough.
+  globalSetup: '<rootDir>/e2e-tests/globalSetup.js',
 };

--- a/src/llm/clients/AnthropicClientAdapter.test.ts
+++ b/src/llm/clients/AnthropicClientAdapter.test.ts
@@ -233,10 +233,15 @@ describe('AnthropicClientAdapter', () => {
     });
 
     it('should map stop_reason correctly', async () => {
+      // Covers Anthropic's full StopReason union - end_turn | max_tokens |
+      // stop_sequence | tool_use | pause_turn | refusal - plus an unknown value.
       const stopReasons = [
         { anthropic: 'end_turn', expected: 'stop' },
         { anthropic: 'max_tokens', expected: 'length' },
         { anthropic: 'stop_sequence', expected: 'stop' },
+        { anthropic: 'tool_use', expected: 'tool_calls' },
+        { anthropic: 'refusal', expected: 'content_filter' },
+        { anthropic: 'pause_turn', expected: 'other' },
         { anthropic: 'unknown_reason', expected: 'other' }
       ];
 
@@ -532,6 +537,106 @@ describe('AnthropicClientAdapter', () => {
     });
   });
 
+  describe('reasoning extraction from thinking blocks', () => {
+    // Anthropic exposes reasoning only as content blocks of type "thinking".
+    // `Message` has no `thinking_content` or `reasoning_details` field, so the
+    // adapter must not depend on either.
+    const withReasoning = (): InternalLLMChatRequest => ({
+      ...basicRequest,
+      settings: {
+        ...basicRequest.settings,
+        reasoning: { enabled: true, effort: undefined as any, maxTokens: undefined as any, exclude: false }
+      }
+    });
+
+    it('should extract reasoning from thinking content blocks', async () => {
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_think',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-3-5-sonnet-20241022',
+        content: [
+          { type: 'thinking', thinking: 'step one ', signature: 'sig' },
+          { type: 'thinking', thinking: 'step two', signature: 'sig' },
+          { type: 'text', text: 'the answer' }
+        ],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 20 }
+      });
+
+      const response = await adapter.sendMessage(withReasoning(), 'test-api-key');
+
+      const success = response as LLMResponse;
+      expect(success.choices[0].reasoning).toBe('step one step two');
+      expect(success.choices[0].message.content).toBe('the answer');
+    });
+
+    it('should not treat a thinking-first response as an invalid structure', async () => {
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_think_first',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-3-5-sonnet-20241022',
+        content: [
+          { type: 'thinking', thinking: 'reasoning', signature: 'sig' },
+          { type: 'text', text: 'answer' }
+        ],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 20 }
+      });
+
+      const response = await adapter.sendMessage(withReasoning(), 'test-api-key');
+
+      expect(response.object).toBe('chat.completion');
+      expect((response as LLMResponse).choices[0].message.content).toBe('answer');
+    });
+
+    it('should ignore non-Anthropic thinking_content and reasoning_details fields', async () => {
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_bogus_fields',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-3-5-sonnet-20241022',
+        content: [{ type: 'text', text: 'answer' }],
+        // Neither of these is an Anthropic response field. thinking_content is
+        // invented; reasoning_details is OpenRouter's. Both must be ignored.
+        thinking_content: 'should not surface',
+        reasoning_details: [{ type: 'reasoning.text', text: 'should not surface' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 20 }
+      });
+
+      const response = await adapter.sendMessage(withReasoning(), 'test-api-key');
+
+      const choice = (response as LLMResponse).choices[0] as any;
+      expect(choice.reasoning).toBeUndefined();
+      expect(choice.reasoning_details).toBeUndefined();
+    });
+
+    it('should omit reasoning when reasoning.exclude is true', async () => {
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_excluded',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-3-5-sonnet-20241022',
+        content: [
+          { type: 'thinking', thinking: 'hidden', signature: 'sig' },
+          { type: 'text', text: 'answer' }
+        ],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 20 }
+      });
+
+      const request = withReasoning();
+      request.settings.reasoning!.exclude = true;
+
+      const response = await adapter.sendMessage(request, 'test-api-key');
+
+      expect((response as LLMResponse).choices[0].reasoning).toBeUndefined();
+      expect((response as LLMResponse).choices[0].message.content).toBe('answer');
+    });
+  });
+
   describe('structured output', () => {
     // Anthropic's structured outputs are GA: the request carries
     // output_config.format, with no `anthropic-beta` header, no schema `name`,
@@ -737,10 +842,10 @@ describe('AnthropicClientAdapter', () => {
         expect(schema).not.toHaveProperty('additionalProperties');
       });
 
-      it('documents that $defs and anyOf branches are NOT traversed', async () => {
-        // Known limitation, tracked separately: the schema preparer walks
-        // `properties` and `items` only. `StructuredOutputSchema` cannot express
-        // these keywords, so they are only reachable via untyped schemas.
+      it('traverses $defs and anyOf branches', async () => {
+        // Previously untraversed - see ISSUE-structured-output-schema-traversal.md.
+        // Full keyword coverage lives in shared/adapters/schemaUtils.test.ts; this
+        // asserts the adapter actually routes through it.
         mockCreate.mockResolvedValueOnce(jsonResponse('{}'));
 
         const compositeSchema = {
@@ -762,8 +867,27 @@ describe('AnthropicClientAdapter', () => {
 
         const schema = mockCreate.mock.calls[0][0].output_config.format.schema;
         expect(schema.additionalProperties).toBe(false);
-        expect(schema.$defs.Address).not.toHaveProperty('additionalProperties');
-        expect(schema.properties.choice.anyOf[0]).not.toHaveProperty('additionalProperties');
+        expect(schema.$defs.Address.additionalProperties).toBe(false);
+        expect(schema.properties.choice.anyOf[0].additionalProperties).toBe(false);
+      });
+
+      it('should not add `required` for Anthropic (that is OpenAI-only strictness)', async () => {
+        mockCreate.mockResolvedValueOnce(jsonResponse('{}'));
+
+        await adapter.sendMessage(
+          withStructuredOutput({
+            name: 'partial_required',
+            schema: {
+              type: 'object',
+              properties: { name: { type: 'string' }, age: { type: 'integer' } },
+              required: ['name']
+            }
+          }),
+          'test-api-key'
+        );
+
+        const schema = mockCreate.mock.calls[0][0].output_config.format.schema;
+        expect(schema.required).toEqual(['name']);
       });
     });
   });

--- a/src/llm/clients/AnthropicClientAdapter.ts
+++ b/src/llm/clients/AnthropicClientAdapter.ts
@@ -11,6 +11,7 @@ import type {
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
+import { applyStrictSchemaConstraints } from "../../shared/adapters/schemaUtils";
 import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
@@ -334,7 +335,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
       // Anthropic requires additionalProperties: false on all object schemas
       const processedSchema: Record<string, unknown> =
         so.strict !== false
-          ? this.addAdditionalPropertiesFalse(so.schema)
+          ? applyStrictSchemaConstraints({ ...so.schema })
           : { ...so.schema };
       messageParams.output_config = {
         format: {
@@ -444,41 +445,6 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
       stop_sequence: null,
       usage: accumulator.usage,
     } as any;
-  }
-
-  /**
-   * Recursively adds additionalProperties: false to all object schemas
-   * Required by Anthropic's strict mode for structured outputs
-   *
-   * @param schema - The JSON schema to process
-   * @returns A new schema with additionalProperties: false on all objects
-   */
-  private addAdditionalPropertiesFalse(schema: any): any {
-    if (!schema || typeof schema !== 'object') {
-      return schema;
-    }
-
-    const processed: any = { ...schema };
-
-    // If this is an object type, add additionalProperties: false
-    if (processed.type === 'object') {
-      processed.additionalProperties = false;
-
-      // Process nested properties
-      if (processed.properties) {
-        processed.properties = {};
-        for (const [key, value] of Object.entries(schema.properties)) {
-          processed.properties[key] = this.addAdditionalPropertiesFalse(value);
-        }
-      }
-    }
-
-    // Process array items
-    if (processed.items) {
-      processed.items = this.addAdditionalPropertiesFalse(schema.items);
-    }
-
-    return processed;
   }
 
   /**
@@ -629,27 +595,15 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
       throw new Error("Invalid completion structure from Anthropic API");
     }
 
-    // Extract thinking/reasoning content if available
-    let reasoning: string | undefined;
-    let reasoning_details: any | undefined;
-    
-    // Check for thinking content in the response
-    if ((completion as any).thinking_content) {
-      reasoning = (completion as any).thinking_content;
-    }
-
+    // Extract reasoning from thinking content blocks. This is the only place
+    // Anthropic exposes it: `Message` has no `thinking_content` or
+    // `reasoning_details` field (the latter is an OpenRouter concept, handled in
+    // OpenRouterClientAdapter), so branches reading those could never fire.
     const thinkingContent = completion.content
       .filter((block: any) => block.type === "thinking" && typeof block.thinking === "string")
       .map((block: any) => block.thinking)
       .join("");
-    if (!reasoning && thinkingContent) {
-      reasoning = thinkingContent;
-    }
-    
-    // Check for reasoning details that need to be preserved
-    if ((completion as any).reasoning_details) {
-      reasoning_details = (completion as any).reasoning_details;
-    }
+    const reasoning: string | undefined = thinkingContent || undefined;
 
     // Map Anthropic's stop reason to our standard format
     const finishReason = this.mapAnthropicStopReason(completion.stop_reason);
@@ -666,11 +620,6 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     // Include reasoning if available and not excluded
     if (reasoning && request.settings.reasoning && !request.settings.reasoning.exclude) {
       choice.reasoning = reasoning;
-    }
-    
-    // Always include reasoning_details if present (for tool use continuation)
-    if (reasoning_details) {
-      choice.reasoning_details = reasoning_details;
     }
 
     return {
@@ -702,12 +651,22 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
   ): string | null {
     if (!anthropicReason) return null;
 
+    // Anthropic's StopReason union is exactly:
+    //   end_turn | max_tokens | stop_sequence | tool_use | pause_turn | refusal
+    // Note there is no `content_filter` - that is OpenAI's vocabulary. A model
+    // that declines on policy grounds reports `refusal`, which we normalize to
+    // `content_filter` so callers can detect a blocked completion with the same
+    // check they already use for OpenAI and Gemini.
     const reasonMap: Record<string, string> = {
       end_turn: "stop",
       max_tokens: "length",
       stop_sequence: "stop",
-      content_filter: "content_filter",
       tool_use: "tool_calls",
+      refusal: "content_filter",
+      // Anthropic-specific: a long-running turn was paused and the caller is
+      // expected to continue it. No equivalent in the normalized vocabulary, so
+      // it maps to "other" deliberately rather than by falling through.
+      pause_turn: "other",
     };
 
     return reasonMap[anthropicReason] || "other";

--- a/src/llm/clients/OpenAIClientAdapter.ts
+++ b/src/llm/clients/OpenAIClientAdapter.ts
@@ -11,6 +11,7 @@ import type {
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
 import { mapOpenAIChatLogprobs } from "../../shared/adapters/logprobsUtils";
+import { applyStrictSchemaConstraints } from "../../shared/adapters/schemaUtils";
 import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
@@ -304,8 +305,10 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
 
     if (request.settings.structuredOutput?.schema && request.settings.structuredOutput.enabled !== false) {
       const so = request.settings.structuredOutput;
+      // OpenAI strict mode additionally requires `required` to list every
+      // property of each object schema.
       const processedSchema = so.strict !== false
-        ? this.addAdditionalPropertiesFalse(so.schema)
+        ? applyStrictSchemaConstraints({ ...so.schema }, { requireAllProperties: true })
         : so.schema;
       completionParams.response_format = {
         type: 'json_schema',
@@ -375,44 +378,6 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
       choices: choices as any,
       ...(usage && { usage }),
     };
-  }
-
-  /**
-   * Recursively adds additionalProperties: false to all object schemas
-   * Required by OpenAI's strict mode for structured outputs
-   *
-   * @param schema - The JSON schema to process
-   * @returns A new schema with additionalProperties: false on all objects
-   */
-  private addAdditionalPropertiesFalse(schema: any): any {
-    if (!schema || typeof schema !== 'object') {
-      return schema;
-    }
-
-    const processed: any = { ...schema };
-
-    // If this is an object type, add additionalProperties: false and ensure required includes all properties
-    if (processed.type === 'object') {
-      processed.additionalProperties = false;
-
-      // Process nested properties
-      if (processed.properties) {
-        const propertyKeys = Object.keys(schema.properties);
-        processed.properties = {};
-        for (const [key, value] of Object.entries(schema.properties)) {
-          processed.properties[key] = this.addAdditionalPropertiesFalse(value);
-        }
-        // OpenAI strict mode requires 'required' to include ALL properties
-        processed.required = propertyKeys;
-      }
-    }
-
-    // Process array items
-    if (processed.items) {
-      processed.items = this.addAdditionalPropertiesFalse(schema.items);
-    }
-
-    return processed;
   }
 
   /**

--- a/src/shared/adapters/schemaUtils.test.ts
+++ b/src/shared/adapters/schemaUtils.test.ts
@@ -1,0 +1,208 @@
+import { applyStrictSchemaConstraints } from './schemaUtils';
+
+describe('applyStrictSchemaConstraints', () => {
+  it('sets additionalProperties: false on the root object schema', () => {
+    const result = applyStrictSchemaConstraints({
+      type: 'object',
+      properties: { name: { type: 'string' } }
+    }) as any;
+
+    expect(result.additionalProperties).toBe(false);
+  });
+
+  it('does not mutate the input schema', () => {
+    const input: any = {
+      type: 'object',
+      properties: { nested: { type: 'object', properties: { a: { type: 'string' } } } }
+    };
+
+    applyStrictSchemaConstraints(input);
+
+    expect(input).not.toHaveProperty('additionalProperties');
+    expect(input.properties.nested).not.toHaveProperty('additionalProperties');
+  });
+
+  it('traverses nested properties and array items', () => {
+    const result = applyStrictSchemaConstraints({
+      type: 'object',
+      properties: {
+        person: { type: 'object', properties: { name: { type: 'string' } } },
+        tags: { type: 'array', items: { type: 'object', properties: { label: { type: 'string' } } } }
+      }
+    }) as any;
+
+    expect(result.properties.person.additionalProperties).toBe(false);
+    expect(result.properties.tags.items.additionalProperties).toBe(false);
+    // Arrays are not objects, so they get no additionalProperties of their own.
+    expect(result.properties.tags).not.toHaveProperty('additionalProperties');
+  });
+
+  it('traverses tuple-form items and prefixItems', () => {
+    const result = applyStrictSchemaConstraints({
+      type: 'object',
+      properties: {
+        pair: {
+          type: 'array',
+          items: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { type: 'object', properties: { b: { type: 'string' } } }
+          ],
+          prefixItems: [{ type: 'object', properties: { c: { type: 'string' } } }]
+        }
+      }
+    }) as any;
+
+    expect(result.properties.pair.items[0].additionalProperties).toBe(false);
+    expect(result.properties.pair.items[1].additionalProperties).toBe(false);
+    expect(result.properties.pair.prefixItems[0].additionalProperties).toBe(false);
+  });
+
+  // These are the branches the pre-0.13.1 walker silently skipped, which is what
+  // ISSUE-structured-output-schema-traversal.md was filed for.
+  it('traverses $defs and definitions', () => {
+    const result = applyStrictSchemaConstraints({
+      type: 'object',
+      properties: { home: { $ref: '#/$defs/Address' } },
+      $defs: {
+        Address: { type: 'object', properties: { city: { type: 'string' } } }
+      },
+      definitions: {
+        Legacy: { type: 'object', properties: { code: { type: 'string' } } }
+      }
+    }) as any;
+
+    expect(result.$defs.Address.additionalProperties).toBe(false);
+    expect(result.definitions.Legacy.additionalProperties).toBe(false);
+    // $ref pointers are left untouched - the target is constrained where defined.
+    expect(result.properties.home).toEqual({ $ref: '#/$defs/Address' });
+  });
+
+  it('traverses anyOf, oneOf, and allOf branches', () => {
+    const result = applyStrictSchemaConstraints({
+      type: 'object',
+      properties: {
+        choice: { anyOf: [{ type: 'object', properties: { a: { type: 'string' } } }, { type: 'null' }] },
+        either: { oneOf: [{ type: 'object', properties: { b: { type: 'string' } } }] },
+        both: { allOf: [{ type: 'object', properties: { c: { type: 'string' } } }] }
+      }
+    }) as any;
+
+    expect(result.properties.choice.anyOf[0].additionalProperties).toBe(false);
+    expect(result.properties.choice.anyOf[1]).toEqual({ type: 'null' });
+    expect(result.properties.either.oneOf[0].additionalProperties).toBe(false);
+    expect(result.properties.both.allOf[0].additionalProperties).toBe(false);
+  });
+
+  it('traverses composition keywords on a root schema with no type', () => {
+    const result = applyStrictSchemaConstraints({
+      anyOf: [
+        { type: 'object', properties: { a: { type: 'string' } } },
+        { type: 'object', properties: { b: { type: 'string' } } }
+      ]
+    }) as any;
+
+    expect(result.anyOf[0].additionalProperties).toBe(false);
+    expect(result.anyOf[1].additionalProperties).toBe(false);
+  });
+
+  it('traverses not', () => {
+    const result = applyStrictSchemaConstraints({
+      type: 'object',
+      properties: {},
+      not: { type: 'object', properties: { forbidden: { type: 'string' } } }
+    }) as any;
+
+    expect(result.not.additionalProperties).toBe(false);
+  });
+
+  it('terminates on a cyclic schema graph and reuses the copy', () => {
+    const cyclic: any = { type: 'object', properties: {} };
+    cyclic.properties.self = cyclic;
+
+    const result = applyStrictSchemaConstraints(cyclic) as any;
+
+    expect(result.additionalProperties).toBe(false);
+    // The cycle resolves to the same processed node rather than recursing forever.
+    expect(result.properties.self).toBe(result);
+  });
+
+  it('reuses one copy for a subschema referenced from two places', () => {
+    const shared: any = { type: 'object', properties: { a: { type: 'string' } } };
+    const result = applyStrictSchemaConstraints({
+      type: 'object',
+      properties: { first: shared, second: shared }
+    }) as any;
+
+    expect(result.properties.first.additionalProperties).toBe(false);
+    expect(result.properties.first).toBe(result.properties.second);
+  });
+
+  it('passes through non-object input unchanged', () => {
+    expect(applyStrictSchemaConstraints(null as any)).toBeNull();
+    expect(applyStrictSchemaConstraints('nope' as any)).toBe('nope');
+    expect(applyStrictSchemaConstraints(undefined as any)).toBeUndefined();
+  });
+
+  describe('requireAllProperties (OpenAI strict mode)', () => {
+    it('rewrites required to every property, at every depth', () => {
+      const result = applyStrictSchemaConstraints(
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+            nested: {
+              type: 'object',
+              properties: { x: { type: 'string' }, y: { type: 'string' } },
+              required: ['x']
+            }
+          },
+          required: ['name']
+        },
+        { requireAllProperties: true }
+      ) as any;
+
+      expect(result.required).toEqual(['name', 'age', 'nested']);
+      expect(result.properties.nested.required).toEqual(['x', 'y']);
+    });
+
+    it('also applies inside $defs and composition branches', () => {
+      const result = applyStrictSchemaConstraints(
+        {
+          type: 'object',
+          properties: { home: { $ref: '#/$defs/Address' } },
+          $defs: {
+            Address: {
+              type: 'object',
+              properties: { city: { type: 'string' }, zip: { type: 'string' } },
+              required: ['city']
+            }
+          }
+        },
+        { requireAllProperties: true }
+      ) as any;
+
+      expect(result.$defs.Address.required).toEqual(['city', 'zip']);
+    });
+
+    it('leaves required alone when the option is off', () => {
+      const result = applyStrictSchemaConstraints({
+        type: 'object',
+        properties: { name: { type: 'string' }, age: { type: 'integer' } },
+        required: ['name']
+      }) as any;
+
+      expect(result.required).toEqual(['name']);
+    });
+
+    it('does not invent required on an object with no properties', () => {
+      const result = applyStrictSchemaConstraints(
+        { type: 'object' },
+        { requireAllProperties: true }
+      ) as any;
+
+      expect(result).not.toHaveProperty('required');
+      expect(result.additionalProperties).toBe(false);
+    });
+  });
+});

--- a/src/shared/adapters/schemaUtils.ts
+++ b/src/shared/adapters/schemaUtils.ts
@@ -1,0 +1,115 @@
+// AI Summary: Shared JSON Schema preparation for providers whose strict
+// structured-output mode requires additionalProperties: false on every object
+// schema. Traverses properties, items (incl. tuple form), $defs/definitions,
+// anyOf/oneOf/allOf, prefixItems and not, and is safe against cyclic input.
+
+/** Keywords whose value is a map of name -> subschema. */
+const SUBSCHEMA_MAPS = ["properties", "$defs", "definitions"] as const;
+
+/** Keywords whose value is an array of subschemas. */
+const SUBSCHEMA_ARRAYS = ["anyOf", "oneOf", "allOf", "prefixItems"] as const;
+
+export interface StrictSchemaOptions {
+  /**
+   * When true, every object schema's `required` is rewritten to list all of its
+   * properties. OpenAI's strict mode demands this; Anthropic's does not.
+   *
+   * @default false
+   */
+  requireAllProperties?: boolean;
+}
+
+/**
+ * Returns a deep copy of `schema` with `additionalProperties: false` set on every
+ * object schema, as required by OpenAI's and Anthropic's strict structured-output
+ * modes.
+ *
+ * The input is never mutated.
+ *
+ * Traversal covers `properties`, `items` (single or tuple form), `prefixItems`,
+ * `$defs`, `definitions`, `anyOf`, `oneOf`, `allOf`, and `not`. Note that `$ref`
+ * pointers are **not** resolved — they are left as-is, and the schemas they point
+ * at are constrained where they are *defined* (typically under `$defs`), which is
+ * what the providers validate. Both providers reject genuinely recursive schemas
+ * anyway, so resolving refs would buy nothing.
+ *
+ * Cyclic *JavaScript* object graphs (a schema object reachable from itself) are
+ * handled: each input node is copied at most once and revisits reuse that copy,
+ * so the walk terminates and shared subschemas stay shared.
+ *
+ * @param schema - The JSON schema to process
+ * @param options - Provider-specific strictness tweaks
+ * @returns A new schema with strict-mode constraints applied
+ */
+export function applyStrictSchemaConstraints<T>(
+  schema: T,
+  options: StrictSchemaOptions = {}
+): T {
+  return walk(schema, options, new Map<object, unknown>()) as T;
+}
+
+function walk(
+  node: unknown,
+  options: StrictSchemaOptions,
+  seen: Map<object, unknown>
+): unknown {
+  if (!node || typeof node !== "object") {
+    return node;
+  }
+
+  const cached = seen.get(node);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (Array.isArray(node)) {
+    const copy: unknown[] = [];
+    seen.set(node, copy);
+    for (const entry of node) {
+      copy.push(walk(entry, options, seen));
+    }
+    return copy;
+  }
+
+  const source = node as Record<string, unknown>;
+  const processed: Record<string, unknown> = { ...source };
+  // Registered before recursing so a cycle resolves to this same object.
+  seen.set(node, processed);
+
+  if (source.type === "object") {
+    processed.additionalProperties = false;
+
+    const properties = source.properties;
+    if (options.requireAllProperties && properties && typeof properties === "object") {
+      processed.required = Object.keys(properties as Record<string, unknown>);
+    }
+  }
+
+  for (const key of SUBSCHEMA_MAPS) {
+    const value = source[key];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const out: Record<string, unknown> = {};
+      for (const [name, subschema] of Object.entries(value as Record<string, unknown>)) {
+        out[name] = walk(subschema, options, seen);
+      }
+      processed[key] = out;
+    }
+  }
+
+  for (const key of SUBSCHEMA_ARRAYS) {
+    const value = source[key];
+    if (Array.isArray(value)) {
+      processed[key] = value.map((subschema) => walk(subschema, options, seen));
+    }
+  }
+
+  if (source.items !== undefined) {
+    processed.items = walk(source.items, options, seen);
+  }
+
+  if (source.not !== undefined) {
+    processed.not = walk(source.not, options, seen);
+  }
+
+  return processed;
+}


### PR DESCRIPTION
Three follow-ups from the v0.13.1 review. Also verifies Dependabot #101 (not merged here).

## 1. E2E suite reported vacuous passes (tracker item 17)

`runIfAvailable` / `runWithAnyProvider` returned without asserting when a provider was missing — and **Jest scores an assertion-free function as passed**. With no llama-server and no keys, four tests reported `√` while verifying nothing. This is the same silent-skip failure mode that let the `output_format` drift hide in the first place.

A `beforeAll` gate can't fix it: the decision must happen *before* Jest registers tests. New `e2e-tests/globalSetup.js` probes llama-server once and publishes `E2E_LLAMACPP_AVAILABLE`, so suites gate with `(AVAILABLE ? describe : describe.skip)` — the idiom the key-gated blocks already use. `providers.e2e.test.ts` had the identical defect; `reasoning.e2e.test.ts` carried a dead unused copy of the probe.

Verified **both** directions:

| | before | after |
|---|---|---|
| no keys, no server | 4 passed (empty) | **19 skipped, 0 passed** |
| `E2E_LLAMACPP_AVAILABLE=true`, no server | 4 passed (empty) | **4 failed** — they actually run |

`globalSetup` honors a pre-set value as an override, which is what makes that second check possible.

## 2. Shared strict-schema walker (closes the traversal issue)

Anthropic and OpenAI each carried a near-duplicate `addAdditionalPropertiesFalse` walking only `properties` and `items`, so object schemas under `$defs` / `anyOf` / `oneOf` / `allOf` never received `additionalProperties: false` and the provider could reject the request. Both are gone, replaced by `applyStrictSchemaConstraints` in `src/shared/adapters/schemaUtils.ts`, which also handles `definitions`, `prefixItems`, tuple-form `items`, and `not`.

This **also fixes the same bug on the OpenAI path**, which had the identical limitation. OpenAI's extra requirement that `required` list every property stays behind a `requireAllProperties` option that Anthropic does not pass (asserted by a regression test).

On cycles: `$ref` is deliberately not resolved — targets are constrained where they're *defined*, which is what providers validate — so JSON-level ref cycles can't recurse. The real hazard is a cyclic *JavaScript* object graph, handled by a copy map that also keeps shared subschemas shared.

The Anthropic test that used to pin the *absence* of traversal now asserts it happens.

## 3. Dead Anthropic reasoning reads (tracker item 14)

Item 14 was **half stale**: the `content[0].type === 'text'` assumption was already fixed by the streaming work. Still real were reads of `completion.thinking_content` and `completion.reasoning_details` — neither is an Anthropic response field (`reasoning_details` is an OpenRouter concept copy-pasted here, where it could never fire). Removed; reasoning now comes solely from `thinking` content blocks.

Adjacent bug in the same function: `mapAnthropicStopReason` had a `content_filter` key Anthropic never emits (that's OpenAI's vocabulary) and was **missing** two real members of the `StopReason` union, so both silently became `"other"`.

⚠️ **Please review one judgment call:** `refusal` now maps to `content_filter`, so callers detect a policy-blocked completion with the same check they use for OpenAI and Gemini. This changes observable `finish_reason` output for consumers who switch on it. `pause_turn` maps to `"other"` explicitly rather than by fallthrough. Happy to revert to `"other"` for `refusal` if you'd rather not change the normalized contract.

## Dependabot #101 verified

`@anthropic-ai/sdk` 0.115.0 tested against current code: `JSONOutputFormat` and `OutputConfig` are byte-identical to 0.110.0, `output_config` is still on `MessageCreateParams`, the error classes `errorUtils` matches by constructor name all survive, and all tests pass. **The PR is 2 commits behind main and needs a rebase.**

## Verification

934 unit tests / 36 suites pass, build clean, prod audit 0 vulnerabilities, pack clean. AGENTS.md documents the new shared utility and the e2e gating convention so the vacuous-pass trap isn't reintroduced.

Two paid e2e runs remain outstanding and can share one top-up: item 16 (structured output) and item 14's reasoning run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AsRvhVuAZje3bHgEYxPFM