### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/ISSUE-next-steps.md
+++ b/ISSUE-next-steps.md
@@ -290,12 +290,20 @@ Anthropic account and run
 pending and can share one top-up: item 16 (structured output) and the item 14
 reasoning run (`npm run test:e2e:reasoning`).
 
-Unreleased on main since v0.13.1: the item 14 / 17 fixes plus the shared schema
-walker (`src/shared/adapters/schemaUtils.ts`). Two of these change observable
-behavior and want a version bump when next released — the `refusal` →
-`content_filter` finish-reason mapping, and `$defs`/`anyOf` branches now
-receiving `additionalProperties: false` on **both** the Anthropic and OpenAI
-paths.
+**v0.14.0 is staged but not released.** `package.json` is bumped and the commit
+is on main; the tag and `npm publish` are still pending. Contents: the item 14 /
+17 fixes plus the shared schema walker (`src/shared/adapters/schemaUtils.ts`).
+
+Minor rather than patch because two changes are observable to consumers:
+
+- `refusal` → `content_filter` in the Anthropic finish-reason mapping (was
+  silently `"other"`).
+- `$defs` / `anyOf` / `oneOf` / `allOf` branches now receive
+  `additionalProperties: false` — on **both** the Anthropic and OpenAI paths, so
+  this reaches OpenAI users who never touched Anthropic.
+
+Neither is a bug fix from a caller's point of view, which is why 0.13.2 would
+have been the wrong signal.
 
 Dependabot: 6 open PRs (#93, #95, #98, #100, #101, #102). **#101**
 (`@anthropic-ai/sdk` 0.110.0 → 0.115.0) was **verified safe on 2026-07-26** —

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-lite",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-lite",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Stages the release of the work merged since v0.13.1. Tag and `npm publish` remain separate, pending steps.

**Minor, not patch.** Two of the changes on `main` are observable to consumers, so `0.13.2` would signal the wrong thing:

- `refusal` now normalizes to `content_filter` in the Anthropic finish-reason mapping, where it previously fell through to `"other"`.
- `$defs` / `anyOf` / `oneOf` / `allOf` branches now receive `additionalProperties: false` — on **both** the Anthropic and OpenAI paths, so this reaches OpenAI users who never touched Anthropic.

Also riding along, with no effect on the published API surface: the e2e skip-gating fix (#105) and removal of the dead Anthropic `thinking_content` / `reasoning_details` reads.

Verified at 0.14.0: 934 tests / 36 suites pass, build clean, `npm pack --dry-run` reports 0.14.0, production audit reports 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AsRvhVuAZje3bHgEYxPFM