### PR TITLE
chore(deps): consolidate Dependabot bumps (#93, #98, #101, #102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -66,9 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.110.0",
+        "@anthropic-ai/sdk": "^0.115.0",
         "@google/genai": "^2.10.0",
         "@mistralai/mistralai": "^1.15.1",
         "js-tiktoken": "^1.0.20",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
-      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+      "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -1288,9 +1288,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:e2e:reasoning": "npm run build && jest --config jest.e2e.config.js reasoning.e2e.test.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.110.0",
+    "@anthropic-ai/sdk": "^0.115.0",
     "@google/genai": "^2.10.0",
     "@mistralai/mistralai": "^1.15.1",
     "js-tiktoken": "^1.0.20",


### PR DESCRIPTION
Consolidated rather than rebased individually, following the precedent set by #91 for #82–#85 and #87. Supersedes and closes four Dependabot PRs.

| PR | Bump | Notes |
|---|---|---|
| #101 | `@anthropic-ai/sdk` ^0.110.0 → ^0.115.0 | Verified against the GA structured-output surfaces — see below |
| #98 | `@types/node` 26.1.0 → 26.1.1 | Lockfile only |
| #93 | `actions/checkout` v6 → v7 | All three CI jobs |
| #102 | `actions/setup-node` v6 → v7 | All three CI jobs |

**`@anthropic-ai/sdk` 0.115.0** was checked against the request contract 0.13.1 shipped, since that work was verified against 0.110.0: `JSONOutputFormat` and `OutputConfig` are byte-identical, `output_config` is still on `MessageCreateParams`, and every error class `errorUtils` matches by constructor name (`APIUserAbortError`, `APIConnectionTimeoutError`, `APIConnectionError`, `APIError`, `BadRequestError`) still exists.

**`@types/node` is a lockfile-only change on purpose.** The `>=20.11.24` range in `package.json` already admits 26.1.1, and dev deps use `>=` by repo convention — so there's nothing to bump there. (`npm install --save-dev` initially rewrote it to `^26.1.1`; I reverted that.)

**The action bumps are exercised by this PR's own CI run**, which is the only meaningful test for them.

Not included, deliberately:
- **#100** (`typescript` 5.9.3 → **7.0.2**) — a major, kept isolated so a failure here can't block the safe bumps. Being verified separately.
- **#95** (`@mistralai/mistralai` 2.x) — blocked by tracker item 12: 2.x is ESM-only and Jest's CJS module registry cannot load it, so it needs dual ESM/CJS packaging first.

Verified locally: typecheck clean, 934 tests / 36 suites pass, build clean, production audit 0 vulnerabilities, pack clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AsRvhVuAZje3bHgEYxPFM