### PR TITLE
feat: add prepared LLM calls and token accounting

### DIFF
--- a/.summary_long.md
+++ b/.summary_long.md
@@ -3,6 +3,16 @@
 ## Overview
 The root directory of the genai-lite project contains all essential configuration files, documentation, and the source code structure for a lightweight Node.js/TypeScript library that provides a unified interface for interacting with multiple Generative AI providers (cloud-based and local). This directory establishes the project as a well-structured npm package with comprehensive documentation, TypeScript support, testing infrastructure, and clear development guidelines. The project has been successfully migrated from an Electron-dependent module to a standalone, portable library suitable for any Node.js environment. Recent enhancements include llama.cpp integration for local LLM support and a flexible model validation system that allows unknown models.
 
+## Prepared-call accounting
+
+The resolved v0.15.0 issue and plan are archived under `docs/archive/`. The
+implementation provides credential-free canonical prepared calls, truthful
+response evidence, certified structural token bounds that exclude consumer
+margins, exact active-template llama.cpp counting, and a single-terminal stream
+lifecycle. User documentation is owned by
+`genai-lite-docs/prepared-calls-and-accounting.md`; certificate maintenance is
+owned by `docs/dev/token-bound-certificates.md`.
+
 ## Key Components
 ### README.md
 ## Overview
@@ -33,7 +43,7 @@ This README serves as the primary documentation for genai-lite, a lightweight No
 
 ## Dependencies
 - **Internal**: Library source files (LLMService, providers, utilities)
-- **External**: npm package 'genai-lite', 'genai-key-storage-lite' (for Electron), 'js-tiktoken' (for utilities)
+- **External**: npm package `genai-lite` and lazily loaded `js-tiktoken` for exact content-token profiles
 
 ## Cross-References
 - Links to LICENSE file
@@ -98,25 +108,25 @@ Documents the completed migration from Electron dependency to standalone Node.js
 
 ### package.json
 ## Purpose
-This package.json file configures the genai-lite npm package, version 0.1.1, which is a lightweight and portable toolkit designed to provide a unified interface for interacting with various Generative AI APIs. The package is published under MIT license and maintained by Luigi Acerbi.
+This package.json file configures genai-lite v0.15.0, a lightweight and portable toolkit designed to provide a unified interface for interacting with various Generative AI APIs. The package is published under the MIT license and maintained by Luigi Acerbi.
 
 ## Key Settings
 - **Package name**: genai-lite
-- **Version**: 0.1.1
+- **Version**: 0.15.0
 - **Entry points**: 
   - Main: dist/index.js
   - Types: dist/index.d.ts
-  - Additional export for utils submodule
-- **Module system**: Supports both CommonJS (require) and ES modules (import)
+  - Additional export for the prompting submodule
+- **Module system**: CommonJS output exposed through both `require` and `import` export conditions
 - **TypeScript support**: Full type definitions included
 - **License**: MIT (permissive open source)
 
 ## Dependencies
 **Production dependencies** (with caret versioning for flexibility):
-- `@anthropic-ai/sdk` (^0.110.0) - SDK for Claude/Anthropic AI integration
+- `@anthropic-ai/sdk` (^0.115.0) - SDK for Claude/Anthropic AI integration
 - `@google/genai` (^2.10.0) - Google's Generative AI SDK for Gemini models
 - `@mistralai/mistralai` (^1.15.1) - Official Mistral SDK (2.x is ESM-only; stay on 1.x until dual packaging)
-- `js-tiktoken` (^1.0.20) - Token counting utility for prompt management
+- `js-tiktoken` (exactly 1.0.21) - lazily loaded, revision-pinned token counting utility
 - `openai` (^6.7.0) - Official OpenAI SDK for GPT models
 
 **Development dependencies** (with >= versioning for broader compatibility):
@@ -130,6 +140,8 @@ This package.json file configures the genai-lite npm package, version 0.1.1, whi
 - `build`: Compiles TypeScript source to JavaScript using `tsc`
 - `test`: Runs Jest test suite with code coverage reporting
 - `test:watch`: Runs Jest in watch mode for development
+- `test:e2e`: Builds and runs the separately configured real-provider suite
+- `test:packed-api`: Builds, packs, installs, and typechecks the public prepared-call API
 
 ## Impact on System
 This configuration establishes genai-lite as a standalone Node.js library that:
@@ -218,7 +230,7 @@ The root directory establishes a well-organized project structure:
 2. **Configuration Layer**: TypeScript, Jest, and npm configurations
 3. **Source Code**: All implementation in src/ directory
 4. **Build System**: TypeScript compilation to dist/
-5. **Testing Infrastructure**: Jest with TypeScript support (421 tests)
+5. **Testing Infrastructure**: Jest with TypeScript support (1,019 tests across 43 suites)
 6. **Provider Support**: Cloud (OpenAI, Anthropic, Google, Mistral, OpenRouter) + Local (llama.cpp)
 
 ## Internal Dependencies

--- a/.summary_short.md
+++ b/.summary_short.md
@@ -17,3 +17,4 @@ Purpose: Root directory of the genai-lite npm package, containing project config
 - `.github/`: Contains GitHub-specific configuration including issue templates and workflows.
 - `.claude/`: Contains Claude Code specific settings.
 - `src/`: Contains the main source code for the genai-lite library, providing the public API and core type definitions.
+- `docs/archive/ISSUE-prepared-llm-calls-and-accounting.md` / `docs/archive/PLAN-prepared-llm-calls.md`: Resolved v0.15.0 prepared-call and truthful token-accounting contract and implementation record.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,15 @@ The `examples/chat-demo` application provides a quick way to test library change
   - `npm audit --omit=dev --audit-level=high` - check for vulnerabilities. This is the blocking CI gate: production deps only, since those are the only ones consumers inherit. CI also runs the full-tree audit non-blocking, because dev-only advisories are often unfixable from here (they sit behind pinned toolchain ranges — e.g. jest pins `glob@10`, which pulls a `brace-expansion` flagged by GHSA-mh99-v99m-4gvg)
   - `npm run build && npm pack --dry-run` - validate package
 - **Dependency updates**: Dependabot will create PRs weekly
-- **Note on versioning**: Production deps use `^`, dev deps use `>=`. Consequence worth knowing: a `>=` range admits majors, so what you actually get is decided by the lockfile and by npm's peer resolution, not by package.json. With `typescript: ">=5.3.3"`, a fresh `npm install` resolves TypeScript to 6.x — capped below 7 by `ts-jest`'s `typescript: ">=4.3 <7"` peer range — even though the lockfile pins 5.9.3. When bumping a dev dep, check what resolution actually picks rather than assuming the lockfile value
+- **Note on versioning**: Production deps normally use `^`, except `js-tiktoken`,
+  which is intentionally pinned exactly because public token-bound certificates
+  bind to its bundled rank artifacts. Dev deps use `>=`. Consequence worth
+  knowing: a `>=` range admits majors, so what you actually get is decided by
+  the lockfile and by npm's peer resolution, not by package.json. With
+  `typescript: ">=5.3.3"`, a fresh `npm install` resolves TypeScript to 6.x —
+  capped below 7 by `ts-jest`'s `typescript: ">=4.3 <7"` peer range — even
+  though the lockfile pins 5.9.3. When bumping a dev dep, check what resolution
+  actually picks rather than assuming the lockfile value
 
 **Still Missing:**
 - Linting configuration (ESLint/Prettier)
@@ -464,7 +472,7 @@ These summary files provide hierarchical context throughout the project:
 
 The summaries enable efficient navigation and understanding of the codebase without processing every file. They include cross-references, usage examples, and architectural decisions at each level.
 
-Last Context Build: 2026-07-03
+Last Context Build: 2026-07-29
 
 ## Commit Guidelines
 

--- a/ISSUE-next-steps.md
+++ b/ISSUE-next-steps.md
@@ -1,7 +1,7 @@
 # ISSUE: Post-v0.9.2 TODO — deferred follow-ups
 
 Created: 2026-07-03
-Updated: 2026-07-27 (item 16 resolved; item 19 added as upstream/low priority)
+Updated: 2026-07-29 (item 20 resolved in v0.15.0)
 Status: OPEN
 Package: genai-lite
 
@@ -291,12 +291,24 @@ Note: all "latest" package versions below were checked via `npm view` on
     `node-fetch` chain. Do not replace the official SDK, add an override, or pin
     a test to this transitive graph solely to hide the warning.
 
+20. ~~**Prepared LLM calls and truthful token accounting.**~~ **RESOLVED
+    (v0.15.0, 2026-07-29).** Added credential-free mode-bound preparation,
+    immutable semantic inspection, identical prepared redispatch, exact
+    active-template llama.cpp counting with coherent state binding,
+    hash-verified token profiles and certified structural bounds, lossless
+    response evidence, and hardened single-terminal streaming. Certified bounds
+    exclude application margins; the consumer applies its heuristic margin
+    exactly once. See
+    [`docs/archive/ISSUE-prepared-llm-calls-and-accounting.md`](docs/archive/ISSUE-prepared-llm-calls-and-accounting.md)
+    and
+    [`docs/archive/PLAN-prepared-llm-calls.md`](docs/archive/PLAN-prepared-llm-calls.md).
+
 ## Pickup point
 
 Open items: 12 (dual packaging — unblocks Mistral 2.x / PR #95), 15 (dev-only
 audit advisory, blocked on jest upstream), 18 (TypeScript 7, blocked on
 ts-jest), 19 (`node-domexception` warning, blocked upstream). Items 13, 14, 16,
-and 17 are resolved.
+17, and 20 are resolved.
 
 **Dependabot queue is clear except for blocked items** (2026-07-26): #93, #98,
 #101, #102 were consolidated into PR #107 and merged (`6e0e3e3`) following the
@@ -307,25 +319,13 @@ CI run. #100 is closed (item 18). **#95 is the only open PR** and is left open o
 purpose as the landing spot for item 12 (Dependabot has since retargeted it from
 2.4.1 to 2.5.0; the ESM-only blocker is unchanged).
 
-**Resume here (2026-07-26, post-v0.14.0):** v0.14.0 is released and published,
-and everything actionable without Anthropic credits is done. The next decision is
-**item 16** — add credits to the Anthropic account and run
-
-```bash
-npm run test:e2e -- structured-output.e2e.test.ts   # needs E2E_ANTHROPIC_API_KEY
-```
-
-to confirm the shipped `output_config.format` request shape against the real API.
-That is still the one claim in 0.13.1/0.14.0 backed only by docs, SDK types, and
-mocks — never a live 200. Two paid runs are pending and can share one top-up:
-item 16 (structured output) and the item 14 reasoning run
-(`npm run test:e2e:reasoning`).
-
-After that, the largest remaining piece of work is **item 12** (dual ESM/CJS
-packaging), which unblocks PR #95 and wants a design decision up front —
-tsup/tshy dual build vs. ESM-only with an engines bump — so it suits its own
-session. Items 15 and 18 need nothing from us; they unblock when jest moves to
-`glob@11` and when `ts-jest` widens its TypeScript peer range.
+**Resume here (2026-07-29, v0.15.0 working tree):** item 20 is implemented,
+verified, and archived. The largest remaining piece of work is **item 12**
+(dual ESM/CJS packaging), which unblocks PR #95 and wants a design decision up
+front — tsup/tshy dual build vs. ESM-only with an engines bump — so it suits
+its own session. Items 15 and 18 need nothing from us; they unblock when jest
+moves to `glob@11` and when `ts-jest` widens its TypeScript peer range. Item 19
+remains a cosmetic upstream deprecation warning.
 
 **v0.14.0 release state**: merged via PR #105 + #106, tag `v0.14.0` on
 `7d5860f`, **published to npm on 2026-07-26** (`npm view genai-lite version` →

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ A lightweight, portable Node.js/TypeScript library providing a unified interface
 - 🎭 **Template Engine** - Sophisticated templating with conditionals and variable substitution
 - 📊 **Configurable Logging** - Debug mode, custom loggers (pino, winston), and silent mode for tests
 
+Prepared calls can inspect and budget the immutable semantic provider request,
+then dispatch that same representation with truthful token/termination evidence.
+
 ## Installation
 
 ```bash
@@ -105,6 +108,24 @@ for await (const event of llmService.streamMessage({
 
 Streaming is implemented for all text providers: `openai`, `anthropic`, `gemini`, `mistral`, `openrouter`, and `llamacpp`. The final `complete.response` event contains the same normalized response shape returned by `sendMessage()`.
 
+### Prepared Calls
+
+```typescript
+const prepared = await llmService.prepareMessage(request, { mode: 'complete' });
+if ('object' in prepared) throw new Error(prepared.error.message);
+
+const inspection = await llmService.inspectPrepared(prepared);
+if ('object' in inspection) throw new Error(inspection.error.message);
+
+console.log(inspection.promptAccounting, inspection.outputTokenLimit);
+const response = await llmService.sendPrepared(prepared);
+```
+
+Preparation is credential-free and mode-bound. See
+**[Prepared Calls & Token Accounting](./genai-lite-docs/prepared-calls-and-accounting.md)**
+for certified structural bounds, the single-margin capacity formula, response
+evidence, and exact active-template llama.cpp counting.
+
 ### Image Generation
 
 ```typescript
@@ -138,6 +159,7 @@ Comprehensive documentation is available in the **[`genai-lite-docs`](./genai-li
 
 ### API Reference
 - **[LLM Service](./genai-lite-docs/llm-service.md)** - Text generation and chat
+- **[Prepared Calls & Token Accounting](./genai-lite-docs/prepared-calls-and-accounting.md)** - Inspect, budget, and dispatch one canonical request
 - **[Image Service](./genai-lite-docs/image-service.md)** - Image generation (cloud and local)
 - **[llama.cpp Integration](./genai-lite-docs/llamacpp-integration.md)** - Local LLM inference
 

--- a/docs/archive/ISSUE-prepared-llm-calls-and-accounting.md
+++ b/docs/archive/ISSUE-prepared-llm-calls-and-accounting.md
@@ -1,0 +1,434 @@
+# Issue: Public Prepared LLM Calls and Truthful Token Accounting
+
+Created: 2026-07-29
+Status: RESOLVED — 2026-07-29 (v0.15.0)
+
+## Summary
+
+Consumers need to inspect the final provider-specific request before dispatch, budget against the
+same request that is sent, and interpret completion limits without relying on fabricated usage
+values. The current service prepares requests privately, while adapters perform additional
+message, schema, system-prompt, and settings transformations later.
+
+Add a public prepared-call seam, model-aware token-counting metadata, certified cross-tokenizer
+bounds, prepared-call revision binding, and lossless completion accounting. These features form
+one contract: inspection is useful only when it describes the payload actually dispatched and the
+response reports which accounting evidence is real.
+
+## Prepared-call API
+
+Expose an immutable prepare, inspect, and dispatch flow alongside the existing convenience
+methods. The exact naming may follow existing conventions; the required shape is:
+
+```ts
+const prepared = await service.prepareMessage(request, { mode: 'complete' });
+const inspection = await service.inspectPrepared(prepared);
+const response = await service.sendPrepared(prepared, options);
+
+const preparedStream = await service.prepareMessage(request, { mode: 'stream' });
+const events = service.streamPrepared(preparedStream, options);
+```
+
+Preparation is mode-bound. `sendPrepared()` accepts only a `complete` artifact, and
+`streamPrepared()` accepts only a `stream` artifact. This ensures that streaming-only request
+fields, including provider usage-reporting options, are fixed before inspection rather than added
+during dispatch.
+
+Preparation must include every deterministic transformation that affects the provider request:
+
+- preset and model-default resolution;
+- capability validation;
+- unsupported-setting filtering;
+- system-message conversion;
+- provider-specific message conversion;
+- structured-output schema normalization and delivery;
+- prompt-based structured-output fallback when selected;
+- reasoning and chat-template settings;
+- mode-specific provider fields;
+- the effective completion-token limit.
+
+Add an explicit structured-output delivery selection for prompt fallback instead of silently
+choosing it. Native delivery remains the compatibility default. When prompt delivery is selected,
+the deterministic schema instruction and its message placement are part of the prepared request,
+inspection, and prompt accounting; no provider-native schema field is also sent. Inspection marks
+prompt delivery as instruction-only rather than provider-enforced, and native capability rejection
+does not incorrectly reject an explicitly selected prompt fallback.
+
+`sendPrepared()` and `streamPrepared()` dispatch that prepared representation without rebuilding
+it through a different transformation path. A prepared call is immutable, reusable, bound to the
+`LLMService` instance that created it, and safe to redispatch unchanged where the dispatch mode
+permits transport retries. It is opaque and nonserializable; forged, deserialized, cross-service,
+and mode-mismatched artifacts are rejected. It contains no API key or other credential in publicly
+inspectable data; credentials are resolved only when needed for dispatch.
+
+For built-in adapters, the existing `sendMessage()` and `streamMessage()` remain convenience
+wrappers around the same prepare-and-dispatch implementation. The optional capability does not
+make existing implementations of the exported adapter interface add new required methods.
+
+## Request inspection
+
+Inspection exposes a stable, read-only, library-owned view of the final semantic provider request.
+The view includes the final provider-facing message order and content, system-instruction
+placement, structured-output or tool delivery, reasoning and chat-template options, effective
+semantic settings, and dispatch mode. It excludes credentials, authorization headers, SDK client
+instances, and other transport-only state. Provider SDK request classes remain private.
+
+Inspection also reports enough accounting evidence to enforce a context boundary without implying
+false precision. The exact type decomposition may vary, but it must preserve these distinctions:
+
+```ts
+interface PreparedPromptTokenCount {
+  tokens: number;
+  method: 'exact' | 'model' | 'heuristic';
+  tokenizerId?: string;
+  tokenProfileRevision?: string;
+  uncertaintyTokens?: number;
+}
+
+interface TokenBoundCertificateRef {
+  id: string;
+  derivation: string;
+  provenance: string;
+  sourceProfileRevision?: string;
+  targetProfileRevision: string;
+}
+
+interface PreparedPromptTokenUpperBound {
+  tokens: number;
+  certificate: TokenBoundCertificateRef;
+}
+
+type PreparedPromptAccounting =
+  | {
+      status: 'available';
+      count: PreparedPromptTokenCount;
+      upperBound?: PreparedPromptTokenUpperBound;
+    }
+  | {
+      status: 'available';
+      count?: undefined;
+      upperBound: PreparedPromptTokenUpperBound;
+    }
+  | { status: 'unavailable' };
+
+interface EffectiveOutputTokenLimit {
+  tokens: number;
+  source:
+    | 'request'
+    | 'preset'
+    | 'model_default'
+    | 'library_default'
+    | 'provider_default';
+  requestedTokens?: number;
+  clamp?: {
+    tokens: number;
+    source: 'model_hard_limit' | 'provider_hard_limit';
+  };
+  counts: 'visible_output' | 'visible_and_reasoning' | 'provider_defined' | 'unknown';
+}
+
+interface PreparedRequestBindings {
+  adapterRevision: string;
+  requestShapeRevision: string;
+  tokenProfileRevision?: string;
+  providerEndpointRevision?: string;
+  serverStateFingerprint?: string;
+  chatTemplateFingerprint?: string;
+}
+
+interface PreparedRequestInspection {
+  provider: ApiProviderId;
+  model: string;
+  mode: 'complete' | 'stream';
+  request: PreparedProviderRequestView;
+  promptAccounting: PreparedPromptAccounting;
+  outputTokenLimit?: EffectiveOutputTokenLimit;
+  bindings: PreparedRequestBindings;
+}
+```
+
+An available prompt-accounting object contains at least a count, a certified upper bound, or both.
+A count covers the final provider-facing messages and schema framing rather than only concatenated
+content strings. An upper bound is structurally conservative over that same final representation.
+A model or heuristic point estimate is never placed in `upperBound`. `uncertaintyTokens` is zero
+or absent for exact counting and describes the provenance and uncertainty of a non-exact point
+count. It is not an application safety margin and is not silently added to a certified upper
+bound. Inspection must not silently use a different tokenizer or fall back from exact to heuristic
+without changing the count method.
+
+Certified prompt bounds contain only tokenizer-, framing-, and transformation-derived structural
+allowances. They exclude every consumer/session heuristic safety margin. A consuming application
+applies its margin exactly once at the capacity boundary:
+
+```ts
+const effectiveCapacity = rawCapacity - heuristicMargin;
+const fits =
+  promptTokenUpperBound + outputBound + countingSlack <= effectiveCapacity;
+```
+
+`countingSlack` is a separately visible allowance chosen from the available counting evidence; it
+is not the application's `heuristicMargin`. For exact profiles the application uses
+`heuristicMargin = 0`. The library does not accept a consumer margin as input to a certified-bound
+API, add one to a returned bound, or subtract one from a model's capacity.
+
+When a request specifies a completion-token maximum, inspection must report the actual
+output-token limit that dispatch will enforce after provider/model defaults, capability filtering,
+and hard-limit clamping. Its metadata states where the limit came from and whether the provider
+counts visible output, visible plus reasoning tokens, or provider-defined units. Absence means the
+consumer cannot prove an output boundary; it must not imply that the requested setting survived.
+
+Every prepared call is bound to its model and to required library-controlled adapter and request
+shape revisions. Token-profile, provider-endpoint, local-server-state, and chat-template bindings
+are included when they are used and observable. Cloud APIs are not assigned a fictional endpoint
+revision, and a local server is represented by a stable state fingerprint rather than an assumed
+monotonic generation counter.
+
+Immediately before inference dispatch, `sendPrepared()` and `streamPrepared()` revalidate every
+available and locally observable binding and reject detected staleness before sending the
+inference request. Revalidation may itself require preflight traffic; the contract does not claim
+to detect unobservable remote changes or eliminate the interval between validation and dispatch.
+Exact local prepared-message counting requires model/server/template fingerprints that are
+rechecked before inference dispatch.
+
+## Token-counting profiles
+
+Expose model-aware counting as a reusable capability rather than requiring every consumer to
+maintain its own provider and model table.
+
+The API must distinguish:
+
+- synchronous content counting suitable for repeated prompt assembly;
+- final prepared-message counting, which may be asynchronous;
+- exact model tokenization;
+- model-family approximations;
+- generic heuristics.
+
+For known local GGUF families, provide a stable model/tokenizer mapping and an offline synchronous
+counter where an implementation is available. For a running llama.cpp model, final message
+counting must account for its actual chat template; raw `/tokenize` counting of concatenated text
+must not be labeled exact prepared-message counting.
+
+Unknown models remain supported. They return an explicit heuristic or unavailable profile rather
+than borrowing an unrelated tokenizer under an exact label.
+
+Expose a certified upper bound for text that is bounded in one tokenizer and will later be
+consumed by another:
+
+```ts
+retokenizationUpperBound(
+  sourceTokenBound: number,
+  sourceProfile: TokenProfile,
+  targetProfile: TokenProfile
+): {
+  targetTokenUpperBound: number;
+  certificate: TokenBoundCertificateRef;
+} | undefined;
+```
+
+The exact API name and profile handles may vary. The semantic requirement is that every returned
+value is a proven conservative upper bound for every text produced by decoding at most
+`sourceTokenBound` ordinary generation tokens under the pinned source profile, not a point estimate
+for sample text. It does not claim to cover arbitrary input strings merely because a normalizing
+source encoder maps them to at most that many tokens: a normalizer may erase or collapse
+unbounded input. This decoded-output domain is the startup-sizing case for text that a source model
+will generate before a target model consumes it.
+
+The certificate pins the relevant tokenizer/profile revisions and documents its derivation and
+provenance. Unsupported profile pairs return unavailable. Heuristic retokenization estimates, if
+offered, use a separate API and can never populate a certified bound. Consumers must be able to
+distinguish this capability from ordinary `count(text)`, because startup sizing occurs before the
+future text exists. Returned values contain structural tokenization bounds only and exclude
+consumer/session heuristic safety margins.
+
+Also expose an upper bound for future text known only by Unicode code-point length:
+
+```ts
+codePointBoundToTokenUpperBound(
+  codePointBound: number,
+  targetProfile: TokenProfile
+): {
+  targetTokenUpperBound: number;
+  certificate: TokenBoundCertificateRef;
+} | undefined;
+```
+
+Every returned value is conservative for all Unicode strings within the code-point bound,
+including astral characters, combining sequences, dense scripts, and byte fallback. Unsupported
+profiles return unavailable rather than a point estimate. Certificates may be derived and tested
+using full tokenizer artifacts during development, but the runtime registry stores only the small
+revision-pinned constants and provenance required to apply the proof; supporting a bound does not
+require bundling every tokenizer implementation. Returned values exclude consumer/session
+heuristic safety margins.
+
+Bound inputs must be nonnegative safe integers. If applying a certificate would overflow a safe
+integer or otherwise lose conservativeness, the API returns unavailable or a typed validation
+error rather than a rounded number.
+
+## Usage and termination evidence
+
+Response normalization must preserve missing information as missing. It must never turn an absent
+provider count into zero.
+
+Replace truthiness-based mappings such as `value || 0` with presence-aware mappings. A real zero
+remains zero; an unavailable field remains `undefined`. Derive `total_tokens` only when the inputs
+needed for that derivation are available, and identify library estimates explicitly if estimates
+are ever added.
+
+Add normalized termination evidence while retaining the raw provider reason:
+
+```ts
+interface LLMTermination {
+  rawReason: string | null;
+  kind: 'stop' | 'limit' | 'content_filter' | 'tool_call' | 'other' | 'unknown';
+  limit?: 'output' | 'context' | 'unknown';
+}
+```
+
+Only report `output` or `context` when the provider supplies enough evidence to distinguish them.
+A generic provider `length` result maps to `kind: 'limit', limit: 'unknown'`, not an invented
+output or context diagnosis. Preserve the existing normalized `finish_reason` during any API
+transition.
+
+Streaming and non-streaming responses expose equivalent final usage and termination evidence.
+Partial responses on failure preserve any evidence received before the failure.
+
+Preserve pre-normalization answer evidence. Responses expose `rawContent`, raw-answer accounting,
+or both. `rawContent`, when present, is the exact textual sequence that would otherwise be
+normalized into `choice.content`, captured before reasoning extraction, tag stripping, whitespace
+cleanup, or any other content transformation. If a provider returns ordered typed content parts
+whose boundaries or types would be lost by textual concatenation, preserve a JSON-safe ordered
+library-owned raw-parts representation as well. Native reasoning remains separately identifiable.
+Raw-answer accounting is not a substitute for that content; it reports the pre-normalization token
+count together with its tokenizer/profile revision, counting method, evidence source, and whether
+native or extracted reasoning tokens are included. This evidence is available in streaming
+terminal envelopes and partial failures. Normalized content and provider-reported usage remain
+separate fields.
+
+Every event emitted for a physical stream carries one stable attempt ID. A consumed stream emits
+exactly one terminal envelope: a completion envelope for success or an error envelope for failure.
+Cancellation uses the normal error envelope with `REQUEST_ABORTED`. No delta may be emitted after
+terminal completion or cancellation, and late adapter events are suppressed by the library rather
+than left for each consumer to interpret. If a consumer abandons iteration, the library performs
+best-effort cancellation but cannot promise delivery of a terminal event to that abandoned
+consumer.
+
+`streamPrepared()` does not transparently retry a physical stream. A caller may redispatch the
+same prepared streaming artifact, creating a new physical stream and attempt ID.
+
+## Capability metadata
+
+Extend model capabilities with facts needed to interpret inspection:
+
+- known context window and its provenance;
+- content-token and prepared-message counting availability;
+- tokenizer/profile identity;
+- structured-output delivery mechanism;
+- whether prompt and completion usage are normally reported;
+- whether limit termination is distinguishable by the provider.
+
+Capabilities describe known provider/model facts, not guarantees about an individual response.
+Per-response fields remain authoritative.
+
+Existing implementations of the exported custom-adapter interface remain source-compatible.
+`LLMService` does not currently expose a custom-adapter registration API, and this issue does not
+add one. Wherever a legacy adapter is accepted by an existing lower-level extension seam, absence
+of the new optional prepared-call/counting capability is reported as unsupported or unavailable
+rather than receiving fabricated inspection data. All built-in adapters implement the canonical
+prepared-call path.
+
+## Retry boundary
+
+Prepared calls support identical transport retries. The library must not silently create a
+content-modified retry after dispatch.
+
+A fallback that changes messages, schema instructions, output limits, or other content produces a
+new prepared call visible to the consumer. Provider capability selection performed during initial
+preparation is not a retry.
+
+## Acceptance criteria
+
+- [x] Public prepare, inspect, non-streaming dispatch, and streaming dispatch APIs exist.
+- [x] Prepared artifacts are immutable, reusable, service-bound, nonserializable, and mode-bound;
+      forged, cross-service, and mode-mismatched artifacts are rejected.
+- [x] Existing convenience methods use the same preparation and dispatch implementation for every
+      built-in adapter; the exported legacy custom-adapter interface remains source-compatible.
+- [x] Inspection exposes a stable library-owned view of the exact semantic prepared
+      representation passed to the adapter without exposing credentials or SDK objects.
+- [x] Schema and system-message transformations are included before inspection.
+- [x] Explicit prompt-based structured-output delivery is injected deterministically before
+      inspection/counting and is not combined with provider-native schema delivery.
+- [x] Prepared calls expose no credentials and are safe for identical transport redispatch.
+- [x] Inspection reports count method, tokenizer/profile identity, uncertainty, certified bounds,
+      output-limit provenance, and output-limit counting semantics.
+- [x] Inspection distinctly represents exact/model/heuristic prompt counts, certified
+      prompt-token upper bounds, and unavailable accounting.
+- [x] Certified prompt, code-point, and retokenization bounds contain structural allowances only;
+      no consumer/session heuristic margin is baked into a bound or subtracted from capacity.
+- [x] Capacity guidance applies `heuristicMargin` exactly once and keeps any explicit
+      `countingSlack` separate; exact profiles use a zero heuristic margin.
+- [x] A numeric regression test uses `rawCapacity = 1000`, `heuristicMargin = 100`,
+      `promptTokenUpperBound = 700`, `outputBound = 150`, and `countingSlack = 25`: the correct
+      comparison is `875 <= 900`; an implementation that also adds the margin to the prompt side
+      produces `975 <= 900` and fails the test.
+- [x] A requested output maximum is reported as the actual enforced value after filtering and
+      clamping; a dropped/unprovable setting remains absent.
+- [x] Prepared calls expose required model/adapter/request-shape bindings and every observable
+      endpoint/template/profile/server-state binding used during preparation.
+- [x] Dispatch revalidates every available and locally observable binding before the inference
+      request and rejects detected staleness.
+- [x] Exact local prepared-message counting includes the active chat template.
+- [x] Unknown models report heuristic or unavailable counting honestly.
+- [x] Cross-tokenizer upper-bound APIs return revision-pinned proof certificates, remain separate
+      from point estimates, and report unsupported pairs as unavailable.
+- [x] Retokenization certificates cover text decoded from the declared source-token bound and do
+      not overclaim coverage for arbitrary strings collapsed by source normalization.
+- [x] Documented derivations establish each certified bound; property and adversarial tests over
+      representative exact/model pairs validate the implementations and find no counterexample.
+- [x] Code-point-to-token upper bounds cover ASCII, dense scripts, astral Unicode, combining
+      sequences, and byte fallback using revision-pinned certificates; unsupported profiles remain
+      unavailable.
+- [x] Certified-bound APIs reject invalid bounds and never return an unsafe rounded value after
+      numeric overflow.
+- [x] Missing Gemini and Mistral usage fields remain absent rather than becoming zero.
+- [x] Real zero usage values remain zero.
+- [x] Raw and normalized termination evidence is available.
+- [x] Ambiguous `length` termination remains explicitly ambiguous.
+- [x] Streaming and non-streaming final envelopes have equivalent accounting semantics.
+- [x] Every emitted stream event exposes its stable physical attempt ID; a consumed stream emits
+      exactly one completion/error terminal envelope and no post-terminal or post-cancellation
+      delta.
+- [x] Streaming cancellation terminates with `REQUEST_ABORTED`; abandoned iteration triggers
+      best-effort cancellation, and stream dispatch does not transparently retry.
+- [x] Partial failures preserve available usage and termination evidence.
+- [x] Lossless pre-normalization content and/or explicitly sourced raw-answer token accounting
+      survives reasoning extraction, cleanup, streaming, and partial failure.
+- [x] No content-modifying retry is hidden inside dispatch.
+- [x] Legacy custom-adapter implementations remain source-compatible and absent optional
+      prepared/counting capabilities report unsupported explicitly; built-ins use the canonical
+      prepared path.
+- [x] Tests cover every provider adapter, missing and partial usage, exact zero values, streaming,
+      structured-output delivery, ambiguous limits, and prepared-call redispatch.
+- [x] User documentation and TypeScript API references describe the new contract.
+
+## Non-goals
+
+This issue does not define application-specific prompt budgets, request classes, routing,
+admission policy, brevity instructions, summary splitting, or content-retry decisions.
+
+## Resolution
+
+Resolved on 2026-07-29 for v0.15.0. The implementation adds service-owned,
+credential-free prepared calls; immutable semantic inspection; identical
+prepared redispatch; exact active-template llama.cpp counting with coherent
+state binding; hash-verified token profiles and structural certificates;
+truthful raw, usage, and termination evidence; and a single-terminal streaming
+lifecycle.
+
+Certified bounds exclude consumer/session margins. The numeric regression locks
+the application-side formula to `875 <= 900` and proves that charging the
+margin twice would incorrectly produce `975 <= 900`.
+
+Verification completed with 43 unit suites / 1,019 tests, a strict TypeScript
+build, production dependency audit, dry-run package inspection, packed-consumer
+typecheck, root-export/lazy-tokenizer check, and a live llama.cpp exact-count
+E2E against the running Gemma server.

--- a/docs/archive/PLAN-prepared-llm-calls.md
+++ b/docs/archive/PLAN-prepared-llm-calls.md
@@ -1,0 +1,855 @@
+# Plan: Prepared LLM Calls
+
+Created: 2026-07-29
+Status: COMPLETE — 2026-07-29 (v0.15.0)
+
+## Implementation Tracking
+
+- [x] Phase 1: Public evidence types and internal contracts
+- [x] Phase 2: Truthful usage, termination, and raw evidence
+- [x] Phase 3: Canonical credential-free adapter preparation
+- [x] Phase 4: Service-owned prepared calls and output-limit provenance
+- [x] Phase 5: Token profiles and certified structural bounds
+- [x] Phase 6: llama.cpp exact counting and stale-state rejection
+- [x] Phase 7: Streaming lifecycle hardening and provider evidence
+- [x] Phase 8: Capability metadata, exports, and documentation
+- [x] Phase 9: Full verification and issue closure
+
+## Summary
+
+Implement the contract in
+[`ISSUE-prepared-llm-calls-and-accounting.md`](ISSUE-prepared-llm-calls-and-accounting.md):
+credential-free, mode-bound prepared calls; a stable inspection view of the semantic provider
+request; truthful prompt/output accounting; revision-bound local counting; lossless response and
+termination evidence; and a service-owned streaming lifecycle.
+
+The work is deliberately staged. First establish additive evidence types and presence-aware
+normalization, then split deterministic provider preparation from credentialed transport, expose
+the public prepared-call API, add token profiles and certified structural bounds, integrate
+llama.cpp's exact chat-input counter, and finally enforce stream terminal semantics. Existing
+`sendMessage()` and `streamMessage()` remain the convenience API and route through the canonical
+prepared path for every built-in adapter.
+
+## Scope
+
+- **In scope**:
+  - Public `prepareMessage`, `inspectPrepared`, `sendPrepared`, and `streamPrepared` methods.
+  - Opaque, immutable, reusable, service-bound, nonserializable, mode-bound prepared handles.
+  - A stable library-owned semantic request view with no credentials or SDK objects.
+  - Explicit native-versus-prompt structured-output delivery, with prompt injection visible before
+    inspection and accounting.
+  - Provider request preparation for OpenAI, Anthropic, Gemini, Mistral, OpenRouter, llama.cpp,
+    and Mock.
+  - Output-limit provenance and counting semantics.
+  - Presence-aware usage, raw and normalized termination, pre-normalization answer evidence, and
+    partial-failure evidence.
+  - Model-aware content/prepared-message token profiles.
+  - Certified retokenization and code-point structural bounds with no consumer safety margin.
+  - Exact active-template prompt counting and observable state binding for current llama.cpp.
+  - Stable stream attempt IDs, exactly one terminal event, cancellation acknowledgement, and
+    late-event suppression.
+  - Public exports, user/developer documentation, summaries, unit/property tests, and a gated
+    llama.cpp E2E smoke test.
+
+- **Out of scope**:
+  - Application routing, admission policy, prompt truncation, or a library-owned capacity/fitting
+    helper.
+  - Applying Palimpsest's `heuristicMargin`; genai-lite returns structural evidence only.
+  - Authenticated cloud token-count calls during preparation.
+  - Bundling additional tokenizer runtimes or model tokenizer assets.
+  - Inventing exact tokenizer revisions for arbitrary GGUF conversions.
+  - Automatic streaming retries.
+  - Changing the existing non-stream retry policy based on whether a failed attempt produced
+    partial content; this issue preserves evidence but does not decide content-retry policy.
+  - Adding a new public `LLMService.registerAdapter()` API. The exported adapter interface remains
+    source-compatible; inaccurate documentation examples are corrected.
+  - Paid provider E2E calls unless separately authorized.
+
+## Confirmed Current State
+
+- `LLMService.prepareRequest()` in `src/llm/LLMService.ts` already centralizes model resolution,
+  validation, settings, filtering, and adapter lookup, but it also retrieves the API key and stops
+  before provider-specific transformations.
+- Every built-in adapter still formats the actual provider request at dispatch time. System
+  conversion, schema rewriting, reasoning translation, and stream-only fields therefore happen
+  after the current private preparation seam.
+- Non-stream retries rebuild provider request objects on every attempt.
+- `SettingsManager` returns final values without provenance and does not distinguish a model
+  default from a verified hard output limit.
+- Gemini and Mistral fabricate missing usage as zero through truthiness mappings; Anthropic's
+  streaming usage merge also fills missing fields with zero.
+- Anthropic and Gemini discard raw provider stop reasons; Mistral can invent `"stop"` when no
+  terminal reason was observed.
+- Service and llama.cpp reasoning cleanup mutate content without retaining the pre-normalization
+  value.
+- `LLMService.streamMessage()` forwards adapter events after a terminal event, can emit two
+  terminals, and silently accepts a stream that ends without a terminal event.
+- `countTokens()` in `src/prompting/content.ts` returns only a number and silently falls back to
+  `ceil(text.length / 4)`.
+- `js-tiktoken@1.0.21` is the only tokenizer dependency. Its installed footprint is about
+  21.4 MiB, so certificates should ship as small constants rather than adding tokenizer bundles.
+- Current llama.cpp documents
+  [`POST /v1/chat/completions/input_tokens`](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md)
+  and exposes `model_path`, `chat_template`, `chat_template_caps`, and `build_info` through
+  `/props`.
+- A live probe against the user-started e4b server (build `b9860-fdb1db877`) confirmed:
+  - `/v1/chat/completions/input_tokens` returned the same count twice for the same body;
+  - complete and stream bodies both counted 21 input tokens;
+  - changing `chat_template_kwargs.enable_thinking` changed the count from 21 to 23;
+  - `/props?model=...` routed correctly;
+  - the active 16,804-character template and server/model fields can be hashed into an observable
+    state fingerprint.
+
+## Design Decisions
+
+### Public artifact and errors
+
+- `prepareMessage(request, { mode })` requires `"complete"` or `"stream"`; there is no
+  mode-changing dispatch.
+- A successful preparation returns a small frozen, nominal handle with no replayable serialized
+  representation. Its private adapter command and inspection data live in a `WeakMap` owned by the
+  creating `LLMService`; JSON serialization either rejects explicitly or produces no data that can
+  be deserialized into a valid handle.
+- Recoverable request/preparation failures use the existing `LLMFailureResponse` convention.
+  Forged, deserialized, cross-service, and mode-mismatched handles receive explicit typed failure
+  codes rather than being dispatched.
+- The handle stores no API key, signal, timeout, retry counter, SDK client, or mutable provider
+  request.
+- Model `PreparedPromptAccounting` so `status: "available"` requires at least one of `count` or
+  `upperBound`; enforce the same invariant at runtime for adapter-provided evidence.
+
+### Adapter seam
+
+- Add an optional prepared-call capability to the exported adapter contract rather than making new
+  methods mandatory on legacy implementations.
+- A built-in adapter's credential-free preparation returns an internal immutable command
+  containing:
+  - its final semantic provider payload;
+  - the public normalized request view;
+  - adapter/request-shape revisions;
+  - output-limit evidence;
+  - optional prompt-counting and staleness hooks;
+  - credentialed complete and/or stream dispatch functions.
+- SDK clients, credential validation, abort timers, and timeout state are created only during
+  dispatch.
+- All built-in adapters implement this capability. A legacy adapter reports the new capability as
+  unsupported rather than receiving fabricated inspection data. Because `LLMService` currently
+  exposes no custom-adapter registration API, compatibility means unchanged implementations still
+  satisfy the exported adapter interface and work in existing lower-level seams; this issue does
+  not invent a service path that does not exist.
+
+### Inspection view
+
+- Define a stable library-owned `PreparedProviderRequestView` rather than exporting SDK request
+  classes.
+- The view records operation/mode, provider-role messages, system placement, structured-output
+  delivery, reasoning/template settings, effective sampling/output settings, and provider
+  extensions that affect semantics.
+- Prompt-based structured output is an explicit additive delivery option. Native delivery remains
+  the compatibility default; prompt delivery deterministically injects one versioned schema
+  instruction and suppresses provider-native schema fields. Inspection labels its enforcement as
+  instruction-only, and capability validation rejects unsupported native delivery without
+  rejecting an explicitly selected prompt fallback.
+- Inspection returns a deeply immutable copy or view so consumer mutation cannot alter dispatch.
+- Provider transport headers, SDK instances, API keys, signals, and timeouts never appear.
+
+### Token evidence and margins
+
+- Point counts and certified upper bounds are separate evidence objects; neither is inferred from
+  the other.
+- Exact point counts carry zero or absent `uncertaintyTokens`. Non-exact uncertainty is evidence
+  metadata, never `countingSlack` or `heuristicMargin`.
+- Certified bounds include tokenizer/framing structural allowances only. They never accept or
+  apply `heuristicMargin`.
+- The documented consumer formula remains:
+
+  ```ts
+  const effectiveCapacity = rawCapacity - heuristicMargin;
+  const fits =
+    promptTokenUpperBound + outputBound + countingSlack <= effectiveCapacity;
+  ```
+
+- Retokenization certificates cover text decoded from at most the declared number of ordinary
+  source-generation tokens. They do not cover arbitrary input erased by source normalization.
+- No same-profile `n -> n` identity certificate is assumed. It is registered only after proving the
+  pinned decoder's complete round trip, including invalid bytes, terminal flush, special-token
+  exclusions, and cross-token composition; otherwise use a derived affine bound or unavailable.
+- `countTokens()` remains as a compatible numeric wrapper; new APIs return method, profile,
+  revision, and uncertainty evidence.
+
+### Local binding
+
+- Always bind the model, adapter revision, and request-shape revision.
+- Bind optional endpoint/profile/template/server fields only when observable; do not invent cloud
+  endpoint revisions.
+- For llama.cpp, hash a canonical selection of `/props` and `/v1/models` fields, including model
+  identity, build information, chat template, and template capabilities. Expose only the hash and
+  non-sensitive metadata, not the absolute local model path.
+- Revalidate observable bindings before each physical inference request. A preflight request is
+  allowed; the guarantee is detection before inference dispatch, not before all network traffic.
+
+### Response and stream compatibility
+
+- Keep `finish_reason` and existing usage fields during migration.
+- Add termination and evidence fields without changing missing values into zero.
+- Add attempt identity at the service boundary. Keep an adapter-facing event type that does not
+  require external adapters to manufacture service attempt IDs.
+- All built-ins use the canonical prepared path. Legacy implementations remain assignable to the
+  exported adapter interface; optional capability detection reports prepared/counting support as
+  unavailable, with no fabricated view or service-registration promise.
+- A public consumed stream has one attempt ID and one terminal completion/error event. Validation
+  failures receive an invocation ID even if no provider stream was opened.
+- Abandoned iteration triggers best-effort cancellation but cannot deliver a terminal event to a
+  consumer that stopped reading.
+- `rawContent` is the exact pre-normalization text that feeds `choice.content`. Providers with
+  ordered typed parts also expose a JSON-safe, library-owned ordered raw-parts view so
+  concatenation does not erase boundaries/types; native reasoning remains separately identifiable.
+
+## Provider Migration Matrix
+
+| Provider | Canonical preparation | Initial prepared prompt accounting | Key accounting/termination work |
+| --- | --- | --- | --- |
+| OpenAI | Freeze messages, `max_completion_tokens`, selected native/prompt schema delivery, reasoning effort, sampling, and mode fields before dispatch | Prepared-message point count only if a versioned framing calculator covers the canonical view; otherwise unavailable | Preserve current usage absence/zero behavior; add raw termination and classify generic `length` as ambiguous |
+| Anthropic | Freeze reordered/alternating messages, separate system prompt, selected schema delivery, thinking budget, and endpoint method | Prepared-message point count only with verified framing; authenticated `countTokens()` remains out of scope | Presence-aware cache/input/output usage; retain raw stop reason; map `max_tokens` to output limit |
+| Gemini | Split semantic config from credentialed SDK client and abort timer; freeze role/system/schema/safety/thinking conversion | Prepared-message point count only with verified framing; authenticated `countTokens()` remains out of scope | Remove fabricated zero usage; preserve raw finish reason and thought/cache evidence |
+| Mistral | Freeze messages, selected JSON-object/prompt delivery, sampling, output limit, and stream selector | Prepared-message heuristic only with versioned framing; otherwise unavailable | Presence-aware aliases; never invent `"stop"` for partial/unknown termination |
+| OpenRouter | Freeze messages, routing, selected native/prompt schema delivery, reasoning, attribution, sampling, and mode fields | Prepared-message point count only with versioned framing; otherwise unavailable | Preserve gateway usage absence and raw underlying finish reason |
+| llama.cpp | Freeze the exact OpenAI-compatible body including template kwargs, grammar, logprobs, selected schema delivery, and mode fields | Exact `/v1/chat/completions/input_tokens` under active template | Add observable state fingerprint, exact count, raw pre-cleanup content, and stale rejection |
+| Mock | Freeze deterministic mock semantics, selected schema delivery, and mode | Explicit prepared-request heuristic with versioned framing provenance | Retain legacy `usage` while labeling its heuristic provenance; preserve partial evidence and cancellation |
+
+## Phases
+
+### Phase 1: Public Evidence Types and Internal Contracts
+
+**Goal**: Establish additive types and internal seams before moving provider behavior.
+
+**Work**:
+
+- Extend `src/llm/types.ts` with:
+  - `PreparedCallMode`, mode-specific opaque prepared-handle types, and preparation options;
+  - stable request-view types;
+  - a nonempty prepared-accounting union, prompt count/upper-bound evidence, and output-limit
+    evidence with `library_default`, requested-value, and clamp provenance;
+  - prepared bindings and inspection types;
+  - token-profile and certificate references;
+  - an explicit native/prompt structured-output delivery selector;
+  - `LLMTermination`, raw-answer evidence, per-choice `rawContent`, and ordered raw parts;
+  - a service-dispatched stream event type with required `attemptId`.
+- Extend `src/llm/clients/types.ts` with:
+  - an adapter-facing stream event type without a required attempt ID;
+  - optional prepared-call capability and internal immutable command types;
+  - preparation/revalidation result types;
+  - explicit prepared-handle/staleness error codes.
+- Add deep-freeze/JSON-view helpers only where shared behavior is real; do not expose SDK objects.
+- Add type-level fixtures proving complete handles cannot call `streamPrepared` and stream handles
+  cannot call `sendPrepared`.
+
+**Steps**:
+
+- [x] Define additive public types without removing `LLMUsage`, `finish_reason`, or existing stream
+      variants.
+- [x] Define the internal prepared adapter capability and legacy capability check.
+- [x] Define failure codes for invalid handle, mode mismatch, unsupported preparation, and stale
+      binding.
+- [x] Add compile-time contract tests; runtime handle/immutability tests land with Phase 4.
+
+**Verification**:
+
+- [x] Existing consumer-facing request/response types still compile.
+- [x] Legacy adapter literals can use the adapter event type without an `attemptId`.
+- [x] Service stream return types guarantee an `attemptId`.
+- [x] Prepared request views are JSON-safe and deeply immutable.
+- [x] No prepared public type contains credential or transport fields.
+- [x] Available accounting cannot be constructed without a count or bound.
+- [x] Exact counts have zero/absent uncertainty; non-exact uncertainty is never reused as capacity
+      slack or an application margin.
+- [x] Output-limit types represent library defaults and request values clamped by separately
+      proven model/provider caps without conflating those sources.
+
+### Phase 2: Truthful Usage, Termination, and Raw Evidence
+
+**Goal**: Fix fabricated accounting and establish equivalent final evidence before the larger
+request refactor.
+
+**Work**:
+
+- Add `src/shared/adapters/usageUtils.ts` and tests for presence-aware alias selection and total
+  derivation:
+  - use presence checks/`??`, never truthiness;
+  - preserve explicit zero;
+  - omit unavailable fields;
+  - derive total only when all required inputs are present;
+  - omit the usage object when it contains no evidence;
+  - identify provider-reported versus library-derived fields.
+- Add an LLM termination mapper with provider-specific raw and normalized output.
+- Update every built-in adapter:
+  - Gemini: remove `usageMetadata || {}` and `|| 0`;
+  - Mistral: remove alias truthiness and fabricated zeros/stops;
+  - Anthropic streaming: merge partial usage without zero-filling;
+  - OpenAI/OpenRouter/llama.cpp: retain existing correct absence behavior while adding evidence;
+  - Mock: mark character counts as heuristic rather than provider usage.
+- Capture the pre-normalization textual answer in every built-in before flattening/cleanup; retain
+  ordered JSON-safe raw parts for Anthropic, Gemini, and any provider where typed-part boundaries
+  would otherwise be lost. Capture before llama.cpp marker/nothink cleanup and service-level
+  thinking-tag extraction.
+- Add raw-answer accounting only when a profile can count the captured sequence honestly; record
+  source and reasoning inclusion as included/excluded/unknown.
+- Preserve usage, termination, and raw evidence in partial failures even when `choices` is empty.
+- Preserve the existing non-stream retry policy. This phase makes final returned partial failures
+  truthful but does not decide whether an intermediate partial-generating attempt should suppress
+  an otherwise configured retry.
+- Keep Mock's legacy `response.usage` fields for compatibility while adding explicit heuristic
+  method/source evidence.
+
+**Steps**:
+
+- [x] Implement and exhaustively test shared usage normalization.
+- [x] Add raw/normalized termination while retaining `finish_reason`.
+- [x] Update non-stream response mappers provider by provider.
+- [x] Update stream accumulators so usage-only and termination-only evidence survives failure.
+- [x] Capture pre-normalization content without changing normalized output.
+- [x] Add compatibility tests for every old response field.
+
+**Verification**:
+
+- [x] Missing Gemini/Mistral/Anthropic streaming fields remain absent.
+- [x] Explicit zero survives every provider mapper.
+- [x] Derived total appears only when its operands exist and is labeled derived.
+- [x] Mistral partial failure with no stop reason remains unknown.
+- [x] Provider-native and normalized termination are both available.
+- [x] Generic OpenAI-compatible `length` remains `limit: "unknown"`.
+- [x] Raw content survives tag extraction, llama.cpp cleanup, structured parsing, and partial
+      failure.
+- [x] Raw parts preserve provider order/type boundaries, and raw-answer evidence always identifies
+      method, profile/revision, source, and native/extracted reasoning inclusion.
+- [x] Provider completion usage is not mislabeled as visible-answer-only usage.
+- [x] Mock retains its legacy usage fields while labeling their heuristic provenance.
+
+### Phase 3: Canonical Credential-Free Adapter Preparation
+
+**Goal**: Move every deterministic provider transformation ahead of inspection and make dispatch
+consume an immutable prepared command.
+
+**Work**:
+
+- Refactor existing adapter builders instead of creating parallel formatting implementations:
+  - `OpenAIClientAdapter.prepareCompletionRequest`;
+  - `AnthropicClientAdapter.prepareMessageRequest`;
+  - `GeminiClientAdapter.prepareGenerateContentRequest`;
+  - `MistralClientAdapter.prepareCompletionRequest`;
+  - `OpenRouterClientAdapter.prepareCompletionRequest`;
+  - `LlamaCppClientAdapter.prepareCompletionRequest`;
+  - Mock request generation.
+- Split semantic preparation from:
+  - SDK client construction;
+  - API key validation/use;
+  - abort-controller/timer creation;
+  - transport timeout options;
+  - inference invocation.
+- Assign explicit adapter and request-shape revision constants to each built-in adapter.
+- Add revision-guard fixtures so changing canonical shape snapshots requires an intentional
+  request-shape revision bump.
+- Make mode-specific behavior part of the command:
+  - OpenAI/OpenRouter/llama.cpp `stream` and `stream_options`;
+  - Mistral stream selector;
+  - Anthropic/Gemini SDK operation choice.
+- Add explicit structured-output delivery:
+  - preserve native delivery as the default;
+  - for prompt delivery, inject one versioned schema instruction at a deterministic provider-aware
+    position before final message conversion;
+  - expose that instruction and delivery mode in inspection;
+  - label prompt delivery as instruction-only rather than provider-enforced;
+  - suppress native schema/JSON response fields in prompt mode;
+  - branch capability validation on the selected delivery;
+  - ensure prepared accounting consumes the injected form.
+- Build the normalized request view from the same final semantic representation used by dispatch.
+- Clone only as required to protect a frozen canonical payload from SDK mutation; do not rerun
+  formatting or capability selection.
+- Preserve current validation diagnostics and exact provider request shapes.
+
+**Steps**:
+
+- [x] Implement the adapter capability in Mock as the deterministic reference.
+- [x] Migrate OpenAI and OpenRouter, sharing helpers only where payload semantics are identical.
+- [x] Migrate Anthropic, preserving message reorder/alternation and strict-schema behavior.
+- [x] Migrate Gemini, separating the API client and abort timer from semantic config.
+- [x] Migrate Mistral.
+- [x] Migrate llama.cpp while leaving exact counting/state binding for Phase 6.
+- [x] For each adapter, compare the prepared command/view with existing SDK-call request assertions.
+
+**Verification**:
+
+- [x] Every built-in adapter prepares without retrieving credentials.
+- [x] Complete and stream modes expose all mode-specific semantic differences.
+- [x] Schema normalization, system conversion, reasoning, routing, grammar, and logprobs are fixed
+      before inspection.
+- [x] Native and prompt schema delivery are mutually exclusive; prompt instructions are stable,
+      visible, counted, and dispatch-identical.
+- [x] Repeated dispatches use semantically identical provider payloads.
+- [x] Existing adapter request-shape tests pass without silent behavior changes.
+- [x] An unchanged legacy adapter still satisfies the public adapter interface; capability guards
+      report prepared/counting support unavailable rather than fabricated.
+
+### Phase 4: Service-Owned Prepared Calls and Output-Limit Provenance
+
+**Goal**: Expose the public lifecycle and route convenience APIs through it.
+
+**Work**:
+
+- Add a service-owned `WeakMap` from frozen public handles to private prepared records.
+- Split the current `LLMService.prepareRequest()` responsibilities into:
+  1. resolve/validate/filter and record settings provenance;
+  2. adapter credential-free preparation;
+  3. public handle registration;
+  4. credentialed dispatch.
+- Add:
+  - `prepareMessage(request, { mode })`;
+  - `inspectPrepared(handle)`;
+  - `sendPrepared(completeHandle, options)`;
+  - `streamPrepared(streamHandle, options)`.
+- Resolve and validate API keys only at dispatch.
+- Revalidate bindings immediately before each physical inference attempt.
+- Make `sendMessage()` equivalent to prepare-complete plus `sendPrepared()`.
+- Make `streamMessage()` equivalent to prepare-stream plus `streamPrepared()`.
+- Allocate the public stream attempt ID at `streamMessage()` entry, before validation,
+  preparation, credential resolution, or provider iteration. `streamPrepared()` likewise
+  allocates before handle validation.
+- Implement the service stream coordinator before exposing the public stream wrappers:
+  - manually drive the adapter iterator;
+  - race each pending `next()` against cancellation;
+  - emit `REQUEST_ABORTED` without depending on adapter signal compliance;
+  - suppress a late `next()` result;
+  - make `return()` cleanup bounded/detached so a noncompliant iterator cannot hang termination.
+- Extend settings resolution to carry per-field source. Introduce an explicit verified hard output
+  limit separate from a default setting:
+  - clamp only against verified provider/model caps;
+  - report `library_default` for the current global 4096-token default when it is the winner;
+  - report the final field actually sent, its requested value when applicable, and separate
+    clamp-cap value/source;
+  - report absent when max tokens were filtered or cannot be proven;
+  - mark whether the provider counts visible output, visible plus reasoning, provider-defined
+    units, or unknown.
+- Keep preset and nested-setting precedence byte-for-byte compatible unless a separate defect is
+  identified and approved.
+
+**Steps**:
+
+- [x] Add provenance-bearing output-limit resolution while retaining existing setting precedence.
+- [x] Add verified output-limit metadata to model/provider config without inferring it for unknown
+      models.
+- [x] Implement handle creation, lookup, mode checks, and inspection.
+- [x] Implement complete dispatch and retry against the same adapter command.
+- [x] Implement the stream coordinator and its cancellation/terminal primitives.
+- [x] Convert both convenience methods to thin wrappers.
+- [x] Add artifact security, redispatch, retry identity, credential timing, and wrapper-equivalence
+      tests.
+
+**Verification**:
+
+- [x] Forged, serialized, cross-service, and mode-mismatched handles fail before dispatch.
+- [x] Inspection mutation cannot alter dispatch.
+- [x] Preparation never calls `ApiKeyProvider`; dispatch does.
+- [x] Complete transport retries reuse the same frozen semantic command and revalidate each
+      observable binding.
+- [x] Concurrent redispatches do not share mutable attempt, usage, cancellation, or SDK state.
+- [x] Content-modifying fallbacks require a newly visible prepared call.
+- [x] Wrapper and explicit flows send the same provider representation and normalize the same
+      response.
+- [x] Output-limit value, provenance, clamp, filtering, and reasoning-count semantics are tested.
+- [x] Validation, preparation, handle, and API-key failures in public streams carry the allocated
+      attempt ID even when no provider iterator is opened.
+- [x] Cancellation terminates when a fake adapter's `next()` and `return()` never settle.
+
+### Phase 5: Token Profiles and Certified Structural Bounds
+
+**Goal**: Add reusable, evidence-bearing counting without increasing the runtime tokenizer bundle.
+
+**Work**:
+
+- Create `src/llm/tokenization/` with:
+  - public profile/count/certificate types;
+  - a token-profile registry and provider/model mapping table;
+  - versioned provider framing calculators that consume canonical prepared views;
+  - tiktoken-backed synchronous content profiles;
+  - certified bound registry and arithmetic;
+  - focused tests and directory summaries.
+- Keep tokenizer profile revision separate from model-to-profile mapping revision.
+- Define ordinary-text/special-token semantics explicitly so special-token literals cannot silently
+  trigger a heuristic fallback.
+- Keep `countTokens()` behavior compatible, but implement/document it as the legacy numeric wrapper.
+- Keep content-only counting distinct from prepared-message accounting. A cloud adapter populates
+  `promptAccounting.count` only when a versioned calculator covers its final message order,
+  system placement, schema/tool or prompt-fallback framing, and mode semantics. Otherwise prepared
+  accounting is unavailable even when content strings can be counted.
+- The composed prepared-count method is no stronger than its weakest component: exact only when
+  tokenizer and framing are exact, otherwise `model`/`heuristic` with explicit uncertainty.
+- Initially register only proof-backed profiles/certificates:
+  - same-profile bounds only where the pinned decoder/encoder round trip proves them;
+  - `cl100k_base` and `o200k_base` byte-complete profiles when their rank/config hashes match known
+    revisions;
+  - model aliases mapped to those profiles only when verified;
+  - all other pairs unavailable.
+- Derive and check certificate constants from the installed rank artifacts:
+  - source maximum decoded bytes per ordinary generation token;
+  - the source decoder's invalid-byte/replacement-character behavior and any UTF-8 re-encoding
+    expansion;
+  - terminal decoder flush, excluded special/control tokens, and cross-token byte composition;
+  - target byte completeness/maximum tokens per byte;
+  - fixed/affine additions where a profile needs them.
+- Add:
+  - `retokenizationUpperBound`;
+  - `codePointBoundToTokenUpperBound`;
+  - separate heuristic estimation only if a real consumer requires it.
+- Validate nonnegative safe integers and fail unavailable/typed-error on overflow.
+- Do not add another runtime tokenizer dependency.
+
+**Steps**:
+
+- [x] Implement profile identity, revision hashing, mapping revision, and exact/model/heuristic evidence.
+- [x] Refactor tiktoken construction/cache around encoding profiles rather than model strings.
+- [x] Derive certificate properties from pinned rank artifacts at runtime and check in the small
+      expected hashes/constants/provenance.
+- [x] Implement safe bound arithmetic and registry lookup.
+- [x] Leave cloud prepared-message accounting unavailable until a verified framing calculator
+      covers the entire canonical provider view.
+- [x] Wire profile-backed raw-answer counts into the evidence fields introduced in Phase 2.
+- [x] Add deterministic property/adversarial tests over ASCII, dense scripts, astral characters,
+      combining sequences, variation selectors, ZWJ emoji, controls/NUL, special-token literals,
+      maximum scalars, and documented lone-surrogate behavior.
+- [x] Add the double-margin and exact-profile zero-margin fixtures against real evidence results.
+
+**Verification**:
+
+- [x] Unknown models/pairs are explicitly heuristic or unavailable.
+- [x] No concatenated-content count is exposed as prepared-message accounting; each available cloud
+      count includes every framing component or is marked unavailable.
+- [x] Certificate availability is disabled when tokenizer data hashes do not match.
+- [x] Retokenization tests generate/decode source token sequences and confirm actual target counts
+      never exceed the bound.
+- [x] Code-point tests confirm actual target counts never exceed `4 * codePoints` only for profiles
+      whose byte-complete proof supports it.
+- [x] `Number.MAX_SAFE_INTEGER` boundaries cannot round down or overflow.
+- [x] Numeric margin test obtains `700` from a certified-bound API fixture that has no margin
+      parameter, then shows raw 1000, margin 100, output 150, and slack 25 evaluate `875 <= 900`;
+      a duplicate margin produces `975 <= 900` and is rejected by the test.
+- [x] An exact prepared-count fixture uses `heuristicMargin = 0`, keeps any explicit
+      `countingSlack` separate, and never manufactures uncertainty.
+- [x] The production dependency list and installed tokenizer-asset footprint do not grow.
+
+### Phase 6: llama.cpp Exact Counting and Stale-State Rejection
+
+**Goal**: Count the exact active-template input and bind it to observable server/model/template
+state.
+
+**Work**:
+
+- Extend `LlamaCppServerClient` with:
+  - typed chat-input-token response;
+  - `countChatCompletionInputTokens(finalBody, options)`;
+  - typed `/props` fields needed for binding;
+  - optional router-mode model selector for `/props`;
+  - signal/timeout handling for count and revalidation calls.
+- Add a canonical fingerprint helper over stable observable fields from `/props` and `/v1/models`.
+- Ensure the count endpoint receives the exact final mode-bound llama.cpp body, including:
+  messages, system fallback, template kwargs, structured output, grammar, and other framing fields.
+- Record:
+  - exact count and active-profile evidence;
+  - chat-template hash;
+  - server-state fingerprint;
+  - build/model metadata suitable for diagnostics without exposing the absolute model path.
+- Re-read state immediately before each physical inference dispatch and reject a mismatch with
+  `PREPARED_CALL_STALE`.
+- Bypass the old capability cache for binding validation; key cached detected capabilities by the
+  state fingerprint or invalidate them when the fingerprint changes.
+- If the endpoint or required state fields are unavailable on an older server, report exact
+  prepared counting/binding unavailable; never relabel raw `/tokenize` as exact chat counting.
+
+**Steps**:
+
+- [x] Add server-client methods and mocked endpoint tests.
+- [x] Add canonical fingerprint serialization/hash tests.
+- [x] Wire exact counting into llama.cpp adapter preparation.
+- [x] Wire fresh state revalidation into each complete retry and stream dispatch.
+- [x] Test model/template/build changes and unchanged redispatch.
+- [x] Add a llama.cpp-only `prepared-counting.e2e.test.ts` comparison between inspection count and
+      terminal `usage.prompt_tokens`, using module-scope `describe.skip` gating.
+
+**Verification**:
+
+- [x] Exact count changes when template kwargs change.
+- [x] Stream-only transport fields do not accidentally change the counted semantic input.
+- [x] Same observable state redispatches; changed model/template/build state rejects before
+      inference.
+- [x] Router-mode model selection is encoded and tested.
+- [x] Older/unavailable endpoints degrade to unavailable without using concatenated `/tokenize`.
+- [x] Optional live e4b smoke test reproduces the count endpoint and fingerprint flow.
+
+### Phase 7: Streaming Lifecycle Hardening and Provider Evidence
+
+**Goal**: Complete the Phase 4 coordinator across every provider and stress it against
+noncompliant iterators, evidence-only events, and cancellation races.
+
+**Work**:
+
+- Harden the focused service-level stream coordinator introduced before public stream exposure.
+- Stamp the ID allocated at `streamMessage()`/`streamPrepared()` entry on every public event.
+- Compose the caller signal with a service-owned abort controller.
+- Manually drive `iterator.next()` and race it with cancellation; do not rely on an adapter to
+  observe the composed signal.
+- While open:
+  - forward start/content/reasoning/usage events;
+  - preserve partial evidence;
+  - accept the first complete/error terminal only.
+- On terminal:
+  - post-process the final/partial response once;
+  - yield exactly one terminal;
+  - close the provider iterator and return;
+  - suppress all later adapter events/errors.
+- If the adapter ends without a terminal, synthesize one provider error.
+- On cancellation, emit one `REQUEST_ABORTED` terminal if the consumer is still iterating.
+- In `finally`, invoke iterator `return()` where available and abort internal transport, but bound
+  or detach cleanup so a never-resolving `return()` cannot block the terminal envelope.
+- Never wrap physical streams in `withRetry`; redispatching the prepared stream creates a new
+  attempt ID.
+
+**Steps**:
+
+- [x] Extend the lifecycle tests with deliberately noncompliant fake adapters.
+- [x] Update built-in accumulators to preserve usage-only/raw evidence and cooperate with
+      cancellation.
+- [x] Add pre-provider failure, late-result suppression, and abandonment cleanup tests without
+      promising delivery to an abandoned consumer.
+- [x] Add an iterator whose `next()` and `return()` never resolve and prove cancellation still emits
+      one terminal promptly.
+
+**Verification**:
+
+- [x] Every emitted event has the same attempt ID for one invocation.
+- [x] Delta-after-complete, error-after-complete, and two-terminal adapters expose one terminal.
+- [x] End-without-terminal becomes one error.
+- [x] Validation/preparation/API-key failures have the invocation ID allocated before provider
+      dispatch.
+- [x] Cancellation after deltas preserves partial evidence and ends with `REQUEST_ABORTED`.
+- [x] Cancellation does not wait for a noncompliant `next()` or `return()`.
+- [x] No post-cancellation delta is exposed.
+- [x] Redispatch uses a new attempt ID and no transparent retry occurs.
+- [x] Streaming and non-streaming final usage/termination fixtures are semantically equivalent.
+
+### Phase 8: Capability Metadata, Exports, and Documentation
+
+**Goal**: Make the new contract discoverable and maintainable without overstating provider facts.
+
+**Work**:
+
+- Extend `ModelCapabilities`/`ModelInfo` additively with:
+  - context-window provenance;
+  - content and prepared-message counting availability;
+  - tokenizer/profile and mapping identity;
+  - structured-output delivery;
+  - expected prompt/completion usage reporting;
+  - limit-termination distinguishability;
+  - runtime-only active-server exact-count status.
+- Preserve `getModelCapabilities()` as static/no-credential/no-network. Active llama.cpp facts belong
+  to prepared inspection, not static preflight.
+- Export public prepared, token-profile, certificate, accounting, and stream types/functions from
+  `src/index.ts` and relevant subpath barrels.
+- Add a packed-tarball consumer typecheck fixture/script that imports only the published surface and
+  verifies mode-bound handles, required service event IDs, output provenance, and an unchanged
+  legacy adapter implementation against generated declarations. It packs/installs in an isolated
+  temporary directory and cleans that directory after the check.
+- Add `genai-lite-docs/prepared-calls-and-accounting.md`.
+  - **Durable audience/question**: application authors who need to inspect the exact semantic
+    request, budget safely, and interpret incomplete provider evidence.
+  - **Unique ownership**: the end-to-end contract spans service dispatch, token profiles, capacity
+    boundaries, response evidence, and streaming; no existing page owns that combined workflow.
+- Add `docs/dev/token-bound-certificates.md`.
+  - **Durable audience/question**: maintainers adding or revising proof-backed tokenizer profiles.
+  - **Unique ownership**: certificate derivation, artifact hashes, decoded-output domain, Unicode
+    assumptions, and adversarial verification are maintenance rules rather than general API usage.
+- Update:
+  - `README.md` and `genai-lite-docs/index.md` with short examples/links;
+  - `genai-lite-docs/llm-service.md`;
+  - `genai-lite-docs/prompting-utilities.md`;
+  - `genai-lite-docs/llamacpp-integration.md`;
+  - `genai-lite-docs/providers-and-models.md`;
+  - `genai-lite-docs/core-concepts.md`;
+  - `genai-lite-docs/typescript-reference.md`;
+  - `docs/dev/adding-models-and-providers.md`.
+- Correct the existing usage docs that show optional token fields as required and the existing
+  `service.registerAdapter()` examples for a method that is not public.
+- Refresh the hand-maintained root/`src`/`src/llm`/client/service/prompting summaries, add summaries
+  for the new tokenization directory, and update the context-build date in `AGENTS.md`.
+
+**Verification**:
+
+- [x] Examples use mode-bound preparation and check preparation failures.
+- [x] Docs distinguish semantic request view from credentials/transport.
+- [x] Docs show explicit native versus prompt structured-output delivery and state that injected
+      prompt/schema framing is included in prepared accounting.
+- [x] Docs distinguish point count, structural bound, counting slack, and application margin.
+- [x] The `875 <= 900` single-margin example appears exactly and is not contradicted elsewhere.
+- [x] Provider capability tables use unknown/unavailable rather than assumptions.
+- [x] llama.cpp docs distinguish `/tokenize` from exact chat-input counting.
+- [x] TypeScript reference matches optional usage fields and attempt-ID guarantees.
+- [x] New public exports are present in built output.
+- [x] The packed consumer fixture typechecks without relying on source-only paths.
+
+### Phase 9: Full Verification and Issue Closure
+
+**Goal**: Verify compatibility, package integrity, and every acceptance criterion before resolving
+the issue.
+
+**Work**:
+
+- Run focused suites after each phase.
+- Run build and the complete Jest suite.
+- Run the production dependency audit and package dry run.
+- Verify CommonJS exports from `dist` and declaration-level use from a packed temporary consumer.
+- Run the gated local llama.cpp E2E suite while the user-provided server is healthy; do not start or
+  stop it implicitly during normal unit tests.
+- Perform a file-by-file acceptance-criteria audit against the issue.
+- When complete:
+  - add the issue `## Resolution` with date/version;
+  - mark criteria complete;
+  - set issue status to `RESOLVED`;
+  - set plan status to `COMPLETE`;
+  - move both files to `docs/archive/`;
+  - update references to their archived locations.
+
+**Commands**:
+
+```powershell
+npm.cmd test -- LLMService.prepared.test.ts LLMService.accounting.test.ts
+npm.cmd test -- OpenAIClientAdapter.test.ts AnthropicClientAdapter.test.ts GeminiClientAdapter.test.ts
+npm.cmd test -- MistralClientAdapter.test.ts OpenRouterClientAdapter.test.ts LlamaCppClientAdapter.test.ts
+npm.cmd test -- TokenProfileRegistry.test.ts CertifiedTokenBounds.test.ts StreamLifecycle.test.ts
+npm.cmd run build
+npm.cmd test
+npm.cmd audit --omit=dev --audit-level=high
+npm.cmd pack --dry-run
+node -e "const lib = require('./dist'); console.log('Exports:', Object.keys(lib));"
+npm.cmd run test:packed-api
+npx.cmd jest --config jest.e2e.config.js prepared-counting.e2e.test.ts --runInBand
+```
+
+Do not use the full E2E command for this issue unless paid cloud calls are separately authorized.
+The llama.cpp-only suite uses the existing availability gate without converting missing
+availability into a pass.
+
+**Verification**:
+
+- [x] Focused suites pass.
+- [x] Full build and unit suite pass.
+- [x] Production audit has no high-severity blocking advisory.
+- [x] Package contents and exports include the new public API and no tokenizer asset explosion.
+- [x] Packed CommonJS/runtime and TypeScript/declaration consumer fixtures pass, including the
+      unchanged legacy adapter compile fixture.
+- [x] Local exact-count E2E passes when the server is available.
+- [x] Every issue acceptance criterion has a test or documented verification.
+
+## Phase Checkpoints and Rollback
+
+- Keep each phase buildable and commit it separately with the required DCO sign-off.
+- Preserve existing request-shape and response-compatibility tests as migration guards until the
+  final phase; do not delete the old builder path before its replacement passes parity tests.
+- If a provider migration fails parity, revert that provider's phase commit while leaving completed
+  additive evidence types/utilities intact.
+- Keep token-profile/certificate registrations fail-closed and data-driven so a bad mapping or hash
+  can be disabled without removing the prepared-call API.
+- Keep exact llama.cpp counting optional: older/incompatible servers continue through the prepared
+  path with accounting marked unavailable, so the integration can be rolled back independently.
+- Archive the issue and plan only after the complete verification gate; until then they remain the
+  authoritative open-work record at the repository root.
+
+## Testing Strategy
+
+### Service contract
+
+- Handle ownership, forgery, serialization, mode mismatch, immutability, credential timing.
+- Explicit versus convenience path equivalence.
+- Sequential/concurrent same-payload redispatch and per-attempt stale checks.
+- Output-limit filtering, library-default/request provenance, separate cap/clamp provenance, and
+  reasoning semantics.
+- Attempt IDs on failures before preparation, credentials, or provider iteration.
+
+### Provider request parity
+
+- Preserve every existing outbound SDK-call assertion.
+- Add a corresponding prepared-view assertion for system conversion, schemas, reasoning, sampling,
+  routing, grammar, logprobs, and mode.
+- Compare native and explicit prompt structured-output delivery, including injected instruction
+  placement, mutual exclusion, framing count, and request-shape revision.
+- Assert no provider builder runs again during dispatch/retry.
+
+### Accounting matrix
+
+For every built-in adapter:
+
+- usage absent;
+- partial usage object;
+- explicit zero;
+- derived total with both operands;
+- usage-only partial failure;
+- raw and normalized termination;
+- absent/unknown termination;
+- ambiguous limit;
+- raw pre-normalization content;
+- ordered raw parts and reasoning-inclusion provenance;
+- partial raw content;
+- provider versus derived/heuristic evidence.
+- nonempty available accounting and exact/non-exact uncertainty invariants.
+
+### Certificate verification
+
+- Exhaustively verify constants against pinned tokenizer artifacts.
+- Use deterministic seeded generation rather than adding a runtime dependency.
+- Exercise decoded source-token sequences, adversarial Unicode, special-token literals, safe
+  integer edges, invalid-byte replacement and terminal flush, unsupported pairs, artifact hash
+  mismatches, same-profile round trips, the single-margin fixture, and exact zero-margin behavior.
+
+### Stream lifecycle
+
+- Normal sequence, cancellation before/after deltas, thrown adapter, terminal then delta, terminal
+  then throw, two terminals, silent end, abandoned iterator, never-settling `next()`/`return()`,
+  usage-only partial, pre-provider failures, and redispatch.
+
+## Risks and Mitigations
+
+- **Large cross-cutting refactor**: land phases as small conventional commits and keep old request
+  shape assertions active throughout.
+- **SDK mutation of request objects**: store a frozen canonical representation and use a mechanical
+  transport clone, never rerun semantic formatting.
+- **Output-limit ambiguity**: represent the library default and request provenance separately from
+  verified cap/clamp provenance; report unknown/absent instead of treating every default as a cap.
+- **Cloud exact count versus no credentials**: keep authoritative authenticated endpoints out of
+  preparation; require versioned full-framing calculators for prepared point counts and otherwise
+  report unavailable.
+- **GGUF identity ambiguity**: use live endpoint count for the prepared text and observable state
+  binding; do not certify cross-token bounds for unpinned conversions.
+- **Server TOCTOU**: revalidate immediately before inference and document that only observable
+  state is covered.
+- **Certificate overclaim**: define decoded-output domain, verify artifact hashes, document proofs,
+  and fail closed on unsupported profiles or overflow.
+- **Double-applied margin**: APIs accept no application margin and the numeric regression locks the
+  single application boundary.
+- **Stream cleanup races**: centralize terminal/cancellation state in the service, race pending
+  iterator reads explicitly, bound/detach cleanup, and test noncompliant adapters.
+- **Legacy adapter source compatibility**: keep prepared capability optional, keep adapter/public
+  stream event requirements separate, and typecheck an unchanged implementation from the package.
+- **Documentation drift**: update API docs, provider matrix, TypeScript reference, and context
+  summaries in the same change.
+
+## Open Questions
+
+No product decision is currently blocking implementation. If exploration during execution reveals
+that a provider/model hard output cap or tokenizer mapping cannot be verified, that metadata will
+remain unknown/unavailable rather than being inferred.
+
+---
+
+## Resolution
+
+Completed on 2026-07-29 for v0.15.0. All nine phases were implemented and
+verified. Three specialized final reviews covered prepared-call architecture,
+tokenization/documentation, and response-accounting/streaming behavior; no
+high- or medium-severity findings remain.

--- a/docs/dev/adding-models-and-providers.md
+++ b/docs/dev/adding-models-and-providers.md
@@ -616,6 +616,24 @@ For entirely new LLM providers (not just models):
 5. Export any new types from `src/index.ts` if needed
 6. Add presets to `src/config/llm-presets.json` (see [Adding Presets](#adding-presets))
 
+Built-in adapters should also implement the optional prepared-call capability:
+split deterministic semantic formatting from SDK/client/credential/transport
+construction, assign explicit adapter and request-shape revisions, and dispatch
+the frozen command without rebuilding it. Leave prepared-message counting
+unavailable unless a versioned calculator covers the complete canonical view.
+See [Token-Bound Certificates](token-bound-certificates.md) before adding a
+token profile or structural certificate. Legacy external implementations of
+`ILLMClientAdapter` remain source-compatible because these methods are optional.
+
+Streaming adapters return `AdapterLLMStreamEvent`. When a provider chunk
+contains raw parts, usage provenance, or termination details, emit
+`adapter_evidence` events for the entire chunk before yielding its first public
+`start`, delta, or usage event. `LLMService` suppresses adapter-only events but
+uses them to build truthful cancellation/failure partials. This ordering matters:
+a caller may abort immediately after any public event, so evidence that was
+already present in the received provider chunk must not remain behind that
+yield.
+
 ## Adding New Image Providers
 
 For entirely new image generation providers:

--- a/docs/dev/token-bound-certificates.md
+++ b/docs/dev/token-bound-certificates.md
@@ -1,0 +1,63 @@
+# Maintaining Token-Bound Certificates
+
+Token-bound certificates are small, proof-backed constants and derivations.
+They must never include an application/session heuristic safety margin.
+
+## Required proof material
+
+For every profile revision, pin and verify:
+
+- tokenizer implementation and rank/config hash;
+- ordinary-token domain and special/control-token exclusions;
+- byte completeness of the target vocabulary;
+- maximum decoded bytes per ordinary source token;
+- decoder behavior for invalid bytes and terminal flush;
+- UTF-8 re-encoding expansion;
+- affine constants and overflow behavior.
+
+Keep the tokenizer profile revision separate from the model-to-profile mapping
+revision. If an installed rank hash differs, the profile and its certificates
+must become unavailable rather than silently using the new data.
+
+## Current derivations
+
+The `cl100k_base` and `o200k_base` profiles are pinned to the bundled
+`js-tiktoken@1.0.21` rank/config hashes. The registry derives byte completeness
+and the maximum token byte length from those artifacts.
+
+The Unicode code-point certificate uses:
+
+```text
+codePoints * 4 UTF-8 bytes/code point * 1 target token/byte
+```
+
+The ordinary-source retokenization certificate uses:
+
+```text
+sourceTokens
+  * maximum source decoded bytes/token
+  * 3 worst-case replacement UTF-8 expansion
+  * 1 target token/byte
+```
+
+This is intentionally conservative. Do not replace it with a same-profile
+`n -> n` rule without a complete decoder/encoder round-trip proof covering
+invalid bytes, terminal flush, cross-token composition, and special-token
+exclusions.
+
+## Verification
+
+Tests must cover:
+
+- ASCII and dense non-Latin scripts;
+- combining sequences and variation selectors;
+- astral characters and ZWJ emoji;
+- controls and NUL;
+- special-token literals treated as ordinary text;
+- maximum Unicode scalars and documented lone-surrogate behavior;
+- decoded ordinary source-token sequences;
+- zero, negative, unsafe-integer, and overflow boundaries.
+
+The numeric margin fixture must obtain its structural bound from the production
+certificate API and prove that the application formula applies the heuristic
+margin once. Certificate functions must not accept a margin parameter.

--- a/e2e-tests/prepared-counting.e2e.test.ts
+++ b/e2e-tests/prepared-counting.e2e.test.ts
@@ -1,0 +1,62 @@
+import { LLMService } from "../src";
+import type {
+  LLMFailureResponse,
+  PreparedCompleteCall,
+  PreparedRequestInspection,
+} from "../src/llm/types";
+import type { ApiKeyProvider } from "../src/types";
+
+const LLAMACPP_AVAILABLE =
+  process.env.E2E_LLAMACPP_AVAILABLE === "true";
+
+const keyProvider: ApiKeyProvider = async (providerId) =>
+  providerId === "llamacpp" ? "not-needed" : null;
+
+const service = new LLMService(keyProvider, {
+  logLevel: "silent",
+  retry: { maxRetries: 0 },
+  timeoutMs: 30000,
+});
+
+(LLAMACPP_AVAILABLE ? describe : describe.skip)(
+  "llama.cpp prepared counting E2E",
+  () => {
+    it("matches exact inspection count to terminal provider usage", async () => {
+      const prepared = await service.prepareMessage(
+        {
+          providerId: "llamacpp",
+          modelId: "llamacpp",
+          messages: [{ role: "user", content: "Reply with exactly: OK" }],
+          settings: {
+            maxTokens: 16,
+            temperature: 0,
+            reasoning: { enabled: false },
+          },
+        },
+        { mode: "complete" }
+      );
+      expect((prepared as LLMFailureResponse).object).not.toBe("error");
+
+      const inspection = await service.inspectPrepared(
+        prepared as PreparedCompleteCall
+      );
+      expect((inspection as LLMFailureResponse).object).not.toBe("error");
+      const inspected = inspection as PreparedRequestInspection;
+      expect(inspected.promptAccounting.status).toBe("available");
+
+      const response = await service.sendPrepared(
+        prepared as PreparedCompleteCall
+      );
+      expect(response.object).toBe("chat.completion");
+      if (
+        response.object === "chat.completion" &&
+        inspected.promptAccounting.status === "available" &&
+        inspected.promptAccounting.count
+      ) {
+        expect(response.usage?.prompt_tokens).toBe(
+          inspected.promptAccounting.count.tokens
+        );
+      }
+    });
+  }
+);

--- a/genai-lite-docs/core-concepts.md
+++ b/genai-lite-docs/core-concepts.md
@@ -1,5 +1,10 @@
 # Core Concepts
 
+Applications that budget model context should use the evidence contract in
+[Prepared Calls and Token Accounting](prepared-calls-and-accounting.md).
+Certified library bounds contain structural allowances only. Subtract an
+application/session heuristic margin once at the capacity boundary.
+
 Fundamental patterns and concepts used across genai-lite's LLM and Image services.
 
 ## Contents
@@ -359,6 +364,9 @@ interface ILLMClientAdapter {
   ): AsyncIterable<LLMStreamEvent>;
 }
 
+// Public service streams add one stable ID per physical invocation:
+type LLMServiceStreamEvent = LLMStreamEvent & { attemptId: string };
+
 // Image Adapter
 interface ImageProviderAdapter {
   readonly id: ImageProviderId;
@@ -372,26 +380,17 @@ interface ImageProviderAdapter {
 }
 ```
 
-### Adapter Registry
+### Adapter Contract
 
-Register custom adapters for additional providers:
+`ILLMClientAdapter` is exported for lower-level integrations, but `LLMService`
+does not expose a public `registerAdapter()` method. Built-in adapters implement
+the optional prepared-call methods. Existing external adapter implementations
+remain source-compatible; prepared capability is reported as unavailable when
+those optional methods are absent.
 
-```typescript
-import { LlamaCppClientAdapter } from 'genai-lite';
-
-const service = new LLMService(fromEnvironment);
-
-service.registerAdapter(
-  'llamacpp-large',
-  new LlamaCppClientAdapter({ baseURL: 'http://localhost:8081' })
-);
-
-const response = await service.sendMessage({
-  providerId: 'llamacpp-large',
-  modelId: 'llamacpp',
-  messages: [{ role: 'user', content: 'Hello!' }]
-});
-```
+Custom adapters do not assign attempt IDs. `LLMService` stamps their events and
+exposes `AsyncIterable<LLMServiceStreamEvent>` from its public streaming
+methods.
 
 ## Logging Configuration
 

--- a/genai-lite-docs/index.md
+++ b/genai-lite-docs/index.md
@@ -20,6 +20,7 @@ Complete documentation for genai-lite - A lightweight, portable TypeScript libra
 
 ### API Reference
 - **[LLM Service](llm-service.md)** - Text generation and chat
+- **[Prepared Calls & Token Accounting](prepared-calls-and-accounting.md)** - Canonical inspection, certified bounds, and truthful evidence
 - **[Image Service](image-service.md)** - Image generation (cloud and local)
 - **[llama.cpp Integration](llamacpp-integration.md)** - Local LLM inference
 

--- a/genai-lite-docs/llamacpp-integration.md
+++ b/genai-lite-docs/llamacpp-integration.md
@@ -157,40 +157,35 @@ export LLAMACPP_API_BASE_URL=http://127.0.0.1:8080  # Default
 
 ### Multiple Servers
 
-```typescript
-import { LLMService, LlamaCppClientAdapter } from 'genai-lite';
-
-const service = new LLMService(async () => 'not-needed');
-
-service.registerAdapter(
-  'llamacpp-small',
-  new LlamaCppClientAdapter({ baseURL: 'http://127.0.0.1:8080' })
-);
-
-service.registerAdapter(
-  'llamacpp-large',
-  new LlamaCppClientAdapter({ baseURL: 'http://localhost:8081' })
-);
-
-const response = await service.sendMessage({
-  providerId: 'llamacpp-small',
-  modelId: 'llamacpp',
-  messages: [{ role: 'user', content: 'Hello!' }]
-});
-```
+`LLMService` does not expose a public adapter-registration method. Configure
+`LLAMACPP_API_BASE_URL` before constructing the service. Applications that need
+simultaneous differently configured local endpoints should isolate those
+configurations in separate processes or use the lower-level exported adapter
+interface deliberately.
 
 ### Health Checking
 
 ```typescript
-import { LlamaCppClientAdapter } from 'genai-lite';
+import { LlamaCppServerClient, LLMService } from 'genai-lite';
 
-const adapter = new LlamaCppClientAdapter({
-  baseURL: 'http://127.0.0.1:8080',
-  checkHealth: true
-});
+const server = new LlamaCppServerClient('http://127.0.0.1:8080');
+const health = await server.getHealth();
+if (health.status !== 'ok') throw new Error(`llama.cpp: ${health.status}`);
 
-service.registerAdapter('llamacpp', adapter);
+const service = new LLMService(async () => 'not-needed');
 ```
+
+### Exact Prepared-Message Counting
+
+Raw `/tokenize` counts content only and does not apply the active chat template.
+`prepareMessage()` instead sends the final mode-bound completion body to
+`/v1/chat/completions/input_tokens`. When the current server exposes the
+required `/props` and `/v1/models` state, inspection reports an exact prompt
+count plus server/template fingerprints. `sendPrepared()` and
+`streamPrepared()` re-read those observable fields and reject changed state
+before inference.
+
+See [Prepared Calls and Token Accounting](prepared-calls-and-accounting.md).
 
 ## Automatic Capability Detection
 

--- a/genai-lite-docs/llm-service.md
+++ b/genai-lite-docs/llm-service.md
@@ -8,6 +8,7 @@ Complete guide to text generation and chat completions using genai-lite's LLMSer
 - [Basic Usage](#basic-usage) - Simple message sending
 - [Capability Preflight](#capability-preflight) - Check provider/model support before sending
 - [Streaming Text](#streaming-text) - Token deltas from streaming-capable providers
+- [Prepared Calls and Accounting](prepared-calls-and-accounting.md) - Inspect and budget the exact semantic request
 - [Structured Output](#structured-output) - Guaranteed JSON responses with schema validation
 - [Reasoning Mode](#reasoning-mode) - Advanced problem-solving with native reasoning
 - [Thinking Tag Fallback](#thinking-tag-fallback) - Structured reasoning for non-reasoning models
@@ -36,6 +37,10 @@ The `LLMService` class provides a unified interface for text generation across m
 - Preset management for common configurations
 - Streaming text deltas for providers that implement streaming
 - Consistent error handling
+- Credential-free, mode-bound prepared requests with immutable inspection
+
+For applications that enforce context boundaries or need lossless accounting
+evidence, see [Prepared Calls and Token Accounting](prepared-calls-and-accounting.md).
 
 ## Basic Usage
 
@@ -189,7 +194,13 @@ type LLMStreamEvent =
   | { type: 'usage'; usage: LLMUsage }
   | { type: 'complete'; response: LLMResponse }
   | { type: 'error'; error: LLMFailureResponse };
+
+type LLMServiceStreamEvent = LLMStreamEvent & { attemptId: string };
 ```
+
+`LLMStreamEvent` is the source-compatible custom-adapter event shape.
+`streamMessage()` and `streamPrepared()` emit `LLMServiceStreamEvent`; all
+events from one physical invocation share its `attemptId`.
 
 ### Provider Support
 

--- a/genai-lite-docs/prepared-calls-and-accounting.md
+++ b/genai-lite-docs/prepared-calls-and-accounting.md
@@ -1,0 +1,182 @@
+# Prepared Calls and Token Accounting
+
+Use prepared calls when an application must inspect the final semantic provider
+request, enforce a context boundary, or retain truthful response evidence.
+`sendMessage()` and `streamMessage()` remain convenient wrappers over this same
+path.
+
+## Prepare, inspect, and dispatch
+
+```typescript
+import {
+  LLMService,
+  fromEnvironment,
+} from "genai-lite";
+
+const service = new LLMService(fromEnvironment);
+const result = await service.prepareMessage(
+  {
+    providerId: "openai",
+    modelId: "gpt-4.1-mini",
+    messages: [{ role: "user", content: "Return a short answer." }],
+    settings: { maxTokens: 200 },
+  },
+  { mode: "complete" }
+);
+
+if ("object" in result) {
+  throw new Error(result.error.message);
+}
+
+const prepared = result;
+const inspection = await service.inspectPrepared(prepared);
+if ("object" in inspection) {
+  throw new Error(inspection.error.message);
+}
+
+const response = await service.sendPrepared(prepared);
+```
+
+Preparation is credential-free. API keys, abort signals, timeout state, SDK
+clients, and authorization headers are created or resolved only at dispatch.
+The inspection view is an immutable library-owned semantic representation, not
+the provider SDK request class.
+
+A prepared handle:
+
+- belongs to the `LLMService` instance that created it;
+- is immutable, reusable, and not serializable;
+- is fixed to `complete` or `stream` mode;
+- rejects forged, deserialized, cross-service, and wrong-mode use.
+
+Complete retries redispatch the same frozen semantic command. Observable local
+bindings are revalidated before every physical inference request.
+
+## Streaming
+
+```typescript
+const result = await service.prepareMessage(request, { mode: "stream" });
+if ("object" in result) {
+  throw new Error(result.error.message);
+}
+
+for await (const event of service.streamPrepared(result)) {
+  console.log(event.attemptId, event.type);
+}
+```
+
+Every event from one invocation has the same `attemptId`. A consumed stream has
+exactly one `complete` or `error` terminal. genai-lite does not automatically
+retry a physical stream. Redispatching a stream handle starts a new attempt with
+a new ID.
+
+If a stream is cancelled or fails, its `partialResponse` retains raw content,
+usage provenance, answer accounting, and termination evidence that the provider
+had already delivered. Built-in adapters record all evidence in a received
+provider chunk before exposing any public event from that chunk, including when
+usage, content, and a finish reason arrive together.
+
+## Structured-output delivery
+
+Native delivery is the default:
+
+```typescript
+structuredOutput: {
+  name: "answer",
+  schema,
+  delivery: "native",
+}
+```
+
+Use `delivery: "prompt"` explicitly when the schema should be injected as a
+versioned instruction:
+
+```typescript
+structuredOutput: {
+  name: "answer",
+  schema,
+  delivery: "prompt",
+}
+```
+
+Prompt delivery suppresses the provider-native schema field. Inspection marks
+it as `instruction_only`, and the injected instruction is part of the inspected
+messages and prepared accounting. It is guidance, not provider enforcement.
+
+For native delivery, inspection reports `provider` when the final provider
+payload contains the schema and `json_only` when that provider can request JSON
+syntax but cannot enforce the supplied schema. The optional inspected `name`
+and `schema` are derived from the final payload rather than copied from the
+original settings.
+
+## Prompt and output evidence
+
+`promptAccounting` is either unavailable or contains a point count, a certified
+upper bound, or both:
+
+- `exact`, `model`, and `heuristic` describe point-count strength.
+- `uncertaintyTokens` describes non-exact evidence. It is not a capacity margin.
+- `upperBound` is present only for a proof-backed structural certificate.
+- Content-only tokenization is not reported as prepared-message accounting.
+
+`outputTokenLimit` reports the value actually serialized, its source
+(`request`, `preset`, `model_default`, `library_default`, or
+`provider_default`), any verified hard-limit clamp, and what the provider counts.
+An ordinary model default is not treated as a hard limit.
+
+For llama.cpp, preparation uses
+`/v1/chat/completions/input_tokens` over the final mode-bound body. The exact
+count is bound to hashes of the active model, server build, and chat template.
+Dispatch rejects a detected change as `PREPARED_CALL_STALE`.
+
+## Certified structural bounds and margins
+
+`countTextTokens()` returns exact ordinary-text evidence for a pinned profile.
+`retokenizationUpperBound()` and `codePointBoundToTokenUpperBound()` return
+certificate-backed structural bounds. These APIs have no consumer-margin
+parameter and never add a session heuristic margin.
+
+Apply an application margin exactly once:
+
+```typescript
+const effectiveCapacity = rawCapacity - heuristicMargin;
+const fits =
+  promptTokenUpperBound + outputBound + countingSlack <= effectiveCapacity;
+```
+
+Numeric example:
+
+```text
+rawCapacity = 1000
+heuristicMargin = 100
+effectiveCapacity = 900
+promptTokenUpperBound = 700
+outputBound = 150
+countingSlack = 25
+875 <= 900
+```
+
+Charging the margin again gives `975 <= 900`, which is false. For an exact
+profile, use `heuristicMargin = 0`; keep any explicit `countingSlack` separate.
+
+Retokenization certificates cover text decoded from the declared number of
+ordinary source-generation tokens. They exclude special/control tokens and do
+not assume a same-profile `n -> n` identity proof.
+
+## Response evidence
+
+Provider usage fields remain optional. A missing field is not rewritten to
+zero; a provider-reported zero remains zero. `usageEvidence` records whether a
+field is provider-reported, derived, or heuristic.
+
+Choices retain:
+
+- `rawContent` before library cleanup;
+- ordered `rawContentParts` where the provider exposes typed parts;
+- `rawAnswerAccounting` when a verified content profile is available;
+- the legacy `finish_reason`;
+- `termination.rawReason` plus a normalized termination classification.
+
+Generic reasons such as `length` remain ambiguous unless the provider supplied
+enough evidence to distinguish an output limit from a context limit. Partial
+failures preserve usage and accumulated choice evidence where available.

--- a/genai-lite-docs/prompting-utilities.md
+++ b/genai-lite-docs/prompting-utilities.md
@@ -17,6 +17,13 @@ Helper functions for working with prompts, templates, and LLM responses.
 genai-lite provides utilities for prompt engineering and content manipulation via the `genai-lite/prompting` subpath.
 
 **Template & Content**: `renderTemplate`, `countTokens`, `getSmartPreview`
+
+For evidence-bearing model profiles and certified structural bounds, use
+`countTextTokens`, `resolveTokenProfile`, `retokenizationUpperBound`, and
+`codePointBoundToTokenUpperBound`. `countTokens` remains the compatible numeric
+wrapper and can fall back to a heuristic. Content-only counts are distinct from
+fully prepared message accounting; see
+[Prepared Calls and Token Accounting](prepared-calls-and-accounting.md).
 **Prompt Engineering**: `parseRoleTags`, `parseStructuredContent`, `extractRandomVariables`, `parseTemplateWithMetadata`, `extractInitialTaggedContent`, `extractMarkerDelimitedContent`
 
 **Note**: For model-aware message creation, use `LLMService.createMessages()` which combines these utilities with model context. See [LLM Service - Creating Messages from Templates](llm-service.md#creating-messages-from-templates).

--- a/genai-lite-docs/providers-and-models.md
+++ b/genai-lite-docs/providers-and-models.md
@@ -1,5 +1,10 @@
 # Providers & Models
 
+Capability metadata is intentionally conservative: unknown model/tokenizer
+mappings are reported as unavailable rather than borrowing an unrelated exact
+profile. Static capability preflight performs no network requests; active
+llama.cpp exact-count status appears only in prepared inspection.
+
 Complete reference of all supported AI providers and models in genai-lite.
 
 ## Contents

--- a/genai-lite-docs/typescript-reference.md
+++ b/genai-lite-docs/typescript-reference.md
@@ -40,6 +40,16 @@ import {
   extractMarkerDelimitedContent
 } from 'genai-lite/prompting';
 
+// Evidence-bearing token profiles and structural certificates
+import {
+  countTextTokens,
+  estimateTextTokens,
+  resolveTokenProfile,
+  getTokenProfileById,
+  codePointBoundToTokenUpperBound,
+  retokenizationUpperBound
+} from 'genai-lite';
+
 // llama.cpp
 import { LlamaCppClientAdapter, LlamaCppServerClient } from 'genai-lite';
 ```
@@ -70,6 +80,24 @@ import type {
   LLMResponse,
   LLMFailureResponse,
   LLMStreamEvent,
+  LLMServiceStreamEvent,
+  PreparedCall,
+  PreparedCompleteCall,
+  PreparedStreamCall,
+  PreparedRequestInspection,
+  PreparedRequestValue,
+  PreparedStructuredOutputView,
+  PreparedPromptAccounting,
+  PreparedPromptTokenUpperBound,
+  EffectiveOutputTokenLimit,
+  LLMTermination,
+  LLMRawContentPart,
+  LLMRawAnswerAccounting,
+  LLMUsageEvidence,
+  TokenProfile,
+  TokenProfileResolution,
+  TokenCountResult,
+  TokenBoundResult,
   LLMError,
   LLMSettings,
   LlamaCppSettings,
@@ -131,6 +159,8 @@ import type {
   LlamaCppSlotsResponse,
   LlamaCppModel,
   LlamaCppModelsResponse,
+  LlamaCppChatInputTokensResponse,
+  LlamaCppUtilityRequestOptions,
   GgufModelPattern
 } from 'genai-lite';
 ```
@@ -180,10 +210,15 @@ interface LLMResponse {
   object: 'chat.completion';
   id: string;
   created: number;
+  provider: string;
   model: string;
   choices: Array<{
     index: number;
     message: LLMMessage;
+    rawContent?: string;
+    rawContentParts?: LLMRawContentPart[];
+    rawAnswerAccounting?: LLMRawAnswerAccounting;
+    termination?: LLMTermination;
     reasoning?: string;
     reasoning_details?: any;    // Provider-specific reasoning details (e.g. OpenRouter)
     logprobs?: TokenLogprob[];  // Per-token log probs (when settings.logprobs requested)
@@ -192,10 +227,11 @@ interface LLMResponse {
     finish_reason: string;
   }>;
   usage?: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
   };
+  usageEvidence?: LLMUsageEvidence;
 }
 
 // Per-token log probability entry (OpenAI-compatible shape; also from llama.cpp)
@@ -234,14 +270,82 @@ type LLMStreamEvent =
   | {
       type: 'usage';
       usage: {
-        prompt_tokens: number;
-        completion_tokens: number;
-        total_tokens: number;
+        prompt_tokens?: number;
+        completion_tokens?: number;
+        total_tokens?: number;
       };
     }
   | { type: 'complete'; response: LLMResponse }
   | { type: 'error'; error: LLMFailureResponse };
+
+type LLMServiceStreamEvent = LLMStreamEvent & { attemptId: string };
 ```
+
+Custom adapters emit the legacy-compatible `LLMStreamEvent` shape without an
+attempt ID. Every `LLMService` public stream event is an
+`LLMServiceStreamEvent` and carries the same `attemptId`, including validation,
+preparation, handle, and API-key failures.
+
+### Prepared calls
+
+```typescript
+type PreparedCallMode = 'complete' | 'stream';
+type PreparedCompleteCall = PreparedCall<'complete'>;
+type PreparedStreamCall = PreparedCall<'stream'>;
+
+interface PreparedStructuredOutputView {
+  delivery: 'native' | 'prompt';
+  enforcement: 'provider' | 'json_only' | 'instruction_only';
+  name?: string;
+  schema?: PreparedRequestValue;
+  promptRevision?: string;
+}
+
+type PreparedPromptAccounting =
+  | {
+      status: 'available';
+      count: {
+        tokens: number;
+        method: 'exact' | 'model' | 'heuristic';
+        tokenizerId?: string;
+        tokenProfileRevision?: string;
+        uncertaintyTokens?: number;
+      };
+      upperBound?: PreparedPromptTokenUpperBound;
+    }
+  | {
+      status: 'available';
+      upperBound: PreparedPromptTokenUpperBound;
+    }
+  | { status: 'unavailable' };
+
+interface EffectiveOutputTokenLimit {
+  tokens: number;
+  source:
+    | 'request'
+    | 'preset'
+    | 'model_default'
+    | 'library_default'
+    | 'provider_default';
+  requestedTokens?: number;
+  clamp?: {
+    tokens: number;
+    source: 'model_hard_limit' | 'provider_hard_limit';
+  };
+  counts: 'visible_only' | 'visible_and_reasoning' | 'provider_defined' | 'unknown';
+}
+
+service.prepareMessage(request, { mode: 'complete' });
+service.inspectPrepared(prepared);
+service.sendPrepared(completePrepared, options);
+service.streamPrepared(streamPrepared, options);
+```
+
+Prepared handles are nominal, service-owned, immutable, and nonserializable.
+Inspection exposes `PreparedProviderRequestView`, `PreparedPromptAccounting`,
+`EffectiveOutputTokenLimit`, and `PreparedRequestBindings`. See
+[Prepared Calls and Token Accounting](prepared-calls-and-accounting.md) for the
+full evidence contract.
 
 ### Capability Types
 
@@ -631,19 +735,30 @@ interface LlamaCppEmbeddingResponse {
 
 interface LlamaCppInfillResponse {
   content: string;
-  stop: boolean;
-  tokens_predicted: number;
-  tokens_evaluated: number;
+  tokens?: number[];
+  stop?: boolean;
 }
 
 interface LlamaCppPropsResponse {
-  total_slots: number;
-  default_generation_settings: Record<string, any>;
+  assistant_name?: string;
+  user_name?: string;
+  default_generation_settings?: Record<string, unknown>;
+  total_slots?: number;
+  model_alias?: string;
+  model_path?: string;
+  chat_template?: string;
+  chat_template_caps?: Record<string, unknown>;
+  bos_token?: string;
+  eos_token?: string;
+  build_info?: Record<string, unknown> | string;
+  [key: string]: unknown;
 }
 
 interface LlamaCppSlot {
   id: number;
-  state: 0 | 1;
+  state: number;
+  prompt?: string;
+  [key: string]: any;
 }
 
 interface LlamaCppSlotsResponse {
@@ -651,11 +766,28 @@ interface LlamaCppSlotsResponse {
 }
 
 interface LlamaCppModel {
-  model: string;
+  id: string;
+  object?: string;
+  created?: number;
+  owned_by?: string;
+  aliases?: string[];
+  meta?: Record<string, unknown>;
 }
 
 interface LlamaCppModelsResponse {
+  object: string;
   data: LlamaCppModel[];
+}
+
+interface LlamaCppChatInputTokensResponse {
+  input_tokens: number;
+  object?: string;
+}
+
+interface LlamaCppUtilityRequestOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  model?: string;
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "genai-lite",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-lite",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
         "@google/genai": "^2.10.0",
         "@mistralai/mistralai": "^1.15.1",
-        "js-tiktoken": "^1.0.20",
+        "js-tiktoken": "1.0.21",
         "openai": "^6.7.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -43,13 +43,14 @@
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "test:e2e": "npm run build && jest --config jest.e2e.config.js",
-    "test:e2e:reasoning": "npm run build && jest --config jest.e2e.config.js reasoning.e2e.test.ts"
+    "test:e2e:reasoning": "npm run build && jest --config jest.e2e.config.js reasoning.e2e.test.ts",
+    "test:packed-api": "npm run build && node scripts/verify-packed-prepared-api.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.115.0",
     "@google/genai": "^2.10.0",
     "@mistralai/mistralai": "^1.15.1",
-    "js-tiktoken": "^1.0.20",
+    "js-tiktoken": "1.0.21",
     "openai": "^6.7.0"
   },
   "devDependencies": {

--- a/scripts/verify-packed-prepared-api.js
+++ b/scripts/verify-packed-prepared-api.js
@@ -1,0 +1,152 @@
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), "genai-lite-packed-api-"));
+const npmCli = process.env.npm_execpath;
+if (!npmCli) {
+  throw new Error("Run this verification through npm run test:packed-api.");
+}
+
+function runNpm(args, options) {
+  return execFileSync(process.execPath, [npmCli, ...args], options);
+}
+
+try {
+  const packed = JSON.parse(
+    runNpm(
+      ["pack", "--json", "--pack-destination", temp],
+      {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "inherit"],
+      }
+    )
+  );
+  const tarball = path.join(temp, packed[0].filename);
+  const consumer = path.join(temp, "consumer");
+  fs.mkdirSync(consumer);
+  fs.writeFileSync(
+    path.join(consumer, "package.json"),
+    JSON.stringify({
+      private: true,
+      dependencies: { "genai-lite": `file:${tarball}` },
+      devDependencies: { typescript: ">=5.3.3" },
+    })
+  );
+  fs.writeFileSync(
+    path.join(consumer, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        module: "Node16",
+        moduleResolution: "Node16",
+        target: "ES2020",
+        esModuleInterop: true,
+        skipLibCheck: true,
+      },
+      include: ["consumer.ts"],
+    })
+  );
+  fs.writeFileSync(
+    path.join(consumer, "consumer.ts"),
+    `
+import {
+  LLMService,
+  codePointBoundToTokenUpperBound,
+  getTokenProfileById,
+  type AdapterLLMStreamEvent,
+  type ILLMClientAdapter,
+  type InternalLLMChatRequest,
+  type LLMFailureResponse,
+  type LLMResponse,
+  type LLMServiceStreamEvent,
+  type LLMStreamEvent,
+} from "genai-lite";
+
+class LegacyAdapter implements ILLMClientAdapter {
+  async sendMessage(
+    request: InternalLLMChatRequest,
+    apiKey: string
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    void apiKey;
+    return {
+      id: "id",
+      provider: request.providerId,
+      model: request.modelId,
+      created: 1,
+      choices: [],
+      object: "chat.completion",
+    };
+  }
+  async *streamMessage(): AsyncIterable<LLMStreamEvent> {
+    yield { type: "content_delta", delta: "legacy", index: 0 };
+  }
+}
+void (null as unknown as LegacyAdapter);
+void (null as unknown as AdapterLLMStreamEvent);
+
+const service = new LLMService(async () => "not-needed");
+async function verify(): Promise<void> {
+  const complete = await service.prepareMessage({
+    providerId: "mock",
+    modelId: "mock",
+    messages: [{ role: "user", content: "x" }],
+  }, { mode: "complete" });
+  if ("object" in complete) return;
+  const inspection = await service.inspectPrepared(complete);
+  if ("object" in inspection) return;
+  const provenance: string | undefined = inspection.outputTokenLimit?.source;
+  void provenance;
+  await service.sendPrepared(complete);
+  // @ts-expect-error complete handles cannot be streamed
+  service.streamPrepared(complete);
+
+  const stream = await service.prepareMessage({
+    providerId: "mock",
+    modelId: "mock",
+    messages: [{ role: "user", content: "x" }],
+  }, { mode: "stream" });
+  if ("object" in stream) return;
+  // @ts-expect-error stream handles cannot be sent as complete calls
+  await service.sendPrepared(stream);
+  for await (const event of service.streamPrepared(stream)) {
+    const id: string = event.attemptId;
+    void id;
+  }
+}
+void verify;
+
+const event = null as unknown as LLMServiceStreamEvent;
+const requiredAttemptId: string = event.attemptId;
+void requiredAttemptId;
+const profile = getTokenProfileById("o200k_base");
+if (profile) codePointBoundToTokenUpperBound(175, profile);
+`
+  );
+
+  runNpm(
+    [
+      "install",
+      "--ignore-scripts",
+      "--package-lock=false",
+      "--no-audit",
+      "--no-fund",
+    ],
+    { cwd: consumer, stdio: "inherit" }
+  );
+  execFileSync(
+    process.execPath,
+    [path.join(consumer, "node_modules", "typescript", "bin", "tsc"), "--noEmit"],
+    {
+      cwd: consumer,
+      stdio: "inherit",
+    }
+  );
+  console.log("Packed prepared-call consumer typecheck passed.");
+} finally {
+  fs.rmSync(temp, { recursive: true, force: true });
+}

--- a/src/.summary_long.md
+++ b/src/.summary_long.md
@@ -3,6 +3,13 @@
 ## Overview
 The src directory is the heart of the genai-lite library, containing the main entry point and foundational type definitions. This directory establishes the public API surface and core abstractions that make the library flexible and environment-agnostic. It serves as the boundary between the library's internal implementation and its consumers, providing a clean, well-organized interface for interacting with multiple AI providers through a unified API. The directory now includes a sophisticated model presets system that allows applications to ship with pre-configured model settings while maintaining full flexibility for customization.
 
+## Prepared-call public surface
+
+`index.ts` now exports mode-bound prepared handles and service options,
+inspection/accounting/termination/usage evidence, token profiles and
+certificate functions, and typed llama.cpp chat-input preflight responses.
+Legacy adapter methods remain exported and source-compatible.
+
 ## Key Components
 ### index.ts
 ## Overview

--- a/src/.summary_short.md
+++ b/src/.summary_short.md
@@ -4,7 +4,7 @@ Purpose: Contains the main source code for the genai-lite library, providing the
 
 ## Files:
 
-- `index.ts`: Exports the public API of the genai-lite library, providing access to the LLM service with createMessages method (and its result type), per-call SendMessageOptions, retry utilities (withRetry, DEFAULT_RETRY_POLICY, and retry policy types), model preset types, configuration options, thinking extraction settings, API key management functionality, llama.cpp integration (adapter, server client, and types), OpenRouter and Mistral integration (adapters and configs), GGUF detection helpers (detectGgufCapabilities, KNOWN_GGUF_MODELS, GgufModelPattern), utility functions (createFallbackModelInfo), template metadata + marker-delimited content parsing utilities, and configurable logging.
+- `index.ts`: Exports the public API, including mode-bound prepared calls, token profiles/certificates, truthful response evidence, stream attempt IDs, llama.cpp exact input-count types, services, adapters, prompting utilities, retries, and logging.
 - `types.ts`: Defines the core type interface for API key retrieval functionality across different AI providers.
 
 ## Subdirectories:

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,13 @@ export type { ApiKeyProvider, PresetMode } from "./types";
 
 // --- LLM Service ---
 export { LLMService } from "./llm/LLMService";
-export type { LLMServiceOptions, SendMessageOptions, StreamMessageOptions, CreateMessagesResult } from "./llm/LLMService";
+export type {
+  LLMServiceOptions,
+  SendMessageOptions,
+  StreamMessageOptions,
+  PrepareMessageOptions,
+  CreateMessagesResult,
+} from "./llm/LLMService";
 
 // --- Retry Utilities ---
 export { withRetry, DEFAULT_RETRY_POLICY } from "./shared/services/withRetry";
@@ -39,6 +45,8 @@ export type {
   LlamaCppSlotsResponse,
   LlamaCppModel,
   LlamaCppModelsResponse,
+  LlamaCppChatInputTokensResponse,
+  LlamaCppUtilityRequestOptions,
 } from "./llm/clients/LlamaCppServerClient";
 
 // --- OpenRouter Integration ---
@@ -88,6 +96,22 @@ export type {
 // --- Utilities ---
 export { renderTemplate } from "./prompting/template";
 export { countTokens, getSmartPreview, extractRandomVariables } from "./prompting/content";
+export {
+  TOKEN_PROFILE_MAPPING_REVISION,
+  codePointBoundToTokenUpperBound,
+  countTextTokens,
+  estimateTextTokens,
+  getTokenProfileById,
+  resolveTokenProfile,
+  retokenizationUpperBound,
+} from "./llm/tokenization";
+export type {
+  TokenBoundResult,
+  TokenCountResult,
+  TokenProfile,
+  TokenProfileId,
+  TokenProfileResolution,
+} from "./llm/tokenization";
 export { parseStructuredContent, parseRoleTags, extractInitialTaggedContent, extractMarkerDelimitedContent, parseTemplateWithMetadata } from "./prompting/parser";
 export type { TemplateMetadata } from "./prompting/parser";
 export { createFallbackModelInfo, detectGgufCapabilities, KNOWN_GGUF_MODELS } from "./llm/config";

--- a/src/llm/.summary_long.md
+++ b/src/llm/.summary_long.md
@@ -3,6 +3,23 @@
 ## Overview
 The llm directory forms the core of the genai-lite library, housing the main LLM service implementation, comprehensive type definitions, and a sophisticated configuration system. This directory orchestrates interactions with multiple AI providers (OpenAI, Anthropic, Google Gemini, Mistral, OpenRouter, llama.cpp) through a unified interface while maintaining provider-specific customizations and capabilities. The architecture follows best practices with clear separation between service logic, configuration, and type definitions, all backed by thorough test coverage.
 
+## Canonical preparation and accounting
+
+`LLMService` owns opaque frozen handles in a `WeakMap`. Preparation resolves,
+validates, filters, applies provider formatting, and records output provenance
+without credentials. Dispatch resolves credentials, revalidates observable
+bindings, and reuses the same adapter command. The stream coordinator assigns
+one attempt ID, races cancellation against provider `next()`, suppresses late
+events, and emits exactly one terminal while detaching iterator cleanup.
+Adapter-only evidence events are consumed before public events from each
+provider chunk, so cancellation partials retain already-observed raw content,
+usage provenance, raw answer accounting, and termination evidence.
+
+`tokenization/` provides hash-verified cl100k/o200k content profiles and
+structural certificate arithmetic. Cloud prepared counts remain unavailable
+without verified framing; llama.cpp uses its active chat-template count
+endpoint and state fingerprints.
+
 ## Key Components
 ### LLMService.ts
 ## Overview

--- a/src/llm/.summary_short.md
+++ b/src/llm/.summary_short.md
@@ -4,7 +4,8 @@ Purpose: Contains the core LLM service implementation, type definitions, configu
 
 ## Files:
 
-- `LLMService.ts`: Orchestrates LLM requests across multiple AI providers by delegating to specialized services (PresetManager, AdapterRegistry, RequestValidator, SettingsManager, ModelResolver) while maintaining the unified public API, including createMessages that returns settings from template metadata and a unified retry/timeout/abort layer (withRetry) configurable via LLMServiceOptions.retry/timeoutMs and per-call SendMessageOptions.
+- `LLMService.ts`: Orchestrates canonical credential-free preparation, opaque WeakMap-owned handles, immutable inspection, credentialed prepared dispatch/retry, single-terminal stream coordination, adapter-only raw/provenance evidence retention for partial failures, output-limit provenance, response post-processing, and existing convenience/template APIs.
+- `LLMService.prepared.test.ts`: Tests handle security, credential timing, frozen retry identity, structured-output delivery, and adversarial stream lifecycles.
 - `LLMService.test.ts`: Tests the LLMService class to ensure proper initialization, request validation, API key handling, adapter routing, settings management, and provider/model information retrieval.
 - `LLMService.presets.test.ts`: Tests the configurable model presets system including default presets, extend mode, replace mode, and edge cases for preset management.
 - `LLMService.createMessages.test.ts`: Tests the unified prompt creation functionality that combines template rendering, model context injection, role tag parsing, and template metadata extraction.
@@ -12,3 +13,7 @@ Purpose: Contains the core LLM service implementation, type definitions, configu
 - `config.ts`: Defines the configuration registry for all supported LLM providers and models (openai, anthropic, gemini, mistral, llamacpp, openrouter, mock), including their capabilities, pricing, defaults, adapter mappings, and the createFallbackModelInfo helper for flexible model validation. Also holds the KNOWN_GGUF_MODELS catalog (38 patterns) with vendor sampling defaults (defaultSettings/reasoningDefaultSettings) and localReasoning toggle metadata, the detectGgufCapabilities helper, and validation for the new flat sampling settings (topK, minP, repeatPenalty, seed, logprobs) and llamacpp namespace.
 - `config.test.ts`: Tests the LLM configuration module's functionality including provider validation, model retrieval, settings management, and validation of LLM parameters.
 - `types.ts`: Defines comprehensive TypeScript interfaces and types for LLM (Large Language Model) interactions including messages, requests, responses (with LLMFailureResponse now including partialResponse field for validation errors, and LLMChoice.logprobs), flat sampling settings (topK, minP, repeatPenalty, seed, logprobs/topLogprobs) plus the llamacpp namespace (LlamaCppSettings: grammar, chatTemplateKwargs), TokenLogprob, provider configurations (with allowUnknownModels field for flexible model validation), reasoning settings, ModelInfo defaultSettings/reasoningDefaultSettings and LocalReasoningMetadata for detected GGUF models, thinking tag fallback settings, OpenRouter provider routing settings, and error handling structures (LLMError now carrying status/retryAfterMs).
+
+## Subdirectories
+
+- `tokenization/`: Hash-verified token profiles, exact content evidence, and certified structural bounds.

--- a/src/llm/LLMService.prepared.test.ts
+++ b/src/llm/LLMService.prepared.test.ts
@@ -1,0 +1,1044 @@
+import { LLMService } from "./LLMService";
+import type {
+  LLMFailureResponse,
+  LLMResponse,
+  PreparedCompleteCall,
+  PreparedStreamCall,
+  StructuredOutputSchema,
+} from "./types";
+import type {
+  AdapterLLMStreamEvent,
+  AdapterPreparationContext,
+  AdapterPreparationResult,
+  AdapterPreparedRequest,
+  AdapterRequestOptions,
+  ILLMClientAdapter,
+  InternalLLMChatRequest,
+} from "./clients/types";
+import { freezeProviderRequest } from "./clients/preparedAdapterUtils";
+import { createFallbackModelInfo } from "./config";
+
+function success(
+  request: InternalLLMChatRequest,
+  id = "fake-response"
+): LLMResponse {
+  return {
+    id,
+    provider: request.providerId,
+    model: request.modelId,
+    created: 1,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: "OK" },
+        rawContent: "OK",
+        finish_reason: "stop",
+      },
+    ],
+    object: "chat.completion",
+  };
+}
+
+class PreparedFakeAdapter implements ILLMClientAdapter {
+  preparedRequests: AdapterPreparedRequest[] = [];
+  dispatchRequests: AdapterPreparedRequest[] = [];
+  revalidations = 0;
+  sendResults: Array<LLMResponse | LLMFailureResponse> = [];
+  streamFactory?: (
+    request: InternalLLMChatRequest
+  ) => AsyncIterable<AdapterLLMStreamEvent>;
+
+  async prepareRequest(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult> {
+    const providerRequest = freezeProviderRequest({ request });
+    const prepared: AdapterPreparedRequest = {
+      mode: context.mode,
+      providerRequest,
+      requestView: Object.freeze({
+        operation: "fake.chat",
+        mode: context.mode,
+        messages: request.messages.map((message) => ({
+          role: message.role,
+          content: message.content,
+        })),
+        settings: {
+          model: request.modelId,
+          maxTokens: request.settings.maxTokens,
+          ...(context.mode === "stream" && { stream: true }),
+        },
+      }),
+      promptAccounting: { status: "unavailable" },
+      outputTokenLimit: context.outputTokenLimit,
+      bindings: {
+        adapterRevision: "fake-adapter-v1",
+        requestShapeRevision: "fake-request-v1",
+      },
+    };
+    this.preparedRequests.push(prepared);
+    return { prepared };
+  }
+
+  async revalidatePreparedRequest(): Promise<{ valid: true }> {
+    this.revalidations += 1;
+    return { valid: true };
+  }
+
+  async sendPrepared(
+    prepared: AdapterPreparedRequest
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    this.dispatchRequests.push(prepared);
+    const providerRequest = prepared.providerRequest as {
+      request: InternalLLMChatRequest;
+    };
+    return this.sendResults.shift() ?? success(providerRequest.request);
+  }
+
+  streamPrepared(
+    prepared: AdapterPreparedRequest
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    this.dispatchRequests.push(prepared);
+    const providerRequest = prepared.providerRequest as {
+      request: InternalLLMChatRequest;
+    };
+    return (
+      this.streamFactory?.(providerRequest.request) ??
+      this.defaultStream(providerRequest.request)
+    );
+  }
+
+  async sendMessage(
+    request: InternalLLMChatRequest
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    return success(request);
+  }
+
+  private async *defaultStream(
+    request: InternalLLMChatRequest
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    yield {
+      type: "start",
+      provider: request.providerId,
+      model: request.modelId,
+      id: "fake-stream",
+      created: 1,
+    };
+    yield { type: "content_delta", delta: "OK", index: 0 };
+    yield { type: "complete", response: success(request, "fake-stream") };
+  }
+}
+
+function registerFake(
+  service: LLMService,
+  fake: PreparedFakeAdapter
+): void {
+  (service as any).adapterRegistry.registerAdapter("mock", fake);
+}
+
+const request = {
+  providerId: "mock" as const,
+  modelId: "mock-model",
+  messages: [{ role: "user" as const, content: "Hello" }],
+  settings: { maxTokens: 123 },
+};
+
+async function collect(
+  events: AsyncIterable<unknown>
+): Promise<any[]> {
+  const result: any[] = [];
+  for await (const event of events) {
+    result.push(event);
+  }
+  return result;
+}
+
+describe("LLMService prepared calls", () => {
+  it("is credential-free, opaque, immutable, nonserializable, and dispatchable", async () => {
+    const keys = jest.fn(async () => "not-needed");
+    const service = new LLMService(keys, { logLevel: "silent" });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+
+    const handle = await service.prepareMessage(request, { mode: "complete" });
+    expect((handle as LLMFailureResponse).object).not.toBe("error");
+    expect(keys).not.toHaveBeenCalled();
+    expect(Object.isFrozen(handle)).toBe(true);
+    expect(() => JSON.stringify(handle)).toThrow("cannot be serialized");
+
+    const inspection = await service.inspectPrepared(
+      handle as PreparedCompleteCall
+    );
+    expect((inspection as any).request.messages[0].content).toBe("Hello");
+    expect(Object.isFrozen(inspection)).toBe(true);
+    expect((inspection as any).outputTokenLimit).toMatchObject({
+      tokens: 123,
+      source: "request",
+    });
+    expect(() => {
+      (inspection as any).request.messages[0].content = "mutated";
+    }).toThrow();
+
+    const response = await service.sendPrepared(
+      handle as PreparedCompleteCall
+    );
+    expect(response.object).toBe("chat.completion");
+    expect(keys).toHaveBeenCalledTimes(1);
+    expect(fake.dispatchRequests[0]).toBe(fake.preparedRequests[0]);
+  });
+
+  it("rejects forged, cross-service, and mode-mismatched handles", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    registerFake(service, new PreparedFakeAdapter());
+    const other = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const stream = await service.prepareMessage(request, { mode: "stream" });
+
+    const forged = await service.inspectPrepared({
+      mode: "complete",
+      toJSON: () => {
+        throw new Error();
+      },
+    } as PreparedCompleteCall);
+    expect((forged as LLMFailureResponse).error.code).toBe(
+      "INVALID_PREPARED_CALL"
+    );
+
+    const crossService = await other.inspectPrepared(
+      stream as PreparedStreamCall
+    );
+    expect((crossService as LLMFailureResponse).error.code).toBe(
+      "INVALID_PREPARED_CALL"
+    );
+
+    const mismatch = await service.sendPrepared(
+      stream as unknown as PreparedCompleteCall
+    );
+    expect((mismatch as LLMFailureResponse).error.code).toBe(
+      "PREPARED_CALL_MODE_MISMATCH"
+    );
+  });
+
+  it("reuses one frozen command across retries and revalidates each attempt", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+      retry: { maxRetries: 1, initialDelayMs: 1, maxDelayMs: 1 },
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    fake.sendResults.push(
+      {
+        provider: "mock",
+        model: "mock-model",
+        error: {
+          message: "retry",
+          code: "NETWORK_ERROR",
+          type: "connection_error",
+        },
+        object: "error",
+      },
+      success({
+        ...request,
+        settings: {} as any,
+      } as InternalLLMChatRequest)
+    );
+    const handle = await service.prepareMessage(request, { mode: "complete" });
+    const response = await service.sendPrepared(
+      handle as PreparedCompleteCall
+    );
+
+    expect(response.object).toBe("chat.completion");
+    expect(fake.dispatchRequests).toHaveLength(2);
+    expect(fake.dispatchRequests[0]).toBe(fake.dispatchRequests[1]);
+    expect(fake.revalidations).toBe(2);
+  });
+
+  it("keeps convenience and explicit preparation equivalent and permits concurrent redispatch", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+
+    const explicitHandle = await service.prepareMessage(request, {
+      mode: "complete",
+    });
+    const explicitResponse = await service.sendPrepared(
+      explicitHandle as PreparedCompleteCall
+    );
+    const convenienceResponse = await service.sendMessage(request);
+
+    expect(convenienceResponse).toEqual(explicitResponse);
+    expect(fake.preparedRequests).toHaveLength(2);
+    expect(fake.preparedRequests[1].requestView).toEqual(
+      fake.preparedRequests[0].requestView
+    );
+    expect(fake.preparedRequests[1].providerRequest).toEqual(
+      fake.preparedRequests[0].providerRequest
+    );
+
+    const reusableHandle = await service.prepareMessage(request, {
+      mode: "complete",
+    });
+    const [first, second] = await Promise.all([
+      service.sendPrepared(reusableHandle as PreparedCompleteCall),
+      service.sendPrepared(reusableHandle as PreparedCompleteCall),
+    ]);
+
+    expect(first).toEqual(second);
+    expect(fake.dispatchRequests.slice(-2)).toHaveLength(2);
+    expect(fake.dispatchRequests[fake.dispatchRequests.length - 2]).toBe(
+      fake.dispatchRequests[fake.dispatchRequests.length - 1]
+    );
+    expect(fake.revalidations).toBe(4);
+  });
+
+  it("makes prompt-delivered schemas visible once and suppresses native fields", async () => {
+    const keys = jest.fn(async () => "unused");
+    const service = new LLMService(keys, { logLevel: "silent" });
+    const schema: StructuredOutputSchema = {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    };
+    const promptHandle = await service.prepareMessage(
+      {
+        providerId: "openai",
+        modelId: "gpt-4.1",
+        messages: [{ role: "user", content: "Answer" }],
+        settings: {
+          structuredOutput: {
+            name: "result",
+            schema,
+            delivery: "prompt",
+          },
+        },
+      },
+      { mode: "complete" }
+    );
+    const nativeHandle = await service.prepareMessage(
+      {
+        providerId: "openai",
+        modelId: "gpt-4.1",
+        messages: [{ role: "user", content: "Answer" }],
+        settings: {
+          structuredOutput: {
+            name: "result",
+            schema,
+            delivery: "native",
+          },
+        },
+      },
+      { mode: "complete" }
+    );
+    const prompt = (await service.inspectPrepared(
+      promptHandle as PreparedCompleteCall
+    )) as any;
+    const native = (await service.inspectPrepared(
+      nativeHandle as PreparedCompleteCall
+    )) as any;
+    const promptContent = String(prompt.request.messages[0].content);
+
+    expect(keys).not.toHaveBeenCalled();
+    expect(
+      promptContent.match(/<GENAI_LITE_STRUCTURED_OUTPUT revision=/g)
+    ).toHaveLength(1);
+    expect(prompt.request.structuredOutput).toMatchObject({
+      delivery: "prompt",
+      enforcement: "instruction_only",
+      promptRevision: "prompt-schema-v1",
+    });
+    expect(prompt.request.settings.response_format).toBeUndefined();
+    expect(native.request.structuredOutput).toMatchObject({
+      delivery: "native",
+      enforcement: "provider",
+      schema: {
+        type: "object",
+        additionalProperties: false,
+      },
+    });
+    expect(native.request.settings.response_format).toBeDefined();
+  });
+
+  it("gives every event one attempt ID, suppresses late terminals, and changes IDs on redispatch", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    fake.streamFactory = (internal) => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "start",
+          provider: internal.providerId,
+          model: internal.modelId,
+          id: "id",
+          created: 1,
+        };
+        yield { type: "content_delta", delta: "A", index: 0 };
+        yield { type: "complete", response: success(internal) };
+        yield { type: "content_delta", delta: "late", index: 0 };
+        yield {
+          type: "error",
+          error: {
+            provider: internal.providerId,
+            model: internal.modelId,
+            error: { message: "late", code: "X", type: "server_error" },
+            object: "error",
+          },
+        };
+      },
+    });
+    const handle = await service.prepareMessage(request, { mode: "stream" });
+    const first = await collect(
+      service.streamPrepared(handle as PreparedStreamCall)
+    );
+    const second = await collect(
+      service.streamPrepared(handle as PreparedStreamCall)
+    );
+
+    expect(first.map((event) => event.type)).toEqual([
+      "start",
+      "content_delta",
+      "complete",
+    ]);
+    expect(new Set(first.map((event) => event.attemptId)).size).toBe(1);
+    expect(first[0].attemptId).not.toBe(second[0].attemptId);
+    expect(fake.dispatchRequests).toHaveLength(2);
+  });
+
+  it("turns an end-without-terminal stream into one error", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    fake.streamFactory = () => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "content_delta", delta: "partial", index: 0 };
+      },
+    });
+    const handle = await service.prepareMessage(request, { mode: "stream" });
+    const events = await collect(
+      service.streamPrepared(handle as PreparedStreamCall)
+    );
+    expect(events.map((event) => event.type)).toEqual([
+      "content_delta",
+      "error",
+    ]);
+    expect(events[1].error.error.message).toContain(
+      "without a terminal event"
+    );
+  });
+
+  it("cancels promptly when next() and return() never settle", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    const returnMock = jest.fn(
+      () => new Promise<IteratorResult<AdapterLLMStreamEvent>>(() => undefined)
+    );
+    fake.streamFactory = (internal) => ({
+      [Symbol.asyncIterator]() {
+        let first = true;
+        return {
+          next: () => {
+            if (first) {
+              first = false;
+              return Promise.resolve({
+                done: false as const,
+                value: {
+                  type: "start" as const,
+                  provider: internal.providerId,
+                  model: internal.modelId,
+                  id: "hung",
+                  created: 1,
+                },
+              });
+            }
+            if (!state.sentContent) {
+              state.sentContent = true;
+              return Promise.resolve({
+                done: false as const,
+                value: {
+                  type: "content_delta" as const,
+                  delta: "partial",
+                  index: 0,
+                  observedEvidence: {
+                    choice: {
+                      index: 0,
+                      rawContentDelta: "<think>raw</think>partial",
+                      rawContentParts: [{
+                        type: "text",
+                        text: "<think>raw</think>partial",
+                      }],
+                      rawAnswerAccounting: {
+                        tokens: 6,
+                        method: "heuristic" as const,
+                        source: "library" as const,
+                        reasoning: "unknown" as const,
+                      },
+                    },
+                  },
+                },
+              });
+            }
+            if (!state.sentUsage) {
+              state.sentUsage = true;
+              return Promise.resolve({
+                done: false as const,
+                value: {
+                  type: "usage" as const,
+                  usage: { prompt_tokens: 7 },
+                  observedEvidence: {
+                    choice: {
+                      index: 0,
+                      finishReason: "length",
+                      termination: {
+                        rawReason: "length",
+                        kind: "limit" as const,
+                        limit: "unknown" as const,
+                      },
+                    },
+                    usageEvidence: {
+                      prompt_tokens: {
+                        source: "provider" as const,
+                        providerField: "input_tokens",
+                      },
+                    },
+                  },
+                },
+              });
+            }
+            return new Promise(() => undefined);
+          },
+          return: returnMock,
+        };
+      },
+    });
+    const state = { sentContent: false, sentUsage: false };
+    const handle = await service.prepareMessage(request, { mode: "stream" });
+    const controller = new AbortController();
+    const iterator = service
+      .streamPrepared(handle as PreparedStreamCall, {
+        signal: controller.signal,
+      })
+      [Symbol.asyncIterator]();
+
+    const first = await iterator.next();
+    expect(first.value?.type).toBe("start");
+    expect((await iterator.next()).value?.type).toBe("content_delta");
+    expect((await iterator.next()).value?.type).toBe("usage");
+    const startedAt = Date.now();
+    const terminalPromise = iterator.next();
+    setTimeout(() => controller.abort(), 10);
+    const terminal = await terminalPromise;
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(terminal.value).toMatchObject({
+      type: "error",
+      error: {
+        error: { code: "REQUEST_ABORTED" },
+        partialResponse: {
+          choices: [{
+            message: { content: "partial" },
+            rawContent: "<think>raw</think>partial",
+            rawContentParts: [{
+              type: "text",
+              text: "<think>raw</think>partial",
+            }],
+            rawAnswerAccounting: {
+              tokens: 6,
+              method: "heuristic",
+            },
+            finish_reason: "length",
+            termination: {
+              rawReason: "length",
+              kind: "limit",
+              limit: "unknown",
+            },
+          }],
+          usage: { prompt_tokens: 7 },
+          usageEvidence: {
+            prompt_tokens: {
+              source: "provider",
+              providerField: "input_tokens",
+            },
+          },
+        },
+      },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+    expect(returnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps usage received in adapter evidence when cancellation wins before the public usage event", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    fake.streamFactory = (internal) => ({
+      [Symbol.asyncIterator]() {
+        let step = 0;
+        return {
+          next: () => {
+            step += 1;
+            if (step === 1) {
+              return Promise.resolve({
+                done: false as const,
+                value: {
+                  type: "adapter_evidence" as const,
+                  observedEvidence: {
+                    usage: {
+                      prompt_tokens: 9,
+                      completion_tokens: 3,
+                      total_tokens: 12,
+                    },
+                    usageEvidence: {
+                      prompt_tokens: {
+                        source: "provider" as const,
+                        providerField: "prompt_tokens",
+                      },
+                      completion_tokens: {
+                        source: "provider" as const,
+                        providerField: "completion_tokens",
+                      },
+                      total_tokens: {
+                        source: "provider" as const,
+                        providerField: "total_tokens",
+                      },
+                    },
+                  },
+                },
+              });
+            }
+            if (step === 2) {
+              return Promise.resolve({
+                done: false as const,
+                value: {
+                  type: "start" as const,
+                  provider: internal.providerId,
+                  model: internal.modelId,
+                  id: "usage-before-abort",
+                  created: 1,
+                },
+              });
+            }
+            return new Promise<IteratorResult<AdapterLLMStreamEvent>>(
+              () => undefined
+            );
+          },
+          return: () =>
+            Promise.resolve({
+              done: true as const,
+              value: undefined,
+            }),
+        };
+      },
+    });
+
+    const handle = await service.prepareMessage(request, { mode: "stream" });
+    const controller = new AbortController();
+    const iterator = service
+      .streamPrepared(handle as PreparedStreamCall, {
+        signal: controller.signal,
+      })
+      [Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value?.type).toBe("start");
+    const terminalPromise = iterator.next();
+    controller.abort();
+    const terminal = await terminalPromise;
+
+    expect(terminal.value).toMatchObject({
+      type: "error",
+      error: {
+        error: { code: "REQUEST_ABORTED" },
+        partialResponse: {
+          usage: {
+            prompt_tokens: 9,
+            completion_tokens: 3,
+            total_tokens: 12,
+          },
+          usageEvidence: {
+            prompt_tokens: {
+              source: "provider",
+              providerField: "prompt_tokens",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("merges observed usage evidence into an adapter partial failure", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    fake.streamFactory = (internal) => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "usage",
+          usage: { prompt_tokens: 11 },
+          observedEvidence: {
+            usageEvidence: {
+              prompt_tokens: {
+                source: "provider",
+                providerField: "input_tokens",
+              },
+            },
+          },
+        } as const;
+        yield {
+          type: "error",
+          error: {
+            provider: internal.providerId,
+            model: internal.modelId,
+            error: {
+              message: "provider failed",
+              code: "PROVIDER_ERROR",
+              type: "server_error",
+            },
+            object: "error",
+            partialResponse: {
+              id: "partial",
+              provider: internal.providerId,
+              model: internal.modelId,
+              created: 1,
+              choices: [{
+                index: 0,
+                message: { role: "assistant", content: "adapter partial" },
+                finish_reason: null,
+              }],
+            },
+          },
+        } as const;
+      },
+    });
+    const handle = await service.prepareMessage(request, { mode: "stream" });
+    const events = await collect(
+      service.streamPrepared(handle as PreparedStreamCall)
+    );
+
+    expect(events[events.length - 1]).toMatchObject({
+      type: "error",
+      error: {
+        partialResponse: {
+          choices: [{
+            message: { content: "adapter partial" },
+          }],
+          usage: { prompt_tokens: 11 },
+          usageEvidence: {
+            prompt_tokens: {
+              source: "provider",
+              providerField: "input_tokens",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("assigns attempt IDs to validation and credential failures before provider iteration", async () => {
+    const validationService = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const validationEvents = await collect(
+      validationService.streamMessage({
+        providerId: "unsupported" as any,
+        modelId: "none",
+        messages: [{ role: "user", content: "x" }],
+      })
+    );
+    expect(validationEvents[0]).toMatchObject({
+      type: "error",
+      attemptId: expect.any(String),
+    });
+
+    const keyService = new LLMService(async () => null, {
+      logLevel: "silent",
+    });
+    registerFake(keyService, new PreparedFakeAdapter());
+    const keyEvents = await collect(keyService.streamMessage(request));
+    expect(keyEvents[0]).toMatchObject({
+      type: "error",
+      attemptId: expect.any(String),
+      error: { error: { code: "API_KEY_ERROR" } },
+    });
+
+    const preparationService = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const preparationAdapter = new PreparedFakeAdapter();
+    preparationAdapter.prepareRequest = jest
+      .fn()
+      .mockRejectedValue(new Error("preparation failed"));
+    registerFake(preparationService, preparationAdapter);
+    const preparationEvents = await collect(
+      preparationService.streamMessage(request)
+    );
+    expect(preparationEvents[0]).toMatchObject({
+      type: "error",
+      attemptId: expect.any(String),
+      error: { error: { message: "preparation failed" } },
+    });
+
+    const handleEvents = await collect(
+      preparationService.streamPrepared({} as PreparedStreamCall)
+    );
+    expect(handleEvents[0]).toMatchObject({
+      type: "error",
+      attemptId: expect.any(String),
+      error: { error: { code: "INVALID_PREPARED_CALL" } },
+    });
+  });
+
+  it("rejects invalid runtime modes and adapter mode drift", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+
+    const invalid = await service.prepareMessage(
+      request,
+      { mode: "invalid" } as any
+    );
+    expect(invalid).toMatchObject({
+      object: "error",
+      error: { code: "INVALID_PREPARED_CALL" },
+    });
+    expect(fake.preparedRequests).toHaveLength(0);
+
+    fake.prepareRequest = jest.fn(
+      async (
+        internal: InternalLLMChatRequest,
+        context: AdapterPreparationContext
+      ): Promise<AdapterPreparationResult> => {
+        const result = await new PreparedFakeAdapter().prepareRequest(
+          internal,
+          context
+        );
+        if ("prepared" in result) {
+          result.prepared.mode =
+            context.mode === "complete" ? "stream" : "complete";
+        }
+        return result;
+      }
+    );
+    const drift = await service.prepareMessage(request, {
+      mode: "complete",
+    });
+    expect(drift).toMatchObject({
+      object: "error",
+      error: { code: "INVALID_PREPARED_CALL" },
+    });
+  });
+
+  it("turns synchronous iterator construction failures into one terminal error", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    fake.streamPrepared = () => {
+      throw new Error("iterator construction failed");
+    };
+    const handle = await service.prepareMessage(request, { mode: "stream" });
+    const events = await collect(
+      service.streamPrepared(handle as PreparedStreamCall)
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      attemptId: expect.any(String),
+      error: { error: { message: "iterator construction failed" } },
+    });
+  });
+
+  it("turns malformed terminal postprocessing into one error envelope", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    fake.streamFactory = (internal) => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "error",
+          error: {
+            provider: internal.providerId,
+            model: internal.modelId,
+            error: {
+              message: "provider failed",
+              code: "PROVIDER_ERROR",
+              type: "server_error",
+            },
+            object: "error",
+            partialResponse: {
+              id: "malformed",
+              provider: internal.providerId,
+              model: internal.modelId,
+              created: 1,
+              choices: undefined,
+            } as any,
+          },
+        };
+      },
+    });
+    const handle = await service.prepareMessage(
+      {
+        ...request,
+        settings: {
+          maxTokens: 123,
+          structuredOutput: {
+            name: "answer",
+            schema: { type: "object" },
+          },
+        },
+      },
+      { mode: "stream" }
+    );
+    const events = await collect(
+      service.streamPrepared(handle as PreparedStreamCall)
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      error: { error: { code: "PROVIDER_ERROR" } },
+    });
+  });
+
+  it("reports library defaults and verified hard-limit clamps separately", () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const libraryModel = {
+      ...createFallbackModelInfo("model", "openai"),
+      maxTokens: undefined,
+      defaultSettings: undefined,
+    };
+    const libraryDefault = (
+      service as any
+    ).createEffectiveOutputTokenLimit(
+      {
+        providerId: "openai",
+        modelId: "model",
+        messages: [],
+      },
+      "openai",
+      libraryModel,
+      4096
+    );
+    const clamped = (
+      service as any
+    ).createEffectiveOutputTokenLimit(
+      {
+        providerId: "openai",
+        modelId: "model",
+        messages: [],
+        settings: { maxTokens: 1000 },
+      },
+      "openai",
+      {
+        ...libraryModel,
+        hardOutputTokenLimit: {
+          tokens: 512,
+          source: "model_hard_limit",
+          counts: "visible_and_reasoning",
+        },
+      },
+      1000
+    );
+
+    expect(libraryDefault).toMatchObject({
+      tokens: 4096,
+      source: "library_default",
+      counts: "visible_and_reasoning",
+    });
+    expect(clamped).toEqual({
+      tokens: 512,
+      source: "request",
+      requestedTokens: 1000,
+      clamp: {
+        tokens: 512,
+        source: "model_hard_limit",
+      },
+      counts: "visible_and_reasoning",
+    });
+    expect(
+      (service as any).createEffectiveOutputTokenLimit(
+        request,
+        "mock",
+        libraryModel,
+        undefined
+      )
+    ).toBeUndefined();
+  });
+
+  it("labels raw counts that include extracted thinking-tag content", async () => {
+    const service = new LLMService(async () => "not-needed", {
+      logLevel: "silent",
+    });
+    const fake = new PreparedFakeAdapter();
+    registerFake(service, fake);
+    fake.sendResults.push({
+      ...success({
+        ...request,
+        settings: {} as any,
+      } as InternalLLMChatRequest),
+      choices: [{
+        index: 0,
+        message: {
+          role: "assistant",
+          content: "<thinking>why</thinking>answer",
+        },
+        rawContent: "<thinking>why</thinking>answer",
+        rawAnswerAccounting: {
+          tokens: 9,
+          method: "heuristic",
+          source: "library",
+          reasoning: "unknown",
+        },
+        finish_reason: "stop",
+      }],
+    });
+    const handle = await service.prepareMessage(
+      {
+        ...request,
+        settings: {
+          maxTokens: 123,
+          thinkingTagFallback: {
+            enabled: true,
+            tagName: "thinking",
+          },
+        },
+      },
+      { mode: "complete" }
+    );
+    const response = await service.sendPrepared(
+      handle as PreparedCompleteCall
+    );
+
+    expect(response.object).toBe("chat.completion");
+    if (response.object === "chat.completion") {
+      expect(response.choices[0]).toMatchObject({
+        message: { content: "answer" },
+        rawContent: "<thinking>why</thinking>answer",
+        reasoning: "why",
+        rawAnswerAccounting: {
+          reasoning: "included_extracted",
+        },
+      });
+    }
+  });
+});

--- a/src/llm/LLMService.test.ts
+++ b/src/llm/LLMService.test.ts
@@ -209,7 +209,9 @@ describe('LLMService', () => {
     it('should yield an error when an adapter does not support streaming', async () => {
       mockApiKeyProvider.mockResolvedValueOnce('sk-ant-test-key-12345678901234567890');
       const originalStreamMessage = AnthropicClientAdapter.prototype.streamMessage;
+      const originalStreamPrepared = AnthropicClientAdapter.prototype.streamPrepared;
       (AnthropicClientAdapter.prototype as any).streamMessage = undefined;
+      (AnthropicClientAdapter.prototype as any).streamPrepared = undefined;
 
       try {
         const events = await collectEvents({
@@ -223,13 +225,14 @@ describe('LLMService', () => {
           type: 'error',
           error: {
             error: {
-              code: 'PROVIDER_ERROR',
+              code: 'PREPARED_CALL_UNSUPPORTED',
               type: 'unsupported_feature',
             },
           },
         });
       } finally {
         AnthropicClientAdapter.prototype.streamMessage = originalStreamMessage;
+        AnthropicClientAdapter.prototype.streamPrepared = originalStreamPrepared;
       }
     });
 
@@ -280,7 +283,7 @@ describe('LLMService', () => {
         timeoutMs: 12345,
         logLevel: 'silent',
       });
-      const spy = jest.spyOn(MockClientAdapter.prototype, 'streamMessage');
+      const spy = jest.spyOn(MockClientAdapter.prototype, 'streamPrepared');
       const controller = new AbortController();
       const events = [];
 
@@ -296,7 +299,10 @@ describe('LLMService', () => {
       expect(spy).toHaveBeenCalledWith(
         expect.anything(),
         expect.any(String),
-        expect.objectContaining({ signal: controller.signal, timeoutMs: 12345 })
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+          timeoutMs: 12345,
+        })
       );
 
       spy.mockRestore();
@@ -1214,7 +1220,7 @@ describe('LLMService', () => {
 
       it('rejects a structured-output request for Claude 4 without calling the adapter', async () => {
         mockApiKeyProvider.mockResolvedValue('sk-ant-test-key-12345678901234567890');
-        const spy = jest.spyOn(AnthropicClientAdapter.prototype, 'sendMessage');
+        const spy = jest.spyOn(AnthropicClientAdapter.prototype, 'sendPrepared');
 
         const response = await service.sendMessage(anthropicRequest('claude-sonnet-4-20250514'));
 
@@ -1232,7 +1238,7 @@ describe('LLMService', () => {
       it('lets a structured-output request for Claude 4.5 reach the adapter', async () => {
         mockApiKeyProvider.mockResolvedValue('sk-ant-test-key-12345678901234567890');
         const spy = jest
-          .spyOn(AnthropicClientAdapter.prototype, 'sendMessage')
+          .spyOn(AnthropicClientAdapter.prototype, 'sendPrepared')
           .mockResolvedValue({
             id: 'msg_ok',
             provider: 'anthropic',

--- a/src/llm/LLMService.ts
+++ b/src/llm/LLMService.ts
@@ -1,6 +1,7 @@
 // AI Summary: Main process service for LLM operations, integrating with ApiKeyProvider for secure key access.
 // Orchestrates LLM requests through provider-specific client adapters with proper error handling.
 
+import { randomUUID } from "node:crypto";
 import type { ApiKeyProvider, PresetMode } from '../types';
 import type { Logger, LogLevel } from '../logging/types';
 import { createDefaultLogger } from '../logging/defaultLogger';
@@ -15,18 +16,33 @@ import type {
   LLMSettings,
   ModelContext,
   LLMMessage,
-  LLMStreamEvent,
+  LLMServiceStreamEvent,
   LLMRequestCapabilityPreflight,
   LLMRequestCapabilityValidationResult,
   ModelCapabilities,
   ModelCapabilitiesResult,
   StructuredOutputSupport,
   CapabilitySource,
+  PreparedCallMode,
+  PreparedCall,
+  PreparedCompleteCall,
+  PreparedStreamCall,
+  PrepareMessageResult,
+  PreparedRequestInspection,
+  EffectiveOutputTokenLimit,
+  PreparedPromptAccounting,
+  LLMRawAnswerAccounting,
+  LLMRawContentPart,
+  LLMTermination,
+  LLMUsage,
+  LLMUsageEvidence,
 } from "./types";
 import type {
   ILLMClientAdapter,
   InternalLLMChatRequest,
   AdapterRequestOptions,
+  AdapterPreparedRequest,
+  AdapterLLMStreamEvent,
 } from "./clients/types";
 import type { ModelPreset } from "../types/presets";
 import {
@@ -50,6 +66,11 @@ import { SettingsManager } from "./services/SettingsManager";
 import { ModelResolver } from "./services/ModelResolver";
 import { withRetry, type RetryPolicy } from "../shared/services/withRetry";
 import { ADAPTER_ERROR_CODES } from "./clients/types";
+import { deepFreeze } from "./clients/preparedAdapterUtils";
+import {
+  countTextTokens,
+  resolveTokenProfile,
+} from "./tokenization";
 
 // Re-export PresetMode for backward compatibility
 export type { PresetMode };
@@ -108,6 +129,11 @@ export interface StreamMessageOptions {
   timeoutMs?: number;
 }
 
+/** Selects the immutable dispatch mode fixed during preparation. */
+export interface PrepareMessageOptions<TMode extends PreparedCallMode> {
+  mode: TMode;
+}
+
 /**
  * Result from createMessages method
  */
@@ -127,8 +153,7 @@ interface PreparedLLMRequest {
   resolvedRequest: LLMChatRequest;
   internalRequest: InternalLLMChatRequest;
   clientAdapter: ILLMClientAdapter;
-  apiKey: string;
-  adapterOptions: AdapterRequestOptions;
+  adapterPrepared: AdapterPreparedRequest;
 }
 
 interface CapabilityValidationContext {
@@ -138,6 +163,28 @@ interface CapabilityValidationContext {
   resolvedRequest: LLMChatRequest;
   finalSettings: Required<LLMSettings>;
   capabilities: ModelCapabilities;
+  adapterPreparationState?: unknown;
+}
+
+interface StreamPartialChoiceState {
+  content: string;
+  reasoning: string;
+  rawContent?: string;
+  rawContentParts?: LLMRawContentPart[];
+  rawAnswerAccounting?: LLMRawAnswerAccounting;
+  finishReason?: string | null;
+  termination?: LLMTermination;
+}
+
+interface StreamPartialState {
+  provider: ApiProviderId;
+  model: string;
+  id?: string;
+  created?: number;
+  started: boolean;
+  choices: Map<number, StreamPartialChoiceState>;
+  usage?: LLMUsage;
+  usageEvidence?: LLMUsageEvidence;
 }
 
 /**
@@ -162,6 +209,7 @@ export class LLMService {
   private modelResolver: ModelResolver;
   private retryOptions: LLMServiceOptions['retry'];
   private defaultTimeoutMs?: number;
+  private preparedCalls = new WeakMap<object, PreparedLLMRequest>();
 
   constructor(getApiKey: ApiKeyProvider, options: LLMServiceOptions = {}) {
     this.getApiKey = getApiKey;
@@ -245,13 +293,15 @@ export class LLMService {
     const resolvedModelId = resolved.modelId!;
     const modelInfo = resolved.modelInfo!;
     const source = this.getCapabilitySource(resolvedProviderId, resolvedModelId);
+    const capabilities = this.buildModelCapabilities(modelInfo, source);
 
     return {
       object: "model.capabilities",
       provider: resolvedProviderId,
       model: resolvedModelId,
       modelInfo: { ...modelInfo },
-      structuredOutput: this.getStructuredOutputSupport(modelInfo, source),
+      structuredOutput: capabilities.structuredOutput,
+      capabilities,
     };
   }
 
@@ -343,100 +393,168 @@ export class LLMService {
       `LLMService.sendMessage called with presetId: ${(request as LLMChatRequestWithPreset).presetId}, provider: ${request.providerId}, model: ${request.modelId}`
     );
 
+    const canonical = await this.prepareMessage(request, { mode: "complete" });
+    if (this.isFailureResponse(canonical)) {
+      return canonical;
+    }
+    return this.sendPrepared(canonical, callOptions);
+
+  }
+
+  /**
+   * Resolves and freezes the final semantic provider request without retrieving
+   * credentials or creating transport state.
+   */
+  async prepareMessage<TMode extends PreparedCallMode>(
+    request: LLMChatRequest | LLMChatRequestWithPreset,
+    options: PrepareMessageOptions<TMode>
+  ): Promise<PrepareMessageResult<TMode>> {
+    if (
+      !options ||
+      (options.mode !== "complete" && options.mode !== "stream")
+    ) {
+      return this.createPreparedFailure(
+        request.providerId ?? "unknown",
+        request.modelId ?? "unknown",
+        ADAPTER_ERROR_CODES.INVALID_PREPARED_CALL,
+        "Prepared-call mode must be either 'complete' or 'stream'.",
+        "validation_error"
+      );
+    }
+    const result = await this.prepareCanonicalRequest(request, options.mode);
+    if ("error" in result) {
+      return result.error;
+    }
+
+    const handle = Object.create(null) as PreparedCall<TMode>;
+    Object.defineProperties(handle, {
+      mode: {
+        value: options.mode,
+        enumerable: true,
+        configurable: false,
+        writable: false,
+      },
+      toJSON: {
+        value: () => {
+          throw new TypeError("Prepared LLM calls cannot be serialized.");
+        },
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      },
+    });
+    Object.freeze(handle);
+    this.preparedCalls.set(handle, result.prepared);
+    return handle;
+  }
+
+  /** Returns the immutable inspection view for a service-owned prepared call. */
+  async inspectPrepared(
+    handle: PreparedCall<PreparedCallMode>
+  ): Promise<PreparedRequestInspection | LLMFailureResponse> {
+    const prepared = this.preparedCalls.get(handle as object);
+    if (!prepared) {
+      return this.createPreparedHandleError(
+        handle,
+        ADAPTER_ERROR_CODES.INVALID_PREPARED_CALL,
+        "The prepared call is invalid, forged, or belongs to another LLMService instance."
+      );
+    }
+
+    return deepFreeze({
+      provider: prepared.providerId,
+      model: prepared.modelId,
+      mode: prepared.adapterPrepared.mode,
+      request: structuredClone(prepared.adapterPrepared.requestView),
+      promptAccounting: structuredClone(
+        prepared.adapterPrepared.promptAccounting
+      ),
+      ...(prepared.adapterPrepared.outputTokenLimit && {
+        outputTokenLimit: structuredClone(
+          prepared.adapterPrepared.outputTokenLimit
+        ),
+      }),
+      bindings: structuredClone(prepared.adapterPrepared.bindings),
+    });
+  }
+
+  /** Dispatches a reusable complete-mode prepared call. */
+  async sendPrepared(
+    handle: PreparedCompleteCall,
+    callOptions?: SendMessageOptions
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    const resolved = this.resolvePreparedHandle(handle, "complete");
+    if ("error" in resolved) {
+      return resolved.error;
+    }
+    const prepared = resolved.prepared;
+    const adapter = prepared.clientAdapter;
+    if (!adapter.sendPrepared) {
+      return this.createPreparedFailure(
+        prepared.providerId,
+        prepared.modelId,
+        ADAPTER_ERROR_CODES.PREPARED_CALL_UNSUPPORTED,
+        `Prepared calls are not supported for provider '${prepared.providerId}'.`,
+        "unsupported_feature"
+      );
+    }
+
+    const apiKey = await this.resolveDispatchApiKey(prepared);
+    if (this.isFailureResponse(apiKey)) {
+      return apiKey;
+    }
+    const adapterOptions = this.createAdapterOptions(callOptions);
+    const retryOnTimeout = this.retryOptions?.retryOnTimeout ?? true;
+    const retryableCodes = new Set<string>([
+      ADAPTER_ERROR_CODES.RATE_LIMIT_EXCEEDED,
+      ADAPTER_ERROR_CODES.NETWORK_ERROR,
+      ...(retryOnTimeout ? [ADAPTER_ERROR_CODES.REQUEST_TIMEOUT] : []),
+    ]);
+
     try {
-      const preparedResult = await this.prepareRequest(request, callOptions);
-      if ("error" in preparedResult) {
-        return preparedResult.error;
-      }
-
-      const prepared = preparedResult.prepared;
-      try {
-        this.logger.info(
-          `Making LLM request with ${prepared.clientAdapter.constructor.name} for provider: ${prepared.providerId}`
-        );
-
-        // Unified retry layer: adapters never throw, so retry decisions are made on
-        // RETURNED failure responses. SDK-internal retries are disabled (maxRetries: 0
-        // at client construction) — this loop is the single owner of retry behavior.
-        const retryOnTimeout = this.retryOptions?.retryOnTimeout ?? true;
-        const retryableCodes = new Set<string>([
-          ADAPTER_ERROR_CODES.RATE_LIMIT_EXCEEDED,
-          ADAPTER_ERROR_CODES.NETWORK_ERROR,
-          ...(retryOnTimeout ? [ADAPTER_ERROR_CODES.REQUEST_TIMEOUT] : []),
-        ]);
-
-        const result = await withRetry(
-          () => prepared.clientAdapter.sendMessage(
-            prepared.internalRequest,
-            prepared.apiKey,
-            prepared.adapterOptions
-          ),
-          (res) => {
-            if (res.object !== 'error') {
-              return { retry: false };
-            }
-            const code = String(res.error.code);
-            const status = res.error.status;
-            const retryable =
+      const result = await withRetry(
+        async () => {
+          const revalidation = await this.revalidatePrepared(
+            prepared,
+            adapterOptions
+          );
+          if (revalidation) {
+            return revalidation;
+          }
+          return adapter.sendPrepared!(
+            prepared.adapterPrepared,
+            apiKey,
+            adapterOptions
+          );
+        },
+        (response) => {
+          if (response.object !== "error") {
+            return { retry: false };
+          }
+          const code = String(response.error.code);
+          const status = response.error.status;
+          return {
+            retry:
               retryableCodes.has(code) ||
               (code === ADAPTER_ERROR_CODES.PROVIDER_ERROR &&
-                typeof status === 'number' &&
-                (status === 408 || status === 409 || status >= 500));
-            return { retry: retryable, retryAfterMs: res.error.retryAfterMs };
-          },
-          {
-            ...this.retryOptions,
-            ...(callOptions?.maxRetries !== undefined && {
-              maxRetries: callOptions.maxRetries,
-            }),
-            signal: callOptions?.signal,
-            logger: this.logger,
-            label: `${prepared.providerId}/${prepared.modelId}`,
-          }
-        );
-
-        const processedResult = this.postProcessResponse(result, prepared);
-
-        if (processedResult.object === "chat.completion") {
-          this.logger.info(
-            `LLM request completed successfully for model: ${prepared.modelId}`
-          );
-        }
-        return processedResult;
-      } catch (error) {
-        this.logger.error("Error in LLMService.sendMessage:", error);
-        return {
-          provider: prepared.providerId,
-          model: prepared.modelId,
-          error: {
-            message:
-              error instanceof Error
-                ? error.message
-                : "An unknown error occurred during message sending.",
-            code: "PROVIDER_ERROR",
-            type: "server_error",
-            providerError: error,
-          },
-          object: "error",
-        };
-      }
-    } catch (error) {
-      this.logger.error("Error in LLMService.sendMessage (outer):", error);
-
-      return {
-        provider: request.providerId || (request as LLMChatRequestWithPreset).presetId || 'unknown',
-        model: request.modelId || (request as LLMChatRequestWithPreset).presetId || 'unknown',
-        error: {
-          message:
-            error instanceof Error
-              ? error.message
-              : "An unknown error occurred.",
-          code: "UNEXPECTED_ERROR",
-          type: "server_error",
-          providerError: error,
+                typeof status === "number" &&
+                (status === 408 || status === 409 || status >= 500)),
+            retryAfterMs: response.error.retryAfterMs,
+          };
         },
-        object: "error",
-      };
+        {
+          ...this.retryOptions,
+          ...(callOptions?.maxRetries !== undefined && {
+            maxRetries: callOptions.maxRetries,
+          }),
+          signal: callOptions?.signal,
+          logger: this.logger,
+          label: `${prepared.providerId}/${prepared.modelId}`,
+        }
+      );
+      return this.postProcessResponse(result, prepared);
+    } catch (error) {
+      return this.createUnexpectedDispatchFailure(prepared, error);
     }
   }
 
@@ -450,93 +568,206 @@ export class LLMService {
   async *streamMessage(
     request: LLMChatRequest | LLMChatRequestWithPreset,
     callOptions?: StreamMessageOptions
-  ): AsyncGenerator<LLMStreamEvent> {
+  ): AsyncGenerator<LLMServiceStreamEvent> {
+    const attemptId = randomUUID();
     this.logger.info(
       `LLMService.streamMessage called with presetId: ${(request as LLMChatRequestWithPreset).presetId}, provider: ${request.providerId}, model: ${request.modelId}`
     );
 
+    const canonical = await this.prepareMessage(request, { mode: "stream" });
+    if (this.isFailureResponse(canonical)) {
+      yield { attemptId, type: "error", error: canonical };
+      return;
+    }
+    yield* this.streamPreparedWithAttempt(canonical, callOptions, attemptId);
+    return;
+
+  }
+
+  /** Dispatches a reusable stream-mode prepared call with no automatic retries. */
+  async *streamPrepared(
+    handle: PreparedStreamCall,
+    callOptions?: StreamMessageOptions
+  ): AsyncGenerator<LLMServiceStreamEvent> {
+    yield* this.streamPreparedWithAttempt(handle, callOptions, randomUUID());
+  }
+
+  private async *streamPreparedWithAttempt(
+    handle: PreparedStreamCall,
+    callOptions: StreamMessageOptions | undefined,
+    attemptId: string
+  ): AsyncGenerator<LLMServiceStreamEvent> {
+    const resolved = this.resolvePreparedHandle(handle, "stream");
+    if ("error" in resolved) {
+      yield { attemptId, type: "error", error: resolved.error };
+      return;
+    }
+    const prepared = resolved.prepared;
+    const adapter = prepared.clientAdapter;
+    if (!adapter.streamPrepared) {
+      yield {
+        attemptId,
+        type: "error",
+        error: this.createPreparedFailure(
+          prepared.providerId,
+          prepared.modelId,
+          ADAPTER_ERROR_CODES.PREPARED_CALL_UNSUPPORTED,
+          `Prepared streaming is not supported for provider '${prepared.providerId}'.`,
+          "unsupported_feature"
+        ),
+      };
+      return;
+    }
+
+    const apiKey = await this.resolveDispatchApiKey(prepared);
+    if (this.isFailureResponse(apiKey)) {
+      yield { attemptId, type: "error", error: apiKey };
+      return;
+    }
+
+    const cancellation = new AbortController();
+    const signal = callOptions?.signal
+      ? AbortSignal.any([callOptions.signal, cancellation.signal])
+      : cancellation.signal;
+    const adapterOptions = this.createAdapterOptions({
+      ...callOptions,
+      signal,
+    });
+    const partialState: StreamPartialState = {
+      provider: prepared.providerId,
+      model: prepared.modelId,
+      started: false,
+      choices: new Map(),
+    };
+    let iterator: AsyncIterator<AdapterLLMStreamEvent> | undefined;
+    let terminal = false;
     try {
-      const preparedResult = await this.prepareRequest(request, callOptions);
-      if ("error" in preparedResult) {
-        yield { type: "error", error: preparedResult.error };
+      const revalidation = await this.revalidatePrepared(
+        prepared,
+        adapterOptions
+      );
+      if (revalidation) {
+        yield { attemptId, type: "error", error: revalidation };
         return;
       }
 
-      const prepared = preparedResult.prepared;
-      if (!prepared.clientAdapter.streamMessage) {
-        yield {
-          type: "error",
-          error: {
-            provider: prepared.providerId,
-            model: prepared.modelId,
-            error: {
-              message: `Streaming is not supported for provider '${prepared.providerId}'.`,
-              code: "PROVIDER_ERROR",
-              type: "unsupported_feature",
-            },
-            object: "error",
-          },
-        };
-        return;
-      }
-
-      try {
-        for await (const event of prepared.clientAdapter.streamMessage(
-          prepared.internalRequest,
-          prepared.apiKey,
-          prepared.adapterOptions
-        )) {
-          if (event.type === "complete") {
-            const processedResult = this.postProcessResponse(event.response, prepared);
-            if (processedResult.object === "error") {
-              yield { type: "error", error: processedResult };
-            } else {
-              yield { type: "complete", response: processedResult };
-            }
-            continue;
-          }
-
-          yield event;
+      iterator = adapter
+        .streamPrepared(prepared.adapterPrepared, apiKey, adapterOptions)
+        [Symbol.asyncIterator]();
+      while (!terminal) {
+        const step = await this.nextStreamEvent(iterator, signal);
+        if (step.done) {
+          break;
         }
-      } catch (error) {
-        this.logger.error("Error in LLMService.streamMessage:", error);
+        const event = step.value;
+        this.observeStreamPartial(partialState, event);
+        if (event.type === "adapter_evidence") {
+          continue;
+        }
+        if (event.type === "complete") {
+          const processed = this.postProcessResponse(event.response, prepared);
+          if (processed.object === "error") {
+            const failure = this.finalizeStreamFailure(
+              processed,
+              partialState,
+              attemptId,
+              prepared
+            );
+            terminal = true;
+            yield {
+              attemptId,
+              type: "error",
+              error: failure,
+            };
+          } else {
+            terminal = true;
+            yield { attemptId, type: "complete", response: processed };
+          }
+          break;
+        }
+        if (event.type === "error") {
+          const failure = this.finalizeStreamFailure(
+            event.error,
+            partialState,
+            attemptId,
+            prepared
+          );
+          terminal = true;
+          yield {
+            attemptId,
+            type: "error",
+            error: failure,
+          };
+          break;
+        }
+        const {
+          observedEvidence: _observedEvidence,
+          ...publicEvent
+        } = event;
+        yield { ...publicEvent, attemptId } as LLMServiceStreamEvent;
+      }
+
+      if (!terminal) {
+        terminal = true;
+        const aborted = signal.aborted;
         yield {
+          attemptId,
           type: "error",
-          error: {
-            provider: prepared.providerId,
-            model: prepared.modelId,
-            error: {
-              message:
-                error instanceof Error
-                  ? error.message
-                  : "An unknown error occurred during message streaming.",
-              code: "PROVIDER_ERROR",
-              type: "server_error",
-              providerError: error,
-            },
-            object: "error",
-          },
+          error: this.finalizeStreamFailure(
+            this.createPreparedFailure(
+              prepared.providerId,
+              prepared.modelId,
+              aborted
+                ? ADAPTER_ERROR_CODES.REQUEST_ABORTED
+                : ADAPTER_ERROR_CODES.PROVIDER_ERROR,
+              aborted
+                ? "The streaming request was aborted."
+                : "The provider stream ended without a terminal event.",
+              aborted ? "abort_error" : "server_error"
+            ),
+            partialState,
+            attemptId,
+            prepared
+          ),
         };
       }
     } catch (error) {
-      this.logger.error("Error in LLMService.streamMessage (outer):", error);
-      yield {
-        type: "error",
-        error: {
-          provider: request.providerId || (request as LLMChatRequestWithPreset).presetId || 'unknown',
-          model: request.modelId || (request as LLMChatRequestWithPreset).presetId || 'unknown',
-          error: {
-            message:
-              error instanceof Error
-                ? error.message
-                : "An unknown error occurred.",
-            code: "UNEXPECTED_ERROR",
-            type: "server_error",
-            providerError: error,
-          },
-          object: "error",
-        },
-      };
+      if (!terminal) {
+        terminal = true;
+        const aborted = signal.aborted;
+        yield {
+          attemptId,
+          type: "error",
+          error: this.finalizeStreamFailure(
+            this.createPreparedFailure(
+              prepared.providerId,
+              prepared.modelId,
+              aborted
+                ? ADAPTER_ERROR_CODES.REQUEST_ABORTED
+                : ADAPTER_ERROR_CODES.PROVIDER_ERROR,
+              aborted
+                ? "The streaming request was aborted."
+                : error instanceof Error
+                  ? error.message
+                  : "An unknown streaming error occurred.",
+              aborted ? "abort_error" : "server_error",
+              error
+            ),
+            partialState,
+            attemptId,
+            prepared
+          ),
+        };
+      }
+    } finally {
+      cancellation.abort();
+      if (iterator?.return) {
+        try {
+          void Promise.resolve(iterator.return()).catch(() => undefined);
+        } catch {
+          // Iterator cleanup is best-effort and must never replace the terminal.
+        }
+      }
     }
   }
 
@@ -626,6 +857,9 @@ export class LLMService {
         resolvedRequest,
         finalSettings,
         capabilities,
+        ...(resolved.adapterPreparationState !== undefined && {
+          adapterPreparationState: resolved.adapterPreparationState,
+        }),
       },
     };
   }
@@ -634,8 +868,45 @@ export class LLMService {
     modelInfo: ModelInfo,
     source: CapabilitySource
   ): ModelCapabilities {
+    const structuredOutput = this.getStructuredOutputSupport(modelInfo, source);
+    const tokenProfile = resolveTokenProfile(
+      modelInfo.providerId,
+      modelInfo.id
+    );
+    const reportsUsage =
+      modelInfo.providerId === "openai" ||
+      modelInfo.providerId === "anthropic" ||
+      modelInfo.providerId === "gemini" ||
+      modelInfo.providerId === "mistral" ||
+      modelInfo.providerId === "openrouter" ||
+      modelInfo.providerId === "llamacpp";
     return {
-      structuredOutput: this.getStructuredOutputSupport(modelInfo, source),
+      structuredOutput,
+      ...(modelInfo.contextWindow !== undefined && {
+        contextWindow: {
+          tokens: modelInfo.contextWindow,
+          source,
+        },
+      }),
+      contentTokenCounting:
+        tokenProfile.status === "available" ? "exact" : "unavailable",
+      preparedMessageTokenCounting:
+        modelInfo.providerId === "llamacpp" ? "runtime" : "unavailable",
+      ...(tokenProfile.status === "available" && {
+        tokenProfileId: tokenProfile.profile.id,
+        tokenProfileMappingRevision: tokenProfile.mappingRevision,
+      }),
+      ...(reportsUsage && {
+        reportsPromptUsage: true,
+        reportsCompletionUsage: true,
+      }),
+      distinguishesLimitCause:
+        modelInfo.providerId === "anthropic" ||
+        modelInfo.providerId === "gemini",
+      structuredOutputDelivery: {
+        native: structuredOutput,
+        prompt: "instruction_only",
+      },
     };
   }
 
@@ -669,9 +940,489 @@ export class LLMService {
     return getModelById(modelId, providerId) ? "registry" : "fallback";
   }
 
-  private async prepareRequest(
-    request: LLMChatRequest | LLMChatRequestWithPreset,
+  private isFailureResponse(value: unknown): value is LLMFailureResponse {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      (value as { object?: unknown }).object === "error"
+    );
+  }
+
+  private createPreparedFailure(
+    provider: string,
+    model: string,
+    code: string,
+    message: string,
+    type: string,
+    providerError?: unknown
+  ): LLMFailureResponse {
+    return {
+      provider,
+      model,
+      error: {
+        message,
+        code,
+        type,
+        ...(providerError !== undefined && { providerError }),
+      },
+      object: "error",
+    };
+  }
+
+  private createPreparedHandleError(
+    handle: unknown,
+    code: string,
+    message: string
+  ): LLMFailureResponse {
+    const mode =
+      typeof handle === "object" && handle !== null && "mode" in handle
+        ? String((handle as { mode?: unknown }).mode ?? "unknown")
+        : "unknown";
+    return this.createPreparedFailure(
+      "unknown",
+      "unknown",
+      code,
+      message,
+      mode === "unknown" ? "invalid_request_error" : "validation_error"
+    );
+  }
+
+  private resolvePreparedHandle(
+    handle: unknown,
+    expectedMode: PreparedCallMode
+  ):
+    | { prepared: PreparedLLMRequest }
+    | { error: LLMFailureResponse } {
+    if (
+      (typeof handle !== "object" && typeof handle !== "function") ||
+      handle === null
+    ) {
+      return {
+        error: this.createPreparedHandleError(
+          handle,
+          ADAPTER_ERROR_CODES.INVALID_PREPARED_CALL,
+          "The prepared call is invalid or forged."
+        ),
+      };
+    }
+    const prepared = this.preparedCalls.get(handle as object);
+    if (!prepared) {
+      return {
+        error: this.createPreparedHandleError(
+          handle,
+          ADAPTER_ERROR_CODES.INVALID_PREPARED_CALL,
+          "The prepared call is invalid, forged, or belongs to another LLMService instance."
+        ),
+      };
+    }
+    if (prepared.adapterPrepared.mode !== expectedMode) {
+      return {
+        error: this.createPreparedFailure(
+          prepared.providerId,
+          prepared.modelId,
+          ADAPTER_ERROR_CODES.PREPARED_CALL_MODE_MISMATCH,
+          `A '${prepared.adapterPrepared.mode}' prepared call cannot be dispatched as '${expectedMode}'.`,
+          "validation_error"
+        ),
+      };
+    }
+    return { prepared };
+  }
+
+  private async resolveDispatchApiKey(
+    prepared: PreparedLLMRequest
+  ): Promise<string | LLMFailureResponse> {
+    try {
+      const apiKey = await this.getApiKey(prepared.providerId);
+      if (!apiKey) {
+        return this.createPreparedFailure(
+          prepared.providerId,
+          prepared.modelId,
+          "API_KEY_ERROR",
+          `API key for provider '${prepared.providerId}' could not be retrieved. Ensure your ApiKeyProvider is configured correctly.`,
+          "authentication_error"
+        );
+      }
+      if (
+        prepared.clientAdapter.validateApiKey &&
+        !prepared.clientAdapter.validateApiKey(apiKey)
+      ) {
+        return this.createPreparedFailure(
+          prepared.providerId,
+          prepared.modelId,
+          ADAPTER_ERROR_CODES.INVALID_API_KEY,
+          `Invalid API key format for provider '${prepared.providerId}'. Please check your API key.`,
+          "authentication_error"
+        );
+      }
+      return apiKey;
+    } catch (error) {
+      return this.createPreparedFailure(
+        prepared.providerId,
+        prepared.modelId,
+        ADAPTER_ERROR_CODES.PROVIDER_ERROR,
+        error instanceof Error
+          ? error.message
+          : "An unknown error occurred while retrieving credentials.",
+        "server_error",
+        error
+      );
+    }
+  }
+
+  private createAdapterOptions(
     callOptions?: StreamMessageOptions
+  ): AdapterRequestOptions {
+    const timeoutMs = callOptions?.timeoutMs ?? this.defaultTimeoutMs;
+    return {
+      ...(callOptions?.signal && { signal: callOptions.signal }),
+      ...(timeoutMs !== undefined && { timeoutMs }),
+    };
+  }
+
+  private async revalidatePrepared(
+    prepared: PreparedLLMRequest,
+    options: AdapterRequestOptions
+  ): Promise<LLMFailureResponse | undefined> {
+    if (!prepared.clientAdapter.revalidatePreparedRequest) {
+      return undefined;
+    }
+    const result = await prepared.clientAdapter.revalidatePreparedRequest(
+      prepared.adapterPrepared,
+      options
+    );
+    return result.valid ? undefined : result.error;
+  }
+
+  private async nextStreamEvent(
+    iterator: AsyncIterator<AdapterLLMStreamEvent>,
+    signal: AbortSignal
+  ): Promise<IteratorResult<AdapterLLMStreamEvent>> {
+    if (signal.aborted) {
+      throw new Error("Streaming request aborted");
+    }
+    return new Promise<IteratorResult<AdapterLLMStreamEvent>>(
+      (resolve, reject) => {
+        const onAbort = () => {
+          reject(new Error("Streaming request aborted"));
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        Promise.resolve(iterator.next()).then(
+          (result) => {
+            signal.removeEventListener("abort", onAbort);
+            resolve(result);
+          },
+          (error) => {
+            signal.removeEventListener("abort", onAbort);
+            reject(error);
+          }
+        );
+      }
+    );
+  }
+
+  private observeStreamPartial(
+    state: StreamPartialState,
+    event: AdapterLLMStreamEvent
+  ): void {
+    const observed = event.observedEvidence;
+    if (observed?.choice) {
+      const choice = this.getStreamPartialChoice(
+        state,
+        observed.choice.index
+      );
+      if (observed.choice.rawContentDelta !== undefined) {
+        choice.rawContent =
+          (choice.rawContent ?? "") + observed.choice.rawContentDelta;
+      }
+      if (observed.choice.rawContentParts) {
+        choice.rawContentParts = [
+          ...(choice.rawContentParts ?? []),
+          ...observed.choice.rawContentParts,
+        ];
+      }
+      if (observed.choice.rawAnswerAccounting) {
+        choice.rawAnswerAccounting =
+          observed.choice.rawAnswerAccounting;
+      }
+      if (observed.choice.finishReason !== undefined) {
+        choice.finishReason = observed.choice.finishReason;
+      }
+      if (observed.choice.termination) {
+        choice.termination = observed.choice.termination;
+      }
+    }
+    if (observed?.usageEvidence) {
+      state.usageEvidence = {
+        ...(state.usageEvidence ?? {}),
+        ...observed.usageEvidence,
+      };
+    }
+    if (observed?.usage) {
+      state.usage = {
+        ...(state.usage ?? {}),
+        ...Object.fromEntries(
+          Object.entries(observed.usage).filter(
+            ([, value]) => value !== undefined
+          )
+        ),
+      };
+    }
+    if (event.type === "adapter_evidence") {
+      return;
+    }
+    if (event.type === "start") {
+      state.started = true;
+      state.provider = event.provider;
+      state.model = event.model;
+      state.id = event.id;
+      state.created = event.created;
+      return;
+    }
+    if (event.type === "content_delta" || event.type === "reasoning_delta") {
+      const choice = this.getStreamPartialChoice(state, event.index);
+      if (event.type === "content_delta") {
+        choice.content += event.delta;
+      } else {
+        choice.reasoning += event.delta;
+      }
+      return;
+    }
+    if (event.type === "usage") {
+      state.usage = {
+        ...(state.usage ?? {}),
+        ...Object.fromEntries(
+          Object.entries(event.usage).filter(
+            ([, value]) => value !== undefined
+          )
+        ),
+      };
+    }
+  }
+
+  private getStreamPartialChoice(
+    state: StreamPartialState,
+    index: number
+  ): StreamPartialChoiceState {
+    let choice = state.choices.get(index);
+    if (!choice) {
+      choice = { content: "", reasoning: "" };
+      state.choices.set(index, choice);
+    }
+    return choice;
+  }
+
+  private finalizeStreamFailure(
+    failure: LLMFailureResponse,
+    state: StreamPartialState,
+    attemptId: string,
+    prepared: PreparedLLMRequest
+  ): LLMFailureResponse {
+    const processed = this.postProcessResponse(
+      this.attachStreamPartial(failure, state, attemptId),
+      prepared
+    );
+    return processed as LLMFailureResponse;
+  }
+
+  private attachStreamPartial(
+    failure: LLMFailureResponse,
+    state: StreamPartialState,
+    attemptId: string
+  ): LLMFailureResponse {
+    const hasEvidence =
+      state.started ||
+      state.choices.size > 0 ||
+      state.usage !== undefined ||
+      state.usageEvidence !== undefined;
+    if (!hasEvidence) {
+      return failure;
+    }
+
+    const choices = Array.from(state.choices.entries())
+      .sort(([left], [right]) => left - right)
+      .map(([index, choice]) => ({
+        index,
+        message: {
+          role: "assistant" as const,
+          content: choice.content,
+        },
+        ...(choice.reasoning.length > 0 && {
+          reasoning: choice.reasoning,
+        }),
+        ...(choice.rawContent !== undefined && {
+          rawContent: choice.rawContent,
+        }),
+        ...(choice.rawContentParts && {
+          rawContentParts: choice.rawContentParts,
+        }),
+        ...(choice.rawAnswerAccounting && {
+          rawAnswerAccounting: choice.rawAnswerAccounting,
+        }),
+        finish_reason: choice.finishReason ?? null,
+        termination: choice.termination ?? {
+          rawReason: null,
+          kind: "unknown" as const,
+        },
+      }));
+    const observed: Omit<LLMResponse, "object"> = {
+      id: state.id ?? attemptId,
+      provider: state.provider,
+      model: state.model,
+      created: state.created ?? Math.floor(Date.now() / 1000),
+      choices,
+      ...(state.usage && { usage: state.usage }),
+      ...(state.usageEvidence && {
+        usageEvidence: state.usageEvidence,
+      }),
+    };
+    if (!failure.partialResponse) {
+      return { ...failure, partialResponse: observed };
+    }
+
+    const provided = failure.partialResponse;
+    const choicesByIndex = new Map(
+      observed.choices.map((choice, position) => [
+        choice.index ?? position,
+        choice,
+      ])
+    );
+    for (const [position, choice] of provided.choices.entries()) {
+      const index = choice.index ?? position;
+      const prior = choicesByIndex.get(index);
+      choicesByIndex.set(index, {
+        ...(prior ?? {}),
+        ...choice,
+        message: {
+          ...(prior?.message ?? { role: "assistant", content: "" }),
+          ...choice.message,
+        },
+        ...(choice.rawContentParts === undefined &&
+          prior?.rawContentParts && {
+            rawContentParts: prior.rawContentParts,
+          }),
+      });
+    }
+    const usage = {
+      ...(observed.usage ?? {}),
+      ...Object.fromEntries(
+        Object.entries(provided.usage ?? {}).filter(
+          ([, value]) => value !== undefined
+        )
+      ),
+    };
+    const usageEvidence = {
+      ...(observed.usageEvidence ?? {}),
+      ...Object.fromEntries(
+        Object.entries(provided.usageEvidence ?? {}).filter(
+          ([, value]) => value !== undefined
+        )
+      ),
+    };
+    return {
+      ...failure,
+      partialResponse: {
+        ...observed,
+        ...provided,
+        choices: Array.from(choicesByIndex.entries())
+          .sort(([left], [right]) => left - right)
+          .map(([, choice]) => choice),
+        ...(Object.keys(usage).length > 0 && { usage }),
+        ...(Object.keys(usageEvidence).length > 0 && {
+          usageEvidence,
+        }),
+      },
+    };
+  }
+
+  private isValidPreparedAccounting(
+    accounting: PreparedPromptAccounting
+  ): boolean {
+    if (accounting.status === "unavailable") {
+      return true;
+    }
+    return accounting.count !== undefined || accounting.upperBound !== undefined;
+  }
+
+  private createEffectiveOutputTokenLimit(
+    request: LLMChatRequest | LLMChatRequestWithPreset,
+    providerId: ApiProviderId,
+    modelInfo: ModelInfo,
+    filteredMaxTokens: number | undefined
+  ): EffectiveOutputTokenLimit | undefined {
+    if (
+      filteredMaxTokens === undefined ||
+      !Number.isSafeInteger(filteredMaxTokens) ||
+      filteredMaxTokens <= 0
+    ) {
+      return undefined;
+    }
+
+    const presetId = (request as LLMChatRequestWithPreset).presetId;
+    const preset = presetId
+      ? this.presetManager
+          .getPresets()
+          .find((candidate) => candidate.id === presetId)
+      : undefined;
+    const source: EffectiveOutputTokenLimit["source"] =
+      request.settings?.maxTokens !== undefined
+        ? "request"
+        : preset?.settings.maxTokens !== undefined
+          ? "preset"
+          : modelInfo.defaultSettings?.maxTokens !== undefined ||
+              modelInfo.maxTokens !== undefined
+            ? "model_default"
+            : "library_default";
+    const hardLimit = modelInfo.hardOutputTokenLimit;
+    const tokens = hardLimit
+      ? Math.min(filteredMaxTokens, hardLimit.tokens)
+      : filteredMaxTokens;
+    const counts: EffectiveOutputTokenLimit["counts"] =
+      hardLimit?.counts ??
+      (providerId === "mistral"
+        ? "visible_output"
+        : providerId === "openrouter"
+          ? "provider_defined"
+          : providerId === "openai" ||
+              providerId === "anthropic" ||
+              providerId === "gemini" ||
+              providerId === "llamacpp"
+            ? "visible_and_reasoning"
+            : "unknown");
+
+    return {
+      tokens,
+      source,
+      ...(tokens !== filteredMaxTokens && {
+        requestedTokens: filteredMaxTokens,
+        clamp: {
+          tokens,
+          source: hardLimit!.source,
+        },
+      }),
+      counts,
+    };
+  }
+
+  private createUnexpectedDispatchFailure(
+    prepared: PreparedLLMRequest,
+    error: unknown
+  ): LLMFailureResponse {
+    return this.createPreparedFailure(
+      prepared.providerId,
+      prepared.modelId,
+      ADAPTER_ERROR_CODES.PROVIDER_ERROR,
+      error instanceof Error
+        ? error.message
+        : "An unknown error occurred during prepared dispatch.",
+      "server_error",
+      error
+    );
+  }
+
+  private async prepareCanonicalRequest(
+    request: LLMChatRequest | LLMChatRequestWithPreset,
+    mode: PreparedCallMode
   ): Promise<{ prepared: PreparedLLMRequest } | { error: LLMFailureResponse }> {
     const validation = await this.resolveAndValidateCapabilities(request, {
       validateStructure: true,
@@ -687,6 +1438,7 @@ export class LLMService {
       modelInfo,
       resolvedRequest,
       finalSettings,
+      adapterPreparationState,
     } = validation.context;
 
     // Get provider info for parameter filtering
@@ -712,6 +1464,18 @@ export class LLMService {
       modelInfo,
       providerInfo
     );
+    const outputTokenLimit = this.createEffectiveOutputTokenLimit(
+      request,
+      providerId,
+      modelInfo,
+      filteredSettings.maxTokens
+    );
+    if (
+      outputTokenLimit?.clamp &&
+      filteredSettings.maxTokens !== outputTokenLimit.tokens
+    ) {
+      filteredSettings.maxTokens = outputTokenLimit.tokens;
+    }
 
     const internalRequest: InternalLLMChatRequest = {
       ...resolvedRequest,
@@ -731,45 +1495,55 @@ export class LLMService {
     // Get client adapter
     const clientAdapter = this.adapterRegistry.getAdapter(providerId);
 
-    try {
-      const apiKey = await this.getApiKey(providerId);
-      if (!apiKey) {
-        return {
-          error: {
-            provider: providerId,
-            model: modelId,
-            error: {
-              message: `API key for provider '${providerId}' could not be retrieved. Ensure your ApiKeyProvider is configured correctly.`,
-              code: "API_KEY_ERROR",
-              type: "authentication_error",
-            },
-            object: "error",
-          },
-        };
-      }
-
-      // Validate API key format if adapter supports it
-      if (clientAdapter.validateApiKey && !clientAdapter.validateApiKey(apiKey)) {
-        return {
-          error: {
-            provider: providerId,
-            model: modelId,
-            error: {
-              message: `Invalid API key format for provider '${providerId}'. Please check your API key.`,
-              code: "INVALID_API_KEY",
-              type: "authentication_error",
-            },
-            object: "error",
-          },
-        };
-      }
-
-      const adapterOptions: AdapterRequestOptions = {
-        ...(callOptions?.signal && { signal: callOptions.signal }),
-        ...((callOptions?.timeoutMs ?? this.defaultTimeoutMs) !== undefined && {
-          timeoutMs: callOptions?.timeoutMs ?? this.defaultTimeoutMs,
-        }),
+    if (!clientAdapter.prepareRequest) {
+      return {
+        error: this.createPreparedFailure(
+          providerId,
+          modelId,
+          ADAPTER_ERROR_CODES.PREPARED_CALL_UNSUPPORTED,
+          `Prepared calls are not supported for provider '${providerId}'.`,
+          "unsupported_feature"
+        ),
       };
+    }
+
+    try {
+      const adapterResult = await clientAdapter.prepareRequest(internalRequest, {
+        mode,
+        modelInfo,
+        outputTokenLimit,
+        ...(adapterPreparationState !== undefined && {
+          providerState: adapterPreparationState,
+        }),
+      });
+      if ("error" in adapterResult) {
+        return { error: adapterResult.error };
+      }
+      if (!this.isValidPreparedAccounting(adapterResult.prepared.promptAccounting)) {
+        return {
+          error: this.createPreparedFailure(
+            providerId,
+            modelId,
+            ADAPTER_ERROR_CODES.INVALID_PREPARED_CALL,
+            "The adapter returned invalid prepared prompt accounting.",
+            "server_error"
+          ),
+        };
+      }
+      if (adapterResult.prepared.mode !== mode) {
+        return {
+          error: this.createPreparedFailure(
+            providerId,
+            modelId,
+            ADAPTER_ERROR_CODES.INVALID_PREPARED_CALL,
+            `The adapter prepared mode '${String(
+              adapterResult.prepared.mode
+            )}' instead of '${mode}'.`,
+            "server_error"
+          ),
+        };
+      }
+      const adapterPrepared = deepFreeze(adapterResult.prepared);
 
       return {
         prepared: {
@@ -779,29 +1553,24 @@ export class LLMService {
           resolvedRequest,
           internalRequest,
           clientAdapter,
-          apiKey,
-          adapterOptions,
+          adapterPrepared,
         },
       };
     } catch (error) {
-      this.logger.error("Error preparing LLM request:", error);
       return {
-        error: {
-          provider: providerId!,
-          model: modelId!,
-          error: {
-            message:
-              error instanceof Error
-                ? error.message
-                : "An unknown error occurred during request preparation.",
-            code: "PROVIDER_ERROR",
-            type: "server_error",
-            providerError: error,
-          },
-          object: "error",
-        },
+        error: this.createPreparedFailure(
+          providerId,
+          modelId,
+          ADAPTER_ERROR_CODES.PROVIDER_ERROR,
+          error instanceof Error
+            ? error.message
+            : "An unknown error occurred during request preparation.",
+          "server_error",
+          error
+        ),
       };
     }
+
   }
 
   private postProcessResponse(
@@ -809,7 +1578,53 @@ export class LLMService {
     prepared: PreparedLLMRequest
   ): LLMResponse | LLMFailureResponse {
     if (result.object === "error") {
-      return result;
+      if (!result.partialResponse) {
+        return result;
+      }
+      const processed = this.postProcessResponse(
+        {
+          ...result.partialResponse,
+          object: "chat.completion",
+        },
+        prepared
+      );
+      if (processed.object === "error") {
+        return {
+          ...result,
+          ...(processed.partialResponse && {
+            partialResponse: processed.partialResponse,
+          }),
+        };
+      }
+      const { object: _object, ...partialResponse } = processed;
+      return { ...result, partialResponse };
+    }
+
+    const tokenProfile = resolveTokenProfile(
+      prepared.providerId,
+      prepared.modelId
+    );
+    if (tokenProfile.status === "available") {
+      for (const choice of result.choices) {
+        const rawContent = choice.rawContent ?? choice.message.content;
+        choice.rawContent ??= rawContent;
+        if (!choice.rawAnswerAccounting) {
+          const counted = countTextTokens(rawContent, tokenProfile.profile);
+          if (counted.status === "available") {
+            choice.rawAnswerAccounting = {
+              tokens: counted.count.tokens,
+              method: counted.count.method,
+              source: "library",
+              tokenizerId: counted.count.tokenizerId,
+              tokenProfileRevision: counted.count.tokenProfileRevision,
+              reasoning:
+                choice.reasoning && choice.reasoning.length > 0
+                  ? "excluded"
+                  : "unknown",
+            };
+          }
+        }
+      }
     }
 
     // Post-process for thinking tag fallback
@@ -830,6 +1645,7 @@ export class LLMService {
       // Process the response - extract thinking tags if present
       const choice = result.choices[0];
       if (choice?.message?.content) {
+        choice.rawContent ??= choice.message.content;
         const { extracted, remaining } = extractInitialTaggedContent(choice.message.content, tagName);
 
         if (extracted !== null) {
@@ -847,6 +1663,9 @@ export class LLMService {
             choice.reasoning = extracted;
           }
           choice.message.content = remaining;
+          if (choice.rawAnswerAccounting) {
+            choice.rawAnswerAccounting.reasoning = "included_extracted";
+          }
         } else {
           // Tag was not found
           // Enforce only if: (1) enforce: true AND (2) native reasoning is NOT active
@@ -875,7 +1694,8 @@ export class LLMService {
                 model: result.model,
                 created: result.created,
                 choices: result.choices,
-                usage: result.usage
+                usage: result.usage,
+                usageEvidence: result.usageEvidence,
               }
             };
           }

--- a/src/llm/clients/.summary_long.md
+++ b/src/llm/clients/.summary_long.md
@@ -5,6 +5,26 @@ The clients directory implements the Adapter pattern for integrating multiple AI
 
 **Note**: Shared error handling utilities live in `src/shared/adapters/errorUtils.ts` (also exposing `parseRetryAfterMs`/`extractRetryAfterMs` for the retry layer). The OpenAI-shaped chat logprobs mapper is shared via `src/shared/adapters/logprobsUtils.ts` and reused by the OpenAI, OpenRouter and llama.cpp adapters.
 
+## Prepared adapter seam
+
+All built-ins implement optional credential-free `prepareRequest`,
+`sendPrepared`, and `streamPrepared` methods with adapter/request-shape
+revisions. Canonical payloads are cloned and frozen before inspection; SDK
+clients, credentials, timers, and transport state are created at dispatch.
+Response normalization preserves raw content/parts, presence-aware usage
+evidence, and raw plus normalized termination.
+During streaming, built-ins buffer each received provider chunk's internal
+evidence ahead of its public events. `LLMService` consumes and suppresses those
+adapter-only events, which makes cancellation and failure partials truthful
+even when usage, content, and a finish reason share one provider chunk.
+
+llama.cpp additionally counts the exact final body with
+`/v1/chat/completions/input_tokens`, fingerprints privacy-preserving
+model/build/template state, brackets the count with a second state read, and
+rejects stale redispatch. Model resolution and request preparation share the
+same opaque snapshot so capability/default decisions, exact counting, and the
+dispatch binding all refer to one observed server state.
+
 ## Key Components
 ### types.ts
 ## Overview

--- a/src/llm/clients/.summary_short.md
+++ b/src/llm/clients/.summary_short.md
@@ -4,16 +4,18 @@ Purpose: Contains provider-specific LLM client adapters that implement a common 
 
 ## Files:
 
-- `types.ts`: Defines the TypeScript interface contract and types that all LLM provider client adapters must implement to handle provider-specific API interactions in a standardized way, including AdapterRequestOptions (abort signal + timeout) on sendMessage and the REQUEST_TIMEOUT/REQUEST_ABORTED error codes used by the unified retry layer.
+- `types.ts`: Defines legacy-compatible adapter methods plus optional credential-free prepared commands, immutable views, revalidation, public-compatible and adapter-only evidence stream events without service attempt IDs, and prepared-call errors.
+- `preparedAdapterUtils.ts`: Shared freezing, semantic inspection, and deterministic prompt-delivered structured-output helpers.
+- `llamaCppState.ts`: Privacy-preserving canonical fingerprints for observable llama.cpp model/build/template state.
 - `OpenAIClientAdapter.ts`: Implements an adapter that integrates with OpenAI's API to send chat completions requests and normalize responses into a standardized format.
 - `OpenAIClientAdapter.test.ts`: Tests the OpenAI client adapter's functionality including API key validation, message formatting, and error handling.
 - `AnthropicClientAdapter.ts`: Implements an adapter that translates between the standardized LLM interface and Anthropic's Claude API, handling message formatting, API calls, and error mapping.
 - `AnthropicClientAdapter.test.ts`: Tests the Anthropic client adapter's message formatting, API interactions, and error handling for Claude models.
 - `GeminiClientAdapter.ts`: Implements the Google Gemini API client adapter that translates between the library's unified interface and Gemini's specific API requirements, including thinking/reasoning mode support.
 - `GeminiClientAdapter.test.ts`: Tests the Gemini client adapter's functionality including message conversion, safety settings, and error handling.
-- `LlamaCppServerClient.ts`: Utility client for interacting with llama.cpp server's non-LLM endpoints including tokenization, embeddings, health checks, and server management.
+- `LlamaCppServerClient.ts`: Utility client for llama.cpp health/tokenization/embedding/state endpoints and exact `/v1/chat/completions/input_tokens` preflight counting.
 - `LlamaCppServerClient.test.ts`: Tests the llama.cpp server client's methods for all server endpoints with 100% coverage (25 tests).
-- `LlamaCppClientAdapter.ts`: Implements an adapter for llama.cpp server integration using the OpenAI-compatible API endpoint for chat completions, supporting local LLM inference without API keys.
+- `LlamaCppClientAdapter.ts`: Implements llama.cpp chat/prepared integration, sharing one model/build/template snapshot with model resolution, bracketing exact input-token counts with state checks, and rejecting stale dispatch.
 - `LlamaCppClientAdapter.test.ts`: Tests the llama.cpp client adapter's functionality including health checks, message formatting, and connection error handling with 98.11% coverage (26 tests).
 - `OpenRouterClientAdapter.ts`: Implements an adapter for the OpenRouter API gateway that provides unified access to 100+ LLM models from multiple providers through an OpenAI-compatible interface with provider routing and app attribution support.
 - `OpenRouterClientAdapter.test.ts`: Tests the OpenRouter client adapter's functionality including API key validation, message formatting, provider routing settings, and error handling.

--- a/src/llm/clients/AnthropicClientAdapter.test.ts
+++ b/src/llm/clients/AnthropicClientAdapter.test.ts
@@ -434,7 +434,7 @@ describe('AnthropicClientAdapter', () => {
         signal: controller.signal,
         timeout: 5000,
       });
-      expect(events[0]).toMatchObject({
+      expect(events.find((event) => event.type === "start")).toMatchObject({
         type: 'start',
         provider: 'anthropic',
         model: 'claude-3-5-sonnet-20241022',
@@ -487,6 +487,21 @@ describe('AnthropicClientAdapter', () => {
         delta: 'thinking ',
         index: 0
       });
+      expect(events.find((event) => event.type === "content_delta")).toMatchObject({
+        type: "content_delta",
+        delta: "answer",
+        index: 0,
+      });
+      expect(
+        new Set(
+          events.flatMap((event) =>
+            event.type === "adapter_evidence" &&
+            event.observedEvidence.choice !== undefined
+              ? [event.observedEvidence.choice.index]
+              : []
+          )
+        )
+      ).toEqual(new Set([0]));
       const complete = events.find((event) => event.type === 'complete');
       if (complete?.type === 'complete') {
         expect(complete.response.choices[0].reasoning).toBe('thinking ');

--- a/src/llm/clients/AnthropicClientAdapter.ts
+++ b/src/llm/clients/AnthropicClientAdapter.ts
@@ -2,22 +2,37 @@
 // Handles Claude-specific request formatting, response parsing, and error mapping to standardized format.
 
 import Anthropic from "@anthropic-ai/sdk";
-import type { LLMResponse, LLMFailureResponse, LLMMessage, LLMStreamEvent } from "../types";
+import type { LLMResponse, LLMFailureResponse, LLMMessage } from "../types";
 import type {
   ILLMClientAdapter,
   InternalLLMChatRequest,
   AdapterErrorCode,
   AdapterRequestOptions,
+  AdapterLLMStreamEvent,
+  AdapterPreparationContext,
+  AdapterPreparationResult,
+  AdapterPreparedRequest,
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
 import { applyStrictSchemaConstraints } from "../../shared/adapters/schemaUtils";
+import {
+  mergeUsageRecords,
+  normalizeTermination,
+  normalizeUsage,
+} from "../../shared/adapters/usageUtils";
 import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
 import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
+import {
+  applyPromptStructuredOutput,
+  createPreparedRequestView,
+  freezeProviderRequest,
+  toPreparedRequestValue,
+} from "./preparedAdapterUtils";
 
 interface AnthropicPreparedRequest {
   anthropic: Anthropic;
@@ -27,6 +42,21 @@ interface AnthropicPreparedRequest {
   messages: Anthropic.Messages.MessageParam[];
 }
 
+interface AnthropicMessagePayload {
+  messageParams: Anthropic.Messages.MessageCreateParams;
+  useStructuredOutput: boolean;
+  messages: Anthropic.Messages.MessageParam[];
+}
+
+interface AnthropicPreparedProviderRequest {
+  request: InternalLLMChatRequest;
+  messageParams: Anthropic.Messages.MessageCreateParams;
+  useStructuredOutput: boolean;
+}
+
+const ANTHROPIC_ADAPTER_REVISION = "anthropic-adapter-v1";
+const ANTHROPIC_REQUEST_SHAPE_REVISION = "anthropic-messages-v1";
+
 interface AnthropicStreamAccumulator {
   id: string;
   model: string;
@@ -35,6 +65,12 @@ interface AnthropicStreamAccumulator {
   reasoning: string;
   stopReason: string | null;
   usage?: any;
+  rawParts: Array<{
+    type: string;
+    text?: string;
+    value?: import("../types").PreparedRequestValue;
+    reasoning?: boolean;
+  }>;
 }
 
 /**
@@ -63,6 +99,90 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     this.logger = config?.logger ?? createDefaultLogger();
   }
 
+  async prepareRequest(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult> {
+    try {
+      request = applyPromptStructuredOutput(request);
+      const payload = this.prepareMessageParams(request);
+      const providerRequest =
+        freezeProviderRequest<AnthropicPreparedProviderRequest>({
+          request,
+          messageParams: payload.messageParams,
+          useStructuredOutput: payload.useStructuredOutput,
+        });
+      return {
+        prepared: {
+          mode: context.mode,
+          providerRequest,
+          requestView: createPreparedRequestView({
+            operation: "anthropic.messages",
+            mode: context.mode,
+            payload: payload.messageParams as unknown as Record<
+              string,
+              unknown
+            >,
+            structuredOutput: request.settings.structuredOutput,
+            reasoningField: "thinking",
+          }),
+          promptAccounting: { status: "unavailable" },
+          outputTokenLimit: context.outputTokenLimit,
+          bindings: {
+            adapterRevision: ANTHROPIC_ADAPTER_REVISION,
+            requestShapeRevision: ANTHROPIC_REQUEST_SHAPE_REVISION,
+          },
+        },
+      };
+    } catch (error) {
+      return { error: this.createErrorResponse(error, request) };
+    }
+  }
+
+  async sendPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    const providerRequest =
+      prepared.providerRequest as AnthropicPreparedProviderRequest;
+    const request = providerRequest.request;
+    try {
+      const anthropic = this.createClient(apiKey);
+      const messageParams = structuredClone(
+        providerRequest.messageParams
+      ) as Anthropic.Messages.MessageCreateParamsNonStreaming;
+      const requestTransportOptions = this.createTransportOptions(options);
+      const completion =
+        Object.keys(requestTransportOptions).length > 0
+          ? await anthropic.messages.create(
+              messageParams,
+              requestTransportOptions
+            )
+          : await anthropic.messages.create(messageParams);
+      return this.createSuccessResponse(completion, request);
+    } catch (error) {
+      this.logger.error("Anthropic prepared API error:", error);
+      return this.createErrorResponse(error, request);
+    }
+  }
+
+  async *streamPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    const providerRequest =
+      prepared.providerRequest as AnthropicPreparedProviderRequest;
+    yield* this.streamMessages(
+      providerRequest.request,
+      structuredClone(providerRequest.messageParams),
+      providerRequest.useStructuredOutput,
+      apiKey,
+      options
+    );
+  }
+
   /**
    * Sends a chat message to Anthropic's API
    *
@@ -75,6 +195,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     apiKey: string,
     options?: AdapterRequestOptions
   ): Promise<LLMResponse | LLMFailureResponse> {
+    request = applyPromptStructuredOutput(request);
     try {
       const {
         anthropic,
@@ -121,7 +242,25 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string,
     options?: AdapterRequestOptions
-  ): AsyncIterable<LLMStreamEvent> {
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    request = applyPromptStructuredOutput(request);
+    const payload = this.prepareMessageParams(request);
+    yield* this.streamMessages(
+      request,
+      payload.messageParams,
+      payload.useStructuredOutput,
+      apiKey,
+      options
+    );
+  }
+
+  private async *streamMessages(
+    request: InternalLLMChatRequest,
+    messageParams: Anthropic.Messages.MessageCreateParams,
+    useStructuredOutput: boolean,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
     const accumulator: AnthropicStreamAccumulator = {
       id: "",
       model: request.modelId,
@@ -129,17 +268,14 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
       content: "",
       reasoning: "",
       stopReason: null,
+      rawParts: [],
     };
     let sawEvent = false;
     let started = false;
 
     try {
-      const {
-        anthropic,
-        messageParams,
-        requestTransportOptions,
-        useStructuredOutput,
-      } = this.prepareMessageRequest(request, apiKey, options);
+      const anthropic = this.createClient(apiKey);
+      const requestTransportOptions = this.createTransportOptions(options);
 
       this.logger.info(`Making Anthropic streaming API call for model: ${request.modelId}`, {
         useStructuredOutput,
@@ -159,6 +295,49 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
           accumulator.stopReason = event.message.stop_reason ?? accumulator.stopReason;
           accumulator.usage = this.mergeAnthropicUsage(accumulator.usage, event.message.usage);
 
+          if (event.message.stop_reason != null) {
+            yield {
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: 0,
+                  finishReason: this.mapAnthropicStopReason(
+                    event.message.stop_reason
+                  ),
+                  termination: normalizeTermination(
+                    event.message.stop_reason,
+                    event.message.stop_reason === "max_tokens"
+                      ? "output"
+                      : undefined
+                  ),
+                },
+              },
+            };
+          }
+
+          let usageEvent: AdapterLLMStreamEvent | undefined;
+          if (event.message.usage) {
+            const normalized = this.normalizeAnthropicUsage(
+              accumulator.usage
+            );
+            if (normalized.usage) {
+              yield {
+                type: "adapter_evidence",
+                observedEvidence: {
+                  usage: normalized.usage,
+                  usageEvidence: normalized.usageEvidence,
+                },
+              };
+              usageEvent = {
+                type: "usage",
+                usage: normalized.usage,
+                observedEvidence: {
+                  usageEvidence: normalized.usageEvidence,
+                },
+              };
+            }
+          }
+
           if (!started) {
             started = true;
             yield {
@@ -170,13 +349,161 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
             };
           }
 
-          if (event.message.usage) {
-            yield {
-              type: "usage",
-              usage: this.mapAnthropicUsage(accumulator.usage),
-            };
+          if (usageEvent) {
+            yield usageEvent;
           }
           continue;
+        }
+
+        const publicEvents: AdapterLLMStreamEvent[] = [];
+
+        if (event.type === "content_block_start") {
+          const block = event.content_block as any;
+          const rawValue = toPreparedRequestValue(block);
+          const rawPart = {
+            type: `content_block_start:${String(block?.type ?? "unknown")}`,
+            ...(typeof block?.text === "string" && { text: block.text }),
+            ...(typeof block?.thinking === "string" && {
+              text: block.thinking,
+              reasoning: true,
+            }),
+            ...(rawValue !== undefined && {
+              value: {
+                blockIndex: event.index,
+                block: rawValue,
+              },
+            }),
+          };
+          accumulator.rawParts.push(rawPart);
+          yield {
+            type: "adapter_evidence",
+            observedEvidence: {
+              choice: {
+                index: 0,
+                ...(block?.type === "text" &&
+                  typeof block.text === "string" && {
+                    rawContentDelta: block.text,
+                  }),
+                rawContentParts: [rawPart],
+              },
+            },
+          };
+          if (block?.type === "text" && typeof block.text === "string" && block.text.length > 0) {
+            accumulator.content += block.text;
+            publicEvents.push({
+              type: "content_delta",
+              delta: block.text,
+              index: 0,
+            });
+          } else if (
+            block?.type === "thinking" &&
+            typeof block.thinking === "string" &&
+            block.thinking.length > 0
+          ) {
+            accumulator.reasoning += block.thinking;
+            if (request.settings.reasoning?.exclude !== true) {
+              publicEvents.push({
+                type: "reasoning_delta",
+                delta: block.thinking,
+                index: 0,
+              });
+            }
+          }
+        } else if (event.type === "content_block_delta") {
+          const delta = event.delta as any;
+          const rawValue = toPreparedRequestValue(delta);
+          const rawPart = {
+            type: String(delta?.type ?? "unknown"),
+            ...(typeof delta?.text === "string" && { text: delta.text }),
+            ...(typeof delta?.thinking === "string" && {
+              text: delta.thinking,
+              reasoning: true,
+            }),
+            ...(rawValue !== undefined && {
+              value: {
+                blockIndex: event.index,
+                delta: rawValue,
+              },
+            }),
+          };
+          accumulator.rawParts.push(rawPart);
+          yield {
+            type: "adapter_evidence",
+            observedEvidence: {
+              choice: {
+                index: 0,
+                ...(delta?.type === "text_delta" &&
+                  typeof delta.text === "string" && {
+                    rawContentDelta: delta.text,
+                  }),
+                rawContentParts: [rawPart],
+              },
+            },
+          };
+          if (delta?.type === "text_delta" && typeof delta.text === "string" && delta.text.length > 0) {
+            accumulator.content += delta.text;
+            publicEvents.push({
+              type: "content_delta",
+              delta: delta.text,
+              index: 0,
+            });
+          } else if (
+            delta?.type === "thinking_delta" &&
+            typeof delta.thinking === "string" &&
+            delta.thinking.length > 0
+          ) {
+            accumulator.reasoning += delta.thinking;
+            if (request.settings.reasoning?.exclude !== true) {
+              publicEvents.push({
+                type: "reasoning_delta",
+                delta: delta.thinking,
+                index: 0,
+              });
+            }
+          }
+        } else if (event.type === "message_delta") {
+          accumulator.stopReason = event.delta.stop_reason ?? accumulator.stopReason;
+          if (event.delta.stop_reason != null) {
+            yield {
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: 0,
+                  finishReason: this.mapAnthropicStopReason(
+                    event.delta.stop_reason
+                  ),
+                  termination: normalizeTermination(
+                    event.delta.stop_reason,
+                    event.delta.stop_reason === "max_tokens"
+                      ? "output"
+                      : undefined
+                  ),
+                },
+              },
+            };
+          }
+          accumulator.usage = this.mergeAnthropicUsage(accumulator.usage, event.usage);
+          if (event.usage) {
+            const normalized = this.normalizeAnthropicUsage(
+              accumulator.usage
+            );
+            if (normalized.usage) {
+              yield {
+                type: "adapter_evidence",
+                observedEvidence: {
+                  usage: normalized.usage,
+                  usageEvidence: normalized.usageEvidence,
+                },
+              };
+              publicEvents.push({
+                type: "usage",
+                usage: normalized.usage,
+                observedEvidence: {
+                  usageEvidence: normalized.usageEvidence,
+                },
+              });
+            }
+          }
         }
 
         if (!started) {
@@ -189,46 +516,8 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
             created: accumulator.created,
           };
         }
-
-        if (event.type === "content_block_start") {
-          const block = event.content_block as any;
-          if (block?.type === "text" && typeof block.text === "string" && block.text.length > 0) {
-            accumulator.content += block.text;
-            yield { type: "content_delta", delta: block.text, index: event.index };
-          } else if (
-            block?.type === "thinking" &&
-            typeof block.thinking === "string" &&
-            block.thinking.length > 0
-          ) {
-            accumulator.reasoning += block.thinking;
-            if (request.settings.reasoning?.exclude !== true) {
-              yield { type: "reasoning_delta", delta: block.thinking, index: event.index };
-            }
-          }
-        } else if (event.type === "content_block_delta") {
-          const delta = event.delta as any;
-          if (delta?.type === "text_delta" && typeof delta.text === "string" && delta.text.length > 0) {
-            accumulator.content += delta.text;
-            yield { type: "content_delta", delta: delta.text, index: event.index };
-          } else if (
-            delta?.type === "thinking_delta" &&
-            typeof delta.thinking === "string" &&
-            delta.thinking.length > 0
-          ) {
-            accumulator.reasoning += delta.thinking;
-            if (request.settings.reasoning?.exclude !== true) {
-              yield { type: "reasoning_delta", delta: delta.thinking, index: event.index };
-            }
-          }
-        } else if (event.type === "message_delta") {
-          accumulator.stopReason = event.delta.stop_reason ?? accumulator.stopReason;
-          accumulator.usage = this.mergeAnthropicUsage(accumulator.usage, event.usage);
-          if (event.usage) {
-            yield {
-              type: "usage",
-              usage: this.mapAnthropicUsage(accumulator.usage),
-            };
-          }
+        for (const publicEvent of publicEvents) {
+          yield publicEvent;
         }
       }
 
@@ -236,6 +525,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
         this.createSyntheticMessage(request, accumulator),
         request
       );
+      response.choices[0].rawContentParts = accumulator.rawParts;
       yield { type: "complete", response };
     } catch (error) {
       this.logger.error("Anthropic streaming API error:", error);
@@ -246,6 +536,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
           this.createSyntheticMessage(request, accumulator),
           request
         );
+        partial.choices[0].rawContentParts = accumulator.rawParts;
         errorResponse.partialResponse = {
           id: partial.id,
           provider: partial.provider,
@@ -253,6 +544,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
           created: partial.created,
           choices: partial.choices,
           usage: partial.usage,
+          usageEvidence: partial.usageEvidence,
         };
       }
 
@@ -287,6 +579,34 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     apiKey: string,
     options?: AdapterRequestOptions
   ): AnthropicPreparedRequest {
+    const payload = this.prepareMessageParams(request);
+    return {
+      anthropic: this.createClient(apiKey),
+      requestTransportOptions: this.createTransportOptions(options),
+      ...payload,
+    };
+  }
+
+  private createClient(apiKey: string): Anthropic {
+    return new Anthropic({
+      apiKey,
+      ...(this.baseURL && { baseURL: this.baseURL }),
+      maxRetries: 0,
+    });
+  }
+
+  private createTransportOptions(
+    options?: AdapterRequestOptions
+  ): Record<string, unknown> {
+    return {
+      ...(options?.signal && { signal: options.signal }),
+      ...(options?.timeoutMs !== undefined && { timeout: options.timeoutMs }),
+    };
+  }
+
+  private prepareMessageParams(
+    request: InternalLLMChatRequest
+  ): AnthropicMessagePayload {
     const hasTemperature = request.settings.temperature !== undefined;
     const hasTopP = request.settings.topP !== undefined;
     if (hasTemperature && hasTopP) {
@@ -298,21 +618,9 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     // Check if generally available structured output is requested.
     const useStructuredOutput = !!(
       request.settings.structuredOutput?.schema &&
-      request.settings.structuredOutput.enabled !== false
+      request.settings.structuredOutput.enabled !== false &&
+      request.settings.structuredOutput.delivery !== "prompt"
     );
-
-    // Initialize Anthropic client
-    const anthropic = new Anthropic({
-      apiKey,
-      ...(this.baseURL && { baseURL: this.baseURL }),
-      maxRetries: 0, // retries are owned by the unified LLMService retry layer
-    });
-
-    // Per-request transport options (abort signal, timeout)
-    const requestTransportOptions = {
-      ...(options?.signal && { signal: options.signal }),
-      ...(options?.timeoutMs !== undefined && { timeout: options.timeoutMs }),
-    };
 
     // Format messages for Anthropic API (Claude has specific requirements)
     const { messages, systemMessage } = this.formatMessagesForAnthropic(request);
@@ -392,22 +700,22 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
     }
 
     return {
-      anthropic,
       messageParams,
-      requestTransportOptions,
       useStructuredOutput,
       messages,
     };
   }
 
+  private normalizeAnthropicUsage(usage: any) {
+    return normalizeUsage(usage, {
+      prompt: ["input_tokens"],
+      completion: ["output_tokens"],
+      total: [],
+    });
+  }
+
   private mapAnthropicUsage(usage: any) {
-    const promptTokens = usage.input_tokens ?? 0;
-    const completionTokens = usage.output_tokens ?? 0;
-    return {
-      prompt_tokens: promptTokens,
-      completion_tokens: completionTokens,
-      total_tokens: promptTokens + completionTokens,
-    };
+    return this.normalizeAnthropicUsage(usage).usage ?? {};
   }
 
   private mergeAnthropicUsage(
@@ -418,12 +726,7 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
       return current;
     }
 
-    return {
-      ...(current || {}),
-      ...next,
-      input_tokens: next.input_tokens ?? current?.input_tokens ?? 0,
-      output_tokens: next.output_tokens ?? current?.output_tokens ?? 0,
-    };
+    return mergeUsageRecords(current, next);
   }
 
   private createSyntheticMessage(
@@ -621,7 +924,23 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
         role: "assistant",
         content: textContent,
       },
+      rawContent: textContent,
+      rawContentParts: completion.content.map((block: any) => ({
+        type: String(block.type ?? "unknown"),
+        ...(typeof block.text === "string" && { text: block.text }),
+        ...(typeof block.thinking === "string" && {
+          text: block.thinking,
+          reasoning: true,
+        }),
+        ...(toPreparedRequestValue(block) !== undefined && {
+          value: toPreparedRequestValue(block),
+        }),
+      })),
       finish_reason: finishReason,
+      termination: normalizeTermination(
+        completion.stop_reason,
+        completion.stop_reason === "max_tokens" ? "output" : undefined
+      ),
       index: 0,
     };
 
@@ -630,20 +949,22 @@ export class AnthropicClientAdapter implements ILLMClientAdapter {
       choice.reasoning = reasoning;
     }
 
+    const normalizedUsage = normalizeUsage(
+      completion.usage as unknown as Record<string, unknown> | undefined,
+      {
+        prompt: ["input_tokens"],
+        completion: ["output_tokens"],
+        total: [],
+      }
+    );
+
     return {
       id: completion.id,
       provider: request.providerId,
       model: completion.model || request.modelId,
       created: Math.floor(Date.now() / 1000), // Anthropic doesn't provide created timestamp
       choices: [choice],
-      usage: completion.usage
-        ? {
-            prompt_tokens: completion.usage.input_tokens,
-            completion_tokens: completion.usage.output_tokens,
-            total_tokens:
-              completion.usage.input_tokens + completion.usage.output_tokens,
-          }
-        : undefined,
+      ...normalizedUsage,
       object: "chat.completion",
     };
   }

--- a/src/llm/clients/GeminiClientAdapter.test.ts
+++ b/src/llm/clients/GeminiClientAdapter.test.ts
@@ -837,7 +837,7 @@ describe('GeminiClientAdapter', () => {
         thinkingBudget: -1,
         includeThoughts: true
       });
-      expect(events[0]).toMatchObject({
+      expect(events.find((event) => event.type === "start")).toMatchObject({
         type: 'start',
         provider: 'gemini',
         model: 'gemini-2.5-pro'
@@ -864,6 +864,49 @@ describe('GeminiClientAdapter', () => {
         expect(complete.response.choices[0].finish_reason).toBe('stop');
         expect(complete.response.usage?.total_tokens).toBe(7);
       }
+    });
+
+    it("keeps non-text streaming evidence typed by its provider part", async () => {
+      mockGenerateContentStream.mockResolvedValueOnce(streamFrom([{
+        modelUsed: "gemini-2.5-pro",
+        candidates: [{
+          finishReason: "STOP",
+          content: {
+            role: "model",
+            parts: [{
+              functionCall: {
+                name: "lookup",
+                args: { city: "Paris" },
+              },
+            }],
+          },
+        }],
+      }]));
+
+      const events = await collectEvents();
+      const evidence = events.find(
+        (event) =>
+          event.type === "adapter_evidence" &&
+          event.observedEvidence.choice?.rawContentParts?.length
+      );
+
+      expect(evidence).toMatchObject({
+        type: "adapter_evidence",
+        observedEvidence: {
+          choice: {
+            index: 0,
+            rawContentParts: [{
+              type: "functionCall",
+              value: {
+                functionCall: {
+                  name: "lookup",
+                  args: { city: "Paris" },
+                },
+              },
+            }],
+          },
+        },
+      });
     });
 
     it('should preserve transport options and request configuration', async () => {

--- a/src/llm/clients/GeminiClientAdapter.ts
+++ b/src/llm/clients/GeminiClientAdapter.ts
@@ -6,21 +6,35 @@ import type {
   LLMResponse,
   LLMFailureResponse,
   GeminiSafetySetting,
-  LLMStreamEvent,
 } from "../types";
 import type {
   ILLMClientAdapter,
   InternalLLMChatRequest,
   AdapterRequestOptions,
+  AdapterLLMStreamEvent,
+  AdapterPreparationContext,
+  AdapterPreparationResult,
+  AdapterPreparedRequest,
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
+import {
+  mergeUsageRecords,
+  normalizeTermination,
+  normalizeUsage,
+} from "../../shared/adapters/usageUtils";
 import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
 import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
+import {
+  applyPromptStructuredOutput,
+  createPreparedRequestView,
+  freezeProviderRequest,
+  toPreparedRequestValue,
+} from "./preparedAdapterUtils";
 
 interface GeminiTransportState {
   abortSignal?: AbortSignal;
@@ -38,14 +52,50 @@ interface GeminiPreparedRequest {
   contents: any[];
 }
 
+interface GeminiSemanticRequest {
+  params: any;
+  generationConfig: any;
+  safetySettings?: any[];
+  systemInstruction?: string;
+  contents: any[];
+}
+
+interface GeminiPreparedProviderRequest {
+  request: InternalLLMChatRequest;
+  params: any;
+}
+
+const GEMINI_ADAPTER_REVISION = "gemini-adapter-v1";
+const GEMINI_REQUEST_SHAPE_REVISION = "gemini-generate-content-v1";
+
 interface GeminiStreamAccumulator {
   responseId: string;
   created: number;
   model: string;
   contentParts: string[];
   thoughtParts: string[];
+  rawParts: Record<string, unknown>[];
   finishReason: string | null;
   usageMetadata?: any;
+}
+
+function getGeminiRawPartType(part: Record<string, unknown>): string {
+  if (part.thought === true) {
+    return "thought";
+  }
+  if (typeof part.text === "string") {
+    return "text";
+  }
+  const typedKeys = [
+    "functionCall",
+    "functionResponse",
+    "executableCode",
+    "codeExecutionResult",
+    "inlineData",
+    "fileData",
+    "videoMetadata",
+  ];
+  return typedKeys.find((key) => part[key] !== undefined) ?? "unknown";
 }
 
 /**
@@ -74,6 +124,97 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
     this.logger = config?.logger ?? createDefaultLogger();
   }
 
+  async prepareRequest(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult> {
+    try {
+      request = applyPromptStructuredOutput(request);
+      const semantic = this.prepareGenerateContentParams(request);
+      const providerRequest =
+        freezeProviderRequest<GeminiPreparedProviderRequest>({
+          request,
+          params: semantic.params,
+        });
+      return {
+        prepared: {
+          mode: context.mode,
+          providerRequest,
+          requestView: createPreparedRequestView({
+            operation:
+              context.mode === "stream"
+                ? "gemini.generateContentStream"
+                : "gemini.generateContent",
+            mode: context.mode,
+            payload: {
+              ...semantic.params,
+              systemInstruction: semantic.systemInstruction,
+              thinkingConfig: semantic.generationConfig.thinkingConfig,
+            },
+            messageField: "contents",
+            systemField: "systemInstruction",
+            reasoningField: "thinkingConfig",
+            structuredOutput: request.settings.structuredOutput,
+          }),
+          promptAccounting: { status: "unavailable" },
+          outputTokenLimit: context.outputTokenLimit,
+          bindings: {
+            adapterRevision: GEMINI_ADAPTER_REVISION,
+            requestShapeRevision: GEMINI_REQUEST_SHAPE_REVISION,
+          },
+        },
+      };
+    } catch (error) {
+      return { error: this.createErrorResponse(error, request) };
+    }
+  }
+
+  async sendPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    const providerRequest =
+      prepared.providerRequest as GeminiPreparedProviderRequest;
+    const request = providerRequest.request;
+    let transportState: GeminiTransportState | undefined;
+    try {
+      transportState = this.createTransportState(options);
+      const params = this.addTransportToParams(
+        structuredClone(providerRequest.params),
+        options,
+        transportState
+      );
+      const genAI = new GoogleGenAI({ apiKey });
+      const result = await genAI.models.generateContent(params);
+      return this.createSuccessResponse(result, request);
+    } catch (error) {
+      this.logger.error("Gemini prepared API error:", error);
+      return this.createErrorResponse(
+        error,
+        request,
+        this.getTransportErrorContext(options, transportState)
+      );
+    } finally {
+      transportState?.cleanup();
+    }
+  }
+
+  async *streamPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    const providerRequest =
+      prepared.providerRequest as GeminiPreparedProviderRequest;
+    yield* this.streamContent(
+      providerRequest.request,
+      structuredClone(providerRequest.params),
+      apiKey,
+      options
+    );
+  }
+
   /**
    * Sends a chat message to Gemini's API
    *
@@ -86,6 +227,7 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
     apiKey: string,
     options?: AdapterRequestOptions
   ): Promise<LLMResponse | LLMFailureResponse> {
+    request = applyPromptStructuredOutput(request);
     // The SDK enforces httpOptions.timeout by aborting the same internal controller
     // the caller's abortSignal funnels into, so timeout and caller abort surface as
     // identical AbortErrors and cannot be distinguished from the error object. The
@@ -131,13 +273,25 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string,
     options?: AdapterRequestOptions
-  ): AsyncIterable<LLMStreamEvent> {
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    request = applyPromptStructuredOutput(request);
+    const semantic = this.prepareGenerateContentParams(request);
+    yield* this.streamContent(request, semantic.params, apiKey, options);
+  }
+
+  private async *streamContent(
+    request: InternalLLMChatRequest,
+    semanticParams: any,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
     const accumulator: GeminiStreamAccumulator = {
       responseId: this.generateResponseId(),
       created: Math.floor(Date.now() / 1000),
       model: request.modelId,
       contentParts: [],
       thoughtParts: [],
+      rawParts: [],
       finishReason: null,
     };
     let transportState: GeminiTransportState | undefined;
@@ -145,15 +299,31 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
     let started = false;
 
     try {
-      const prepared = this.prepareGenerateContentRequest(request, apiKey, options);
-      transportState = prepared.transportState;
+      transportState = this.createTransportState(options);
+      const params = this.addTransportToParams(
+        semanticParams,
+        options,
+        transportState
+      );
+      const genAI = new GoogleGenAI({ apiKey });
 
       this.logger.info(`Making Gemini streaming API call for model: ${request.modelId}`);
-      const stream = await prepared.genAI.models.generateContentStream(prepared.params);
+      const stream = await genAI.models.generateContentStream(params);
 
       for await (const chunk of stream) {
         sawChunk = true;
         this.updateGeminiAccumulatorMetadata(accumulator, chunk);
+        const chunkEvents = this.processGeminiStreamChunk(
+          accumulator,
+          chunk,
+          request
+        );
+
+        for (const event of chunkEvents) {
+          if (event.type === "adapter_evidence") {
+            yield event;
+          }
+        }
 
         if (!started) {
           started = true;
@@ -166,8 +336,10 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
           };
         }
 
-        for (const event of this.processGeminiStreamChunk(accumulator, chunk, request)) {
-          yield event;
+        for (const event of chunkEvents) {
+          if (event.type !== "adapter_evidence") {
+            yield event;
+          }
         }
       }
 
@@ -196,6 +368,7 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
           created: partial.created,
           choices: partial.choices,
           usage: partial.usage,
+          usageEvidence: partial.usageEvidence,
         };
       }
 
@@ -238,13 +411,27 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
   ): GeminiPreparedRequest {
     // The SDK's internal retry layer is opt-in via httpOptions.retryOptions and
     // must stay unset because LLMService's withRetry owns retrying.
-    const genAI = new GoogleGenAI({ apiKey });
-    const { contents, generationConfig, safetySettings, systemInstruction } =
-      this.formatInternalRequestToGemini(request);
+    const semantic = this.prepareGenerateContentParams(request);
     const transportState = this.createTransportState(options);
 
     return {
-      genAI,
+      ...semantic,
+      genAI: new GoogleGenAI({ apiKey }),
+      params: this.addTransportToParams(
+        semantic.params,
+        options,
+        transportState
+      ),
+      transportState,
+    };
+  }
+
+  private prepareGenerateContentParams(
+    request: InternalLLMChatRequest
+  ): GeminiSemanticRequest {
+    const { contents, generationConfig, safetySettings, systemInstruction } =
+      this.formatInternalRequestToGemini(request);
+    return {
       params: {
         model: request.modelId,
         contents,
@@ -252,21 +439,31 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
           ...generationConfig,
           safetySettings,
           ...(systemInstruction && { systemInstruction }),
-          ...(transportState.abortSignal && {
-            abortSignal: transportState.abortSignal,
-          }),
-          // Keep the SDK's server-side timeout hint (X-Server-Timeout header),
-          // padded so the adapter's local timer always fires first.
-          ...(options?.timeoutMs !== undefined && {
-            httpOptions: { timeout: options.timeoutMs + 1000 },
-          }),
         },
       },
-      transportState,
       generationConfig,
       safetySettings,
       systemInstruction,
       contents,
+    };
+  }
+
+  private addTransportToParams(
+    semanticParams: any,
+    options: AdapterRequestOptions | undefined,
+    transportState: GeminiTransportState
+  ): any {
+    return {
+      ...semanticParams,
+      config: {
+        ...semanticParams.config,
+        ...(transportState.abortSignal && {
+          abortSignal: transportState.abortSignal,
+        }),
+        ...(options?.timeoutMs !== undefined && {
+          httpOptions: { timeout: options.timeoutMs + 1000 },
+        }),
+      },
     };
   }
 
@@ -326,7 +523,10 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
     const candidate = chunk.candidates?.[0];
     accumulator.finishReason = candidate?.finishReason ?? accumulator.finishReason;
     if (chunk.usageMetadata) {
-      accumulator.usageMetadata = chunk.usageMetadata;
+      accumulator.usageMetadata = mergeUsageRecords(
+        accumulator.usageMetadata,
+        chunk.usageMetadata
+      );
     }
   }
 
@@ -334,11 +534,56 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
     accumulator: GeminiStreamAccumulator,
     chunk: any,
     request: InternalLLMChatRequest
-  ): LLMStreamEvent[] {
-    const events: LLMStreamEvent[] = [];
-    const parts = chunk.candidates?.[0]?.content?.parts || [];
+  ): AdapterLLMStreamEvent[] {
+    const events: AdapterLLMStreamEvent[] = [];
+    const candidate = chunk.candidates?.[0];
+    const parts = candidate?.content?.parts || [];
+    const rawFinishReason = candidate?.finishReason;
+    if (rawFinishReason != null) {
+      events.push({
+        type: "adapter_evidence",
+        observedEvidence: {
+          choice: {
+            index: 0,
+            finishReason: this.mapGeminiFinishReason(rawFinishReason),
+            termination: normalizeTermination(
+              rawFinishReason,
+              rawFinishReason === "MAX_TOKENS" ? "output" : undefined
+            ),
+          },
+        },
+      });
+    }
 
     for (const part of parts) {
+      const rawPart = toPreparedRequestValue(part);
+      if (
+        rawPart &&
+        typeof rawPart === "object" &&
+        !Array.isArray(rawPart)
+      ) {
+        accumulator.rawParts.push(rawPart);
+      }
+      events.push({
+        type: "adapter_evidence",
+        observedEvidence: {
+          choice: {
+            index: 0,
+            ...(!part?.thought &&
+              typeof part?.text === "string" && {
+                rawContentDelta: part.text,
+              }),
+            rawContentParts: [{
+              type: getGeminiRawPartType(part),
+              ...(typeof part?.text === "string" && {
+                text: part.text,
+              }),
+              ...(rawPart !== undefined && { value: rawPart }),
+              ...(part?.thought && { reasoning: true }),
+            }],
+          },
+        },
+      });
       if (typeof part?.text !== "string" || part.text.length === 0) {
         continue;
       }
@@ -363,14 +608,27 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
     }
 
     if (chunk.usageMetadata) {
-      events.push({
-        type: "usage",
-        usage: {
-          prompt_tokens: chunk.usageMetadata.promptTokenCount || 0,
-          completion_tokens: chunk.usageMetadata.candidatesTokenCount || 0,
-          total_tokens: chunk.usageMetadata.totalTokenCount || 0,
-        },
+      const normalized = normalizeUsage(chunk.usageMetadata, {
+        prompt: ["promptTokenCount"],
+        completion: ["candidatesTokenCount"],
+        total: ["totalTokenCount"],
       });
+      if (normalized.usage) {
+        events.push({
+          type: "adapter_evidence",
+          observedEvidence: {
+            usage: normalized.usage,
+            usageEvidence: normalized.usageEvidence,
+          },
+        });
+        events.push({
+          type: "usage",
+          usage: normalized.usage,
+          observedEvidence: {
+            usageEvidence: normalized.usageEvidence,
+          },
+        });
+      }
     }
 
     return events;
@@ -379,10 +637,7 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
   private createSyntheticGeminiResponse(
     accumulator: GeminiStreamAccumulator
   ): any {
-    const parts = [
-      ...accumulator.thoughtParts.map((text) => ({ text, thought: true })),
-      ...accumulator.contentParts.map((text) => ({ text })),
-    ];
+    const parts = accumulator.rawParts;
 
     return {
       responseId: accumulator.responseId,
@@ -528,7 +783,11 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
     }
 
     // Handle structured output configuration for Gemini
-    if (request.settings.structuredOutput?.schema && request.settings.structuredOutput.enabled !== false) {
+    if (
+      request.settings.structuredOutput?.schema &&
+      request.settings.structuredOutput.enabled !== false &&
+      request.settings.structuredOutput.delivery !== "prompt"
+    ) {
       const so = request.settings.structuredOutput;
       generationConfig.responseMimeType = 'application/json';
       generationConfig.responseSchema = this.convertToGeminiSchema(so.schema);
@@ -587,11 +846,10 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
       }
     }
 
-    // Extract usage data if available
-    const usageMetadata = response.usageMetadata || {};
+    const rawFinishReason = candidate?.finishReason ?? null;
 
     const finishReason = this.mapGeminiFinishReason(
-      candidate?.finishReason || null
+      rawFinishReason
     );
 
     const choice: any = {
@@ -599,7 +857,20 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
         role: "assistant",
         content: content,
       },
+      rawContent: content,
+      rawContentParts: (candidate?.content?.parts ?? []).map((part: any) => ({
+        type: getGeminiRawPartType(part),
+        ...(typeof part.text === "string" && { text: part.text }),
+        ...(part.thought && { reasoning: true }),
+        ...(toPreparedRequestValue(part) !== undefined && {
+          value: toPreparedRequestValue(part),
+        }),
+      })),
       finish_reason: finishReason,
+      termination: normalizeTermination(
+        rawFinishReason,
+        rawFinishReason === "MAX_TOKENS" ? "output" : undefined
+      ),
       index: 0,
     };
 
@@ -608,19 +879,19 @@ export class GeminiClientAdapter implements ILLMClientAdapter {
       choice.reasoning = reasoning;
     }
 
+    const normalizedUsage = normalizeUsage(response.usageMetadata, {
+      prompt: ["promptTokenCount"],
+      completion: ["candidatesTokenCount"],
+      total: ["totalTokenCount"],
+    });
+
     return {
       id: (response as any).responseId || this.generateResponseId(),
       provider: request.providerId,
       model: response.modelUsed || request.modelId,
       created: (response as any).created || Math.floor(Date.now() / 1000),
       choices: [choice],
-      usage: usageMetadata
-        ? {
-            prompt_tokens: usageMetadata.promptTokenCount || 0,
-            completion_tokens: usageMetadata.candidatesTokenCount || 0,
-            total_tokens: usageMetadata.totalTokenCount || 0,
-          }
-        : undefined,
+      ...normalizedUsage,
       object: "chat.completion",
     };
   }

--- a/src/llm/clients/LlamaCppClientAdapter.test.ts
+++ b/src/llm/clients/LlamaCppClientAdapter.test.ts
@@ -995,7 +995,7 @@ describe('LlamaCppClientAdapter', () => {
         stream: true,
         stream_options: { include_usage: true },
       }));
-      expect(events[0]).toMatchObject({
+      expect(events.find((event) => event.type === "start")).toMatchObject({
         type: 'start',
         provider: 'llamacpp',
         model: 'llamacpp',

--- a/src/llm/clients/LlamaCppClientAdapter.ts
+++ b/src/llm/clients/LlamaCppClientAdapter.ts
@@ -2,11 +2,16 @@
 // Provides LLM chat completions via llama.cpp's /v1/chat/completions endpoint.
 
 import OpenAI from "openai";
-import type { LLMResponse, LLMFailureResponse, ModelInfo, LLMStreamEvent } from "../types";
+import type { LLMResponse, LLMFailureResponse, ModelInfo } from "../types";
 import type {
   ILLMClientAdapter,
   InternalLLMChatRequest,
   AdapterRequestOptions,
+  AdapterLLMStreamEvent,
+  AdapterPreparationContext,
+  AdapterPreparationResult,
+  AdapterPreparedRequest,
+  AdapterRevalidationResult,
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
@@ -14,12 +19,29 @@ import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
-import { LlamaCppServerClient } from "./LlamaCppServerClient";
+import {
+  LlamaCppServerClient,
+  type LlamaCppModelsResponse,
+} from "./LlamaCppServerClient";
 import { detectGgufCapabilities } from "../config";
 import { extractMarkerDelimitedContent } from "../../prompting/parser";
 import { mapOpenAIChatLogprobs } from "../../shared/adapters/logprobsUtils";
+import {
+  normalizeTermination,
+  normalizeUsage,
+} from "../../shared/adapters/usageUtils";
 import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
+import {
+  applyPromptStructuredOutput,
+  createPreparedRequestView,
+  freezeProviderRequest,
+} from "./preparedAdapterUtils";
+import {
+  createLlamaCppStateBinding,
+  selectLlamaCppModel,
+  type LlamaCppStateBinding,
+} from "./llamaCppState";
 
 /**
  * Configuration options for LlamaCppClientAdapter
@@ -38,6 +60,28 @@ interface LlamaCppCompletionRequest {
   completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams;
   detectedCaps: Partial<ModelInfo> | null;
 }
+
+interface LlamaCppSemanticRequest {
+  completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams;
+  detectedCaps: Partial<ModelInfo> | null;
+}
+
+interface LlamaCppPreparedProviderRequest extends LlamaCppSemanticRequest {
+  request: InternalLLMChatRequest;
+  stateBinding?: LlamaCppStateBinding;
+}
+
+/** Opaque dynamic state shared from service resolution into preparation. */
+interface LlamaCppPreparationSnapshot {
+  kind: "llamacpp-preparation-v1";
+  selectedModel: string;
+  detectedCaps: Partial<ModelInfo> | null;
+  stateBinding?: LlamaCppStateBinding;
+}
+
+const LLAMACPP_ADAPTER_REVISION = "llamacpp-adapter-v1";
+const LLAMACPP_REQUEST_SHAPE_REVISION = "llamacpp-chat-completions-v1";
+const LLAMACPP_PREFLIGHT_TIMEOUT_MS = 5000;
 
 interface LlamaCppStreamChoiceState {
   content: string;
@@ -87,8 +131,10 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
   private baseURL: string;
   private checkHealth: boolean;
   private serverClient: LlamaCppServerClient;
-  private cachedModelCapabilities: Partial<ModelInfo> | null = null;
-  private detectionAttempted: boolean = false;
+  private cachedModelCapabilities = new Map<
+    string,
+    Partial<ModelInfo> | null
+  >();
   private logger: Logger;
 
   /**
@@ -107,54 +153,328 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
   }
 
   /**
+   * Captures the selected model capabilities and observable state in one
+   * snapshot so service-level defaults and adapter preparation cannot diverge.
+   */
+  async getPreparationSnapshot(
+    selectedModel = "llamacpp"
+  ): Promise<LlamaCppPreparationSnapshot> {
+    try {
+      const [props, models] = await Promise.all([
+        this.serverClient.getProps({
+          model: selectedModel,
+          timeoutMs: LLAMACPP_PREFLIGHT_TIMEOUT_MS,
+        }),
+        this.serverClient.getModels({
+          timeoutMs: LLAMACPP_PREFLIGHT_TIMEOUT_MS,
+        }),
+      ]);
+      const stateBinding = createLlamaCppStateBinding(
+        props,
+        models,
+        selectedModel
+      );
+      return {
+        kind: "llamacpp-preparation-v1",
+        selectedModel,
+        detectedCaps: this.detectModelCapabilities(
+          models,
+          selectedModel
+        ),
+        ...(stateBinding && { stateBinding }),
+      };
+    } catch (error) {
+      this.logger.warn(
+        "Observable llama.cpp state is unavailable during resolution:",
+        error
+      );
+      return {
+        kind: "llamacpp-preparation-v1",
+        selectedModel,
+        detectedCaps: null,
+      };
+    }
+  }
+
+  async prepareRequest(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult> {
+    request = applyPromptStructuredOutput(request);
+    const providedSnapshot = context.providerState as
+      | LlamaCppPreparationSnapshot
+      | undefined;
+    const snapshot =
+      providedSnapshot?.kind === "llamacpp-preparation-v1" &&
+      providedSnapshot.selectedModel === request.modelId
+        ? providedSnapshot
+        : await this.getPreparationSnapshot(request.modelId);
+    const stateBinding = snapshot.stateBinding;
+
+    const semantic = await this.prepareCompletionParams(
+      request,
+      snapshot.detectedCaps
+    );
+    if ("error" in semantic) {
+      return semantic;
+    }
+    const completionParams =
+      context.mode === "stream"
+        ? ({
+            ...semantic.completionParams,
+            stream: true,
+            stream_options: { include_usage: true },
+          } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming)
+        : semantic.completionParams;
+    let promptAccounting: AdapterPreparedRequest["promptAccounting"] = {
+      status: "unavailable",
+    };
+    if (stateBinding) {
+      try {
+        const counted = await this.serverClient.countChatCompletionInputTokens(
+          completionParams as unknown as Record<string, unknown>,
+          {
+            model: request.modelId,
+            timeoutMs: LLAMACPP_PREFLIGHT_TIMEOUT_MS,
+          }
+        );
+        const [currentProps, currentModels] = await Promise.all([
+          this.serverClient.getProps({
+            model: request.modelId,
+            timeoutMs: LLAMACPP_PREFLIGHT_TIMEOUT_MS,
+          }),
+          this.serverClient.getModels({
+            timeoutMs: LLAMACPP_PREFLIGHT_TIMEOUT_MS,
+          }),
+        ]);
+        const currentBinding = createLlamaCppStateBinding(
+          currentProps,
+          currentModels,
+          request.modelId
+        );
+        if (
+          currentBinding?.serverStateFingerprint ===
+          stateBinding.serverStateFingerprint
+        ) {
+          promptAccounting = {
+            status: "available",
+            count: {
+              tokens: counted.input_tokens,
+              method: "exact",
+              tokenizerId: `llamacpp-active:${stateBinding.metadata.model}`,
+              tokenProfileRevision:
+                `llamacpp-state:${stateBinding.serverStateFingerprint}`,
+            },
+          };
+        } else {
+          this.logger.warn(
+            "llama.cpp state changed while preparing the exact prompt count; accounting is unavailable."
+          );
+        }
+      } catch (error) {
+        this.logger.warn(
+          "Exact llama.cpp prepared-message counting is unavailable:",
+          error
+        );
+      }
+    }
+
+    const providerRequest =
+      freezeProviderRequest<LlamaCppPreparedProviderRequest>({
+        request,
+        completionParams,
+        detectedCaps: semantic.detectedCaps,
+        ...(stateBinding && { stateBinding }),
+      });
+    return {
+      prepared: {
+        mode: context.mode,
+        providerRequest,
+        requestView: createPreparedRequestView({
+          operation: "llamacpp.chat.completions",
+          mode: context.mode,
+          payload: completionParams as unknown as Record<string, unknown>,
+          structuredOutput: request.settings.structuredOutput,
+          extensionFields: ["chat_template_kwargs", "grammar"],
+        }),
+        promptAccounting,
+        outputTokenLimit: context.outputTokenLimit,
+        bindings: {
+          adapterRevision: LLAMACPP_ADAPTER_REVISION,
+          requestShapeRevision: LLAMACPP_REQUEST_SHAPE_REVISION,
+          ...(stateBinding && {
+            tokenProfileRevision:
+              `llamacpp-state:${stateBinding.serverStateFingerprint}`,
+            serverStateFingerprint: stateBinding.serverStateFingerprint,
+            chatTemplateFingerprint: stateBinding.chatTemplateFingerprint,
+          }),
+        },
+      },
+    };
+  }
+
+  async revalidatePreparedRequest(
+    prepared: AdapterPreparedRequest,
+    options?: AdapterRequestOptions
+  ): Promise<AdapterRevalidationResult> {
+    const providerRequest =
+      prepared.providerRequest as LlamaCppPreparedProviderRequest;
+    if (!providerRequest.stateBinding) {
+      return { valid: true };
+    }
+    try {
+      const utilityOptions = {
+        model: providerRequest.request.modelId,
+        ...(options?.signal && { signal: options.signal }),
+        timeoutMs: options?.timeoutMs ?? LLAMACPP_PREFLIGHT_TIMEOUT_MS,
+      };
+      const [props, models] = await Promise.all([
+        this.serverClient.getProps(utilityOptions),
+        this.serverClient.getModels(utilityOptions),
+      ]);
+      const current = createLlamaCppStateBinding(
+        props,
+        models,
+        providerRequest.request.modelId
+      );
+      if (
+        !current ||
+        current.serverStateFingerprint !==
+          providerRequest.stateBinding.serverStateFingerprint ||
+        current.chatTemplateFingerprint !==
+          providerRequest.stateBinding.chatTemplateFingerprint
+      ) {
+        this.clearModelCache();
+        return {
+          valid: false,
+          error: {
+            provider: providerRequest.request.providerId,
+            model: providerRequest.request.modelId,
+            error: {
+              message:
+                "The llama.cpp model, server build, or chat template changed after preparation.",
+              code: ADAPTER_ERROR_CODES.PREPARED_CALL_STALE,
+              type: "validation_error",
+            },
+            object: "error",
+          },
+        };
+      }
+      return { valid: true };
+    } catch (error) {
+      return {
+        valid: false,
+        error: this.createErrorResponse(error, providerRequest.request),
+      };
+    }
+  }
+
+  async sendPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    const providerRequest =
+      prepared.providerRequest as LlamaCppPreparedProviderRequest;
+    const request = providerRequest.request;
+    try {
+      const openai = this.createClient(apiKey);
+      const completionParams = structuredClone(
+        providerRequest.completionParams
+      ) as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming;
+      const transportOptions = this.createTransportOptions(options);
+      const completion =
+        Object.keys(transportOptions).length > 0
+          ? await openai.chat.completions.create(
+              completionParams,
+              transportOptions
+            )
+          : await openai.chat.completions.create(completionParams);
+      return this.createSuccessResponse(
+        completion,
+        request,
+        providerRequest.detectedCaps
+      );
+    } catch (error) {
+      this.handleConnectionError(error);
+      return this.createErrorResponse(error, request);
+    }
+  }
+
+  async *streamPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    const providerRequest =
+      prepared.providerRequest as LlamaCppPreparedProviderRequest;
+    yield* this.streamCompletion(
+      providerRequest.request,
+      structuredClone(
+        providerRequest.completionParams
+      ) as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+      providerRequest.detectedCaps,
+      apiKey,
+      options
+    );
+  }
+
+  /**
    * Gets model capabilities by detecting the loaded GGUF model
    *
-   * This method caches the result to avoid repeated HTTP calls.
-   * Cache is automatically cleared on connection errors in sendMessage().
+   * The observable model list is refreshed on each call so router selection
+   * cannot reuse stale identity. Capability classification is cached by the
+   * selected model's full observable identity and cleared on connection errors.
    *
    * @returns Detected model capabilities or null if detection fails
    */
-  async getModelCapabilities(): Promise<Partial<ModelInfo> | null> {
-    // Return cached result if available
-    if (this.cachedModelCapabilities !== null) {
-      return this.cachedModelCapabilities;
-    }
-
-    // Return null if we already tried and failed
-    if (this.detectionAttempted) {
-      return null;
-    }
-
+  async getModelCapabilities(
+    selectedModel?: string
+  ): Promise<Partial<ModelInfo> | null> {
     // Attempt detection
     try {
       this.logger.debug(`Detecting model capabilities from llama.cpp server at ${this.baseURL}`);
-      const { data } = await this.serverClient.getModels();
+      const models = await this.serverClient.getModels();
+      const { data } = models;
 
       if (!data || data.length === 0) {
         this.logger.warn('No models loaded in llama.cpp server');
-        this.detectionAttempted = true;
         return null;
       }
-
-      const ggufFilename = data[0].id;
-      const capabilities = detectGgufCapabilities(ggufFilename);
-
-      // Cache the result (even if null)
-      this.cachedModelCapabilities = capabilities;
-      this.detectionAttempted = true;
-
-      if (capabilities) {
-        this.logger.debug(`Cached model capabilities for: ${ggufFilename}`);
-      } else {
-        this.logger.debug(`No known pattern matched for: ${ggufFilename}`);
-      }
-
-      return capabilities;
+      return this.detectModelCapabilities(models, selectedModel);
     } catch (error) {
       this.logger.warn('Failed to detect model capabilities:', error);
-      this.detectionAttempted = true;
       return null;
     }
+  }
+
+  private detectModelCapabilities(
+    models: LlamaCppModelsResponse,
+    selectedModel?: string
+  ): Partial<ModelInfo> | null {
+    const selected = selectLlamaCppModel(models, selectedModel);
+    if (!selected) {
+      this.logger.warn(
+        `Could not identify llama.cpp router model '${selectedModel ?? ""}'.`
+      );
+      return null;
+    }
+    const cacheKey = JSON.stringify({
+      id: selected.id,
+      aliases: selected.aliases,
+      meta: selected.meta,
+    });
+    if (this.cachedModelCapabilities.has(cacheKey)) {
+      return this.cachedModelCapabilities.get(cacheKey) ?? null;
+    }
+    const capabilities = detectGgufCapabilities(selected.id);
+    this.cachedModelCapabilities.set(cacheKey, capabilities);
+    if (capabilities) {
+      this.logger.debug(`Cached model capabilities for: ${selected.id}`);
+    } else {
+      this.logger.debug(`No known pattern matched for: ${selected.id}`);
+    }
+    return capabilities;
   }
 
   /**
@@ -164,8 +484,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
    * if the server has been restarted with a different model.
    */
   clearModelCache(): void {
-    this.cachedModelCapabilities = null;
-    this.detectionAttempted = false;
+    this.cachedModelCapabilities.clear();
     this.logger.debug('Cleared model capabilities cache');
   }
 
@@ -181,6 +500,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
     apiKey: string,
     options?: AdapterRequestOptions
   ): Promise<LLMResponse | LLMFailureResponse> {
+    request = applyPromptStructuredOutput(request);
     try {
       const prepared = await this.prepareCompletionRequest(request, apiKey);
       if ("error" in prepared) {
@@ -236,40 +556,165 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string,
     options?: AdapterRequestOptions
-  ): AsyncIterable<LLMStreamEvent> {
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    request = applyPromptStructuredOutput(request);
+    const prepared = await this.prepareCompletionRequest(request, apiKey);
+    if ("error" in prepared) {
+      yield { type: "error", error: prepared.error };
+      return;
+    }
+    const streamParams = {
+      ...prepared.completionParams,
+      stream: true,
+      stream_options: { include_usage: true },
+    } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
+    yield* this.streamCompletion(
+      request,
+      streamParams,
+      prepared.detectedCaps,
+      apiKey,
+      options
+    );
+  }
+
+  private async *streamCompletion(
+    request: InternalLLMChatRequest,
+    streamParams: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+    initialDetectedCaps: Partial<ModelInfo> | null,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
     const choiceStates = new Map<number, LlamaCppStreamChoiceState>();
     let responseId = "";
     let responseModel = request.modelId;
     let created = Math.floor(Date.now() / 1000);
     let usage: OpenAI.Completions.CompletionUsage | undefined;
-    let detectedCaps: Partial<ModelInfo> | null = null;
+    const detectedCaps = initialDetectedCaps;
 
     try {
-      const prepared = await this.prepareCompletionRequest(request, apiKey);
-      if ("error" in prepared) {
-        yield { type: "error", error: prepared.error };
-        return;
-      }
-
-      detectedCaps = prepared.detectedCaps;
-      const streamParams = {
-        ...prepared.completionParams,
-        stream: true,
-        stream_options: { include_usage: true },
-      } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
-
+      const openai = this.createClient(apiKey);
       const transportOptions = this.createTransportOptions(options);
       const stream =
         Object.keys(transportOptions).length > 0
-          ? await prepared.openai.chat.completions.create(streamParams, transportOptions)
-          : await prepared.openai.chat.completions.create(streamParams);
+          ? await openai.chat.completions.create(streamParams, transportOptions)
+          : await openai.chat.completions.create(streamParams);
 
       let started = false;
       for await (const chunk of stream) {
         responseId = chunk.id || responseId;
         responseModel = chunk.model || responseModel;
         created = chunk.created || created;
+        const evidenceEvents: AdapterLLMStreamEvent[] = [];
+        const publicEvents: AdapterLLMStreamEvent[] = [];
 
+        if (chunk.usage) {
+          usage = chunk.usage;
+          const normalized = normalizeUsage(
+            chunk.usage as unknown as Record<string, unknown>,
+            {
+              prompt: ["prompt_tokens"],
+              completion: ["completion_tokens"],
+              total: ["total_tokens"],
+            }
+          );
+          if (normalized.usage) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                usage: normalized.usage,
+                usageEvidence: normalized.usageEvidence,
+              },
+            });
+            publicEvents.push({
+              type: "usage",
+              usage: normalized.usage,
+              observedEvidence: {
+                usageEvidence: normalized.usageEvidence,
+              },
+            });
+          }
+        }
+
+        for (const choice of chunk.choices || []) {
+          const state = this.getStreamChoiceState(choiceStates, choice.index);
+          state.finishReason = choice.finish_reason ?? state.finishReason;
+          if (choice.finish_reason != null) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  finishReason: choice.finish_reason,
+                  termination: normalizeTermination(choice.finish_reason),
+                },
+              },
+            });
+          }
+
+          const delta = choice.delta as any;
+          const reasoningDelta = delta?.reasoning_content ?? delta?.reasoning;
+          if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
+            state.reasoningContent += reasoningDelta;
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  rawContentParts: [{
+                    type: "reasoning",
+                    text: reasoningDelta,
+                    reasoning: true,
+                  }],
+                },
+              },
+            });
+            if (request.settings.reasoning?.exclude !== true) {
+              publicEvents.push({
+                type: "reasoning_delta",
+                delta: reasoningDelta,
+                index: choice.index,
+              });
+            }
+          }
+
+          if (typeof delta?.content === "string" && delta.content.length > 0) {
+            state.content += delta.content;
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  rawContentDelta: delta.content,
+                  rawContentParts: [{
+                    type: "text",
+                    text: delta.content,
+                  }],
+                },
+              },
+            });
+            const visibleDelta = this.filterLiveNothinkPrefixDelta(
+              state,
+              delta.content,
+              detectedCaps?.localReasoning?.nothinkPrefix
+            );
+            if (visibleDelta) {
+              publicEvents.push({
+                type: "content_delta",
+                delta: visibleDelta,
+                index: choice.index,
+              });
+            }
+          }
+
+          const mappedLogprobs = mapOpenAIChatLogprobs(choice.logprobs);
+          if (mappedLogprobs) {
+            state.logprobs.push(...((choice.logprobs as any)?.content || []));
+          }
+        }
+
+        for (const event of evidenceEvents) {
+          yield event;
+        }
         if (!started) {
           started = true;
           yield {
@@ -280,56 +725,8 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
             created,
           };
         }
-
-        if (chunk.usage) {
-          usage = chunk.usage;
-          yield {
-            type: "usage",
-            usage: {
-              prompt_tokens: chunk.usage.prompt_tokens,
-              completion_tokens: chunk.usage.completion_tokens,
-              total_tokens: chunk.usage.total_tokens,
-            },
-          };
-        }
-
-        for (const choice of chunk.choices || []) {
-          const state = this.getStreamChoiceState(choiceStates, choice.index);
-          state.finishReason = choice.finish_reason ?? state.finishReason;
-
-          const delta = choice.delta as any;
-          const reasoningDelta = delta?.reasoning_content ?? delta?.reasoning;
-          if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
-            state.reasoningContent += reasoningDelta;
-            if (request.settings.reasoning?.exclude !== true) {
-              yield {
-                type: "reasoning_delta",
-                delta: reasoningDelta,
-                index: choice.index,
-              };
-            }
-          }
-
-          if (typeof delta?.content === "string" && delta.content.length > 0) {
-            state.content += delta.content;
-            const visibleDelta = this.filterLiveNothinkPrefixDelta(
-              state,
-              delta.content,
-              detectedCaps?.localReasoning?.nothinkPrefix
-            );
-            if (visibleDelta) {
-              yield {
-                type: "content_delta",
-                delta: visibleDelta,
-                index: choice.index,
-              };
-            }
-          }
-
-          const mappedLogprobs = mapOpenAIChatLogprobs(choice.logprobs);
-          if (mappedLogprobs) {
-            state.logprobs.push(...((choice.logprobs as any)?.content || []));
-          }
+        for (const event of publicEvents) {
+          yield event;
         }
       }
 
@@ -362,14 +759,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
     } catch (error) {
       this.logger.error("llama.cpp streaming API error:", error);
 
-      const errorMessage = (error as any)?.message || String(error);
-      if (
-        errorMessage.includes("ECONNREFUSED") ||
-        errorMessage.includes("fetch failed") ||
-        errorMessage.includes("connect")
-      ) {
-        this.clearModelCache();
-      }
+      this.handleConnectionError(error);
 
       const errorResponse = this.createErrorResponse(error, request);
       if (choiceStates.size > 0) {
@@ -392,6 +782,24 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
           created: partial.created,
           choices: partial.choices,
           usage: partial.usage,
+          usageEvidence: partial.usageEvidence,
+        };
+      } else if (usage) {
+        const normalizedUsage = normalizeUsage(
+          usage as unknown as Record<string, unknown>,
+          {
+            prompt: ["prompt_tokens"],
+            completion: ["completion_tokens"],
+            total: ["total_tokens"],
+          }
+        );
+        errorResponse.partialResponse = {
+          id: responseId,
+          provider: request.providerId,
+          model: responseModel,
+          created,
+          choices: [],
+          ...normalizedUsage,
         };
       }
 
@@ -426,14 +834,20 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
       }
     }
 
-    // Initialize OpenAI client with llama.cpp base URL
-    // API key is not used by llama.cpp but required by SDK
-    const openai = new OpenAI({
-      apiKey: apiKey || 'not-needed',
-      baseURL: `${this.baseURL}/v1`,
-      maxRetries: 0, // retries are owned by the unified LLMService retry layer
-    });
+    const semantic = await this.prepareCompletionParams(request);
+    if ("error" in semantic) {
+      return semantic;
+    }
+    return {
+      openai: this.createClient(apiKey),
+      ...semantic,
+    };
+  }
 
+  private async prepareCompletionParams(
+    request: InternalLLMChatRequest,
+    detectedCapsSnapshot?: Partial<ModelInfo> | null
+  ): Promise<LlamaCppSemanticRequest | { error: LLMFailureResponse }> {
     const messages = this.formatMessages(request);
     const completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams = {
       model: request.modelId,
@@ -464,7 +878,11 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
       }),
     } as OpenAI.Chat.Completions.ChatCompletionCreateParams;
 
-    if (request.settings.structuredOutput?.schema && request.settings.structuredOutput.enabled !== false) {
+    if (
+      request.settings.structuredOutput?.schema &&
+      request.settings.structuredOutput.enabled !== false &&
+      request.settings.structuredOutput.delivery !== "prompt"
+    ) {
       const so = request.settings.structuredOutput;
       (completionParams as any).response_format = {
         type: 'json_object',
@@ -472,7 +890,10 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
       };
     }
 
-    const detectedCaps = await this.getModelCapabilities();
+    const detectedCaps =
+      detectedCapsSnapshot === undefined
+        ? await this.getModelCapabilities(request.modelId)
+        : detectedCapsSnapshot;
     const localReasoning = detectedCaps?.localReasoning;
     const derivedKwargs: Record<string, string | number | boolean> = {};
     if (localReasoning?.toggleKwarg) {
@@ -518,7 +939,26 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
       }
     }
 
-    return { openai, completionParams, detectedCaps };
+    return { completionParams, detectedCaps };
+  }
+
+  private createClient(apiKey: string): OpenAI {
+    return new OpenAI({
+      apiKey: apiKey || "not-needed",
+      baseURL: `${this.baseURL}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  private handleConnectionError(error: unknown): void {
+    const errorMessage = (error as any)?.message || String(error);
+    if (
+      errorMessage.includes("ECONNREFUSED") ||
+      errorMessage.includes("fetch failed") ||
+      errorMessage.includes("connect")
+    ) {
+      this.clearModelCache();
+    }
   }
 
   private createTransportOptions(options?: AdapterRequestOptions) {
@@ -750,13 +1190,23 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
       detectedCaps?.reasoning?.canDisable === false;
     const excludeReasoning = request.settings.reasoning?.exclude === true;
 
+    const normalizedUsage = normalizeUsage(
+      completion.usage as unknown as Record<string, unknown> | undefined,
+      {
+        prompt: ["prompt_tokens"],
+        completion: ["completion_tokens"],
+        total: ["total_tokens"],
+      }
+    );
+
     return {
       id: completion.id,
       provider: request.providerId,
       model: completion.model || request.modelId,
       created: completion.created,
       choices: completion.choices.map((c) => {
-        let content = c.message.content || "";
+        const rawContent = c.message.content || "";
+        let content = rawContent;
 
         // Strip the template-injected "nothink" prefix (some chat templates leak an
         // empty think block into content when thinking is disabled). Exact match.
@@ -769,7 +1219,22 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
             role: "assistant",
             content,
           },
+          rawContent,
+          rawContentParts: [
+            {
+              type: "text",
+              text: rawContent,
+            },
+            ...((c.message as any).reasoning_content
+              ? [{
+                  type: "reasoning",
+                  text: String((c.message as any).reasoning_content),
+                  reasoning: true,
+                }]
+              : []),
+          ],
           finish_reason: c.finish_reason,
+          termination: normalizeTermination(c.finish_reason),
           index: c.index,
         };
 
@@ -803,13 +1268,7 @@ export class LlamaCppClientAdapter implements ILLMClientAdapter {
 
         return mappedChoice;
       }),
-      usage: completion.usage
-        ? {
-            prompt_tokens: completion.usage.prompt_tokens,
-            completion_tokens: completion.usage.completion_tokens,
-            total_tokens: completion.usage.total_tokens,
-          }
-        : undefined,
+      ...normalizedUsage,
       object: "chat.completion",
     };
   }

--- a/src/llm/clients/LlamaCppPrepared.test.ts
+++ b/src/llm/clients/LlamaCppPrepared.test.ts
@@ -1,0 +1,221 @@
+import { DEFAULT_LLM_SETTINGS } from "../config";
+import { LlamaCppClientAdapter } from "./LlamaCppClientAdapter";
+import type { InternalLLMChatRequest } from "./types";
+
+const baseProps = {
+  model_alias: "model.gguf",
+  chat_template: "{{ messages }}",
+  chat_template_caps: { supports_system_role: true },
+  build_info: { build: 1, commit: "abc" },
+};
+const baseModels = {
+  object: "list",
+  data: [{ id: "model.gguf", meta: { n_ctx: 4096 } }],
+};
+
+function request(enableThinking: boolean): InternalLLMChatRequest {
+  return {
+    providerId: "llamacpp",
+    modelId: "llamacpp",
+    messages: [{ role: "user", content: "Hello" }],
+    settings: {
+      ...DEFAULT_LLM_SETTINGS,
+      reasoning: { ...DEFAULT_LLM_SETTINGS.reasoning, enabled: false },
+      llamacpp: {
+        chatTemplateKwargs: { enable_thinking: enableThinking },
+      },
+    },
+  };
+}
+
+describe("LlamaCppClientAdapter prepared state", () => {
+  function adapterWithServer() {
+    const adapter = new LlamaCppClientAdapter({ logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } });
+    jest
+      .spyOn(adapter, "getModelCapabilities")
+      .mockResolvedValue(null);
+    const server = {
+      getProps: jest.fn().mockResolvedValue(baseProps),
+      getModels: jest.fn().mockResolvedValue(baseModels),
+      countChatCompletionInputTokens: jest
+        .fn()
+        .mockImplementation(async (body: Record<string, any>) => ({
+          input_tokens:
+            body.chat_template_kwargs?.enable_thinking === true ? 23 : 21,
+        })),
+    };
+    (adapter as any).serverClient = server;
+    return { adapter, server };
+  }
+
+  it("counts the exact final mode-bound body including template kwargs", async () => {
+    const { adapter } = adapterWithServer();
+    const plain = await adapter.prepareRequest(request(false), {
+      mode: "complete",
+      modelInfo: {} as any,
+    });
+    const thinking = await adapter.prepareRequest(request(true), {
+      mode: "stream",
+      modelInfo: {} as any,
+    });
+
+    expect("prepared" in plain && plain.prepared.promptAccounting).toMatchObject({
+      status: "available",
+      count: { tokens: 21, method: "exact" },
+    });
+    expect(
+      "prepared" in thinking && thinking.prepared.promptAccounting
+    ).toMatchObject({
+      status: "available",
+      count: { tokens: 23, method: "exact" },
+    });
+    if ("prepared" in thinking) {
+      expect(thinking.prepared.requestView.settings.stream).toBe(true);
+      expect(
+        thinking.prepared.requestView.extensions?.chat_template_kwargs
+      ).toEqual({ enable_thinking: true });
+    }
+  });
+
+  it("derives capability transformations from the same selected-model snapshot", async () => {
+    const { adapter, server } = adapterWithServer();
+    const capabilityProbe = jest.spyOn(adapter, "getModelCapabilities");
+    server.getModels.mockResolvedValue({
+      object: "list",
+      data: [{ id: "gemma-4-e4b-it.gguf", meta: { n_ctx: 32768 } }],
+    });
+    server.getProps.mockResolvedValue({
+      ...baseProps,
+      model_alias: "gemma-4-e4b-it.gguf",
+    });
+    const enabled = request(false);
+    enabled.settings.reasoning = {
+      ...enabled.settings.reasoning,
+      enabled: true,
+    };
+    enabled.settings.llamacpp = {};
+
+    const result = await adapter.prepareRequest(enabled, {
+      mode: "complete",
+      modelInfo: {} as any,
+    });
+
+    expect(capabilityProbe).not.toHaveBeenCalled();
+    if ("error" in result) {
+      throw new Error(result.error.error.message);
+    }
+    expect(
+      result.prepared.requestView.extensions?.chat_template_kwargs
+    ).toEqual({ enable_thinking: true });
+  });
+
+  it("reuses the service resolution snapshot and rejects a later model change", async () => {
+    const { adapter, server } = adapterWithServer();
+    server.getModels.mockResolvedValue({
+      object: "list",
+      data: [{ id: "gemma-4-e4b-it.gguf", meta: { n_ctx: 32768 } }],
+    });
+    server.getProps.mockResolvedValue({
+      ...baseProps,
+      model_alias: "gemma-4-e4b-it.gguf",
+    });
+    const snapshot = await adapter.getPreparationSnapshot("llamacpp");
+
+    server.getModels.mockResolvedValue({
+      object: "list",
+      data: [{ id: "different-model.gguf", meta: { n_ctx: 4096 } }],
+    });
+    server.getProps.mockResolvedValue({
+      ...baseProps,
+      model_alias: "different-model.gguf",
+      chat_template: "{{ different }}",
+    });
+    const enabled = request(false);
+    enabled.settings.reasoning = {
+      ...enabled.settings.reasoning,
+      enabled: true,
+    };
+    enabled.settings.llamacpp = {};
+
+    const result = await adapter.prepareRequest(enabled, {
+      mode: "complete",
+      modelInfo: {
+        ...snapshot.detectedCaps,
+      } as any,
+      providerState: snapshot,
+    });
+
+    if ("error" in result) {
+      throw new Error(result.error.error.message);
+    }
+    expect(
+      result.prepared.requestView.extensions?.chat_template_kwargs
+    ).toEqual({ enable_thinking: true });
+    expect(result.prepared.promptAccounting).toEqual({
+      status: "unavailable",
+    });
+  });
+
+  it("discards an exact count when observable state changes around counting", async () => {
+    const { adapter, server } = adapterWithServer();
+    server.getProps
+      .mockResolvedValueOnce(baseProps)
+      .mockResolvedValueOnce({
+        ...baseProps,
+        chat_template: "{{ changed during count }}",
+      });
+
+    const result = await adapter.prepareRequest(request(false), {
+      mode: "complete",
+      modelInfo: {} as any,
+    });
+
+    expect("prepared" in result && result.prepared.promptAccounting).toEqual({
+      status: "unavailable",
+    });
+  });
+
+  it("accepts unchanged state and rejects template/build/model changes", async () => {
+    const { adapter, server } = adapterWithServer();
+    const result = await adapter.prepareRequest(request(false), {
+      mode: "complete",
+      modelInfo: {} as any,
+    });
+    if ("error" in result) {
+      throw new Error(result.error.error.message);
+    }
+
+    await expect(
+      adapter.revalidatePreparedRequest(result.prepared)
+    ).resolves.toEqual({ valid: true });
+
+    server.getProps.mockResolvedValueOnce({
+      ...baseProps,
+      chat_template: "{{ changed }}",
+    });
+    const stale = await adapter.revalidatePreparedRequest(result.prepared);
+    expect(stale).toMatchObject({
+      valid: false,
+      error: {
+        error: { code: "PREPARED_CALL_STALE" },
+      },
+    });
+  });
+
+  it("degrades to unavailable when count/state endpoints are unavailable", async () => {
+    const { adapter, server } = adapterWithServer();
+    server.getProps.mockRejectedValueOnce(new Error("404"));
+    const result = await adapter.prepareRequest(request(false), {
+      mode: "complete",
+      modelInfo: {} as any,
+    });
+    expect("prepared" in result && result.prepared.promptAccounting).toEqual({
+      status: "unavailable",
+    });
+  });
+});

--- a/src/llm/clients/LlamaCppServerClient.test.ts
+++ b/src/llm/clients/LlamaCppServerClient.test.ts
@@ -365,4 +365,58 @@ describe('LlamaCppServerClient', () => {
       await expect(client.getSlots()).rejects.toThrow('Get slots failed: 500 Server Error');
     });
   });
+
+  describe("prepared chat input counting", () => {
+    it("sends the exact final body and validates the response", async () => {
+      const body = {
+        model: "llamacpp",
+        messages: [{ role: "user", content: "Hello" }],
+        stream: true,
+        stream_options: { include_usage: true },
+        chat_template_kwargs: { enable_thinking: false },
+      };
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          input_tokens: 21,
+          object: "response.input_tokens",
+        }),
+      });
+
+      const result = await client.countChatCompletionInputTokens(body);
+
+      expect(result.input_tokens).toBe(21);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${baseURL}/v1/chat/completions/input_tokens`,
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(body),
+        })
+      );
+    });
+
+    it("supports an encoded router model selector for props", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ chat_template: "template" }),
+      });
+
+      await client.getProps({ model: "folder/model name.gguf" });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${baseURL}/props?model=folder%2Fmodel%20name.gguf`
+      );
+    });
+
+    it("rejects malformed count responses", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ input_tokens: -1 }),
+      });
+
+      await expect(
+        client.countChatCompletionInputTokens({})
+      ).rejects.toThrow("invalid input_tokens");
+    });
+  });
 });

--- a/src/llm/clients/LlamaCppServerClient.ts
+++ b/src/llm/clients/LlamaCppServerClient.ts
@@ -45,9 +45,29 @@ export interface LlamaCppInfillResponse {
 export interface LlamaCppPropsResponse {
   assistant_name?: string;
   user_name?: string;
-  default_generation_settings?: Record<string, any>;
+  default_generation_settings?: Record<string, unknown>;
   total_slots?: number;
-  [key: string]: any;
+  model_alias?: string;
+  model_path?: string;
+  chat_template?: string;
+  chat_template_caps?: Record<string, unknown>;
+  bos_token?: string;
+  eos_token?: string;
+  build_info?: Record<string, unknown> | string;
+  [key: string]: unknown;
+}
+
+/** Response from /v1/chat/completions/input_tokens. */
+export interface LlamaCppChatInputTokensResponse {
+  input_tokens: number;
+  object?: string;
+}
+
+/** Transport and router-selection options for utility/preflight requests. */
+export interface LlamaCppUtilityRequestOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  model?: string;
 }
 
 /**
@@ -82,7 +102,9 @@ export interface LlamaCppModel {
   object?: string;
   created?: number;
   owned_by?: string;
-  [key: string]: any;
+  aliases?: string[];
+  meta?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 /**
@@ -126,6 +148,24 @@ export class LlamaCppServerClient {
   constructor(baseURL: string) {
     // Remove trailing slash if present
     this.baseURL = baseURL.replace(/\/$/, '');
+  }
+
+  private createFetchSignal(
+    options?: LlamaCppUtilityRequestOptions
+  ): AbortSignal | undefined {
+    if (options?.signal && options.timeoutMs !== undefined) {
+      return AbortSignal.any([
+        options.signal,
+        AbortSignal.timeout(options.timeoutMs),
+      ]);
+    }
+    if (options?.signal) {
+      return options.signal;
+    }
+    if (options?.timeoutMs !== undefined) {
+      return AbortSignal.timeout(options.timeoutMs);
+    }
+    return undefined;
   }
 
   /**
@@ -248,8 +288,16 @@ export class LlamaCppServerClient {
    * @returns Promise resolving to server properties
    * @throws Error if the request fails
    */
-  async getProps(): Promise<LlamaCppPropsResponse> {
-    const response = await fetch(`${this.baseURL}/props`);
+  async getProps(
+    options?: LlamaCppUtilityRequestOptions
+  ): Promise<LlamaCppPropsResponse> {
+    const query = options?.model
+      ? `?model=${encodeURIComponent(options.model)}`
+      : "";
+    const signal = this.createFetchSignal(options);
+    const response = signal
+      ? await fetch(`${this.baseURL}/props${query}`, { signal })
+      : await fetch(`${this.baseURL}/props${query}`);
 
     if (!response.ok) {
       throw new Error(`Get props failed: ${response.status} ${response.statusText}`);
@@ -323,13 +371,49 @@ export class LlamaCppServerClient {
    * // Output: "Qwen2.5-7B-Instruct-Q4_K_M.gguf"
    * ```
    */
-  async getModels(): Promise<LlamaCppModelsResponse> {
-    const response = await fetch(`${this.baseURL}/v1/models`);
+  async getModels(
+    options?: LlamaCppUtilityRequestOptions
+  ): Promise<LlamaCppModelsResponse> {
+    const signal = this.createFetchSignal(options);
+    const response = signal
+      ? await fetch(`${this.baseURL}/v1/models`, { signal })
+      : await fetch(`${this.baseURL}/v1/models`);
 
     if (!response.ok) {
       throw new Error(`Get models failed: ${response.status} ${response.statusText}`);
     }
 
     return await response.json();
+  }
+
+  /**
+   * Counts input tokens after the active llama.cpp chat template is applied.
+   * The body must be the final semantic /v1/chat/completions payload.
+   */
+  async countChatCompletionInputTokens(
+    finalBody: Record<string, unknown>,
+    options?: LlamaCppUtilityRequestOptions
+  ): Promise<LlamaCppChatInputTokensResponse> {
+    const signal = this.createFetchSignal(options);
+    const response = await fetch(
+      `${this.baseURL}/v1/chat/completions/input_tokens`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(finalBody),
+        ...(signal && { signal }),
+      }
+    );
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Chat input token count failed: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+    const result = (await response.json()) as LlamaCppChatInputTokensResponse;
+    if (!Number.isSafeInteger(result.input_tokens) || result.input_tokens < 0) {
+      throw new Error("llama.cpp returned an invalid input_tokens value.");
+    }
+    return result;
   }
 }

--- a/src/llm/clients/MistralClientAdapter.test.ts
+++ b/src/llm/clients/MistralClientAdapter.test.ts
@@ -531,7 +531,7 @@ describe('MistralClientAdapter', () => {
       }, expect.objectContaining({
         signal: expect.any(AbortSignal),
       }));
-      expect(events[0]).toMatchObject({
+      expect(events.find((event) => event.type === "start")).toMatchObject({
         type: 'start',
         provider: 'mistral',
         model: 'mistral-small-latest',

--- a/src/llm/clients/MistralClientAdapter.ts
+++ b/src/llm/clients/MistralClientAdapter.ts
@@ -2,30 +2,53 @@
 // Provides access to Mistral models including Codestral and Mistral Large.
 
 import { Mistral } from "@mistralai/mistralai";
-import type { LLMResponse, LLMFailureResponse, LLMStreamEvent } from "../types";
+import type { LLMResponse, LLMFailureResponse } from "../types";
 import type {
   ILLMClientAdapter,
   InternalLLMChatRequest,
   AdapterRequestOptions,
+  AdapterLLMStreamEvent,
+  AdapterPreparationContext,
+  AdapterPreparationResult,
+  AdapterPreparedRequest,
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
+import {
+  normalizeTermination,
+  normalizeUsage,
+} from "../../shared/adapters/usageUtils";
 import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
 import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
+import {
+  applyPromptStructuredOutput,
+  createPreparedRequestView,
+  freezeProviderRequest,
+  toPreparedRequestValue,
+} from "./preparedAdapterUtils";
 
 interface MistralPreparedRequest {
   mistral: Mistral;
   requestOptions: any;
 }
 
+interface MistralPreparedProviderRequest {
+  request: InternalLLMChatRequest;
+  requestOptions: Record<string, unknown>;
+}
+
+const MISTRAL_ADAPTER_REVISION = "mistral-adapter-v1";
+const MISTRAL_REQUEST_SHAPE_REVISION = "mistral-chat-v1";
+
 interface MistralStreamChoiceState {
   content: string;
   reasoning: string;
   finishReason: string | null;
+  rawContentParts: unknown[];
 }
 
 /**
@@ -78,6 +101,83 @@ export class MistralClientAdapter implements ILLMClientAdapter {
     this.logger = config?.logger ?? createDefaultLogger();
   }
 
+  async prepareRequest(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult> {
+    try {
+      request = applyPromptStructuredOutput(request);
+      const baseOptions = this.prepareCompletionParams(request);
+      const requestOptions =
+        context.mode === "stream"
+          ? { ...baseOptions, stream: true }
+          : baseOptions;
+      const providerRequest =
+        freezeProviderRequest<MistralPreparedProviderRequest>({
+          request,
+          requestOptions,
+        });
+      return {
+        prepared: {
+          mode: context.mode,
+          providerRequest,
+          requestView: createPreparedRequestView({
+            operation: "mistral.chat",
+            mode: context.mode,
+            payload: requestOptions,
+            structuredOutput: request.settings.structuredOutput,
+          }),
+          promptAccounting: { status: "unavailable" },
+          outputTokenLimit: context.outputTokenLimit,
+          bindings: {
+            adapterRevision: MISTRAL_ADAPTER_REVISION,
+            requestShapeRevision: MISTRAL_REQUEST_SHAPE_REVISION,
+          },
+        },
+      };
+    } catch (error) {
+      return { error: this.createErrorResponse(error, request) };
+    }
+  }
+
+  async sendPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    const providerRequest =
+      prepared.providerRequest as MistralPreparedProviderRequest;
+    const request = providerRequest.request;
+    try {
+      const mistral = this.createClient(apiKey);
+      const requestOptions = structuredClone(providerRequest.requestOptions);
+      const transportOptions = this.createTransportOptions(options);
+      const completion =
+        Object.keys(transportOptions).length > 0
+          ? await mistral.chat.complete(requestOptions as any, transportOptions as any)
+          : await mistral.chat.complete(requestOptions as any);
+      return this.createSuccessResponse(completion, request);
+    } catch (error) {
+      this.logger.error("Mistral prepared API error:", error);
+      return this.createErrorResponse(error, request);
+    }
+  }
+
+  async *streamPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    const providerRequest =
+      prepared.providerRequest as MistralPreparedProviderRequest;
+    yield* this.streamCompletion(
+      providerRequest.request,
+      structuredClone(providerRequest.requestOptions),
+      apiKey,
+      options
+    );
+  }
+
   /**
    * Sends a chat message to Mistral API
    *
@@ -90,6 +190,7 @@ export class MistralClientAdapter implements ILLMClientAdapter {
     apiKey: string,
     options?: AdapterRequestOptions
   ): Promise<LLMResponse | LLMFailureResponse> {
+    request = applyPromptStructuredOutput(request);
     try {
       // Initialize Mistral client (Speakeasy SDK retry default is "none" — retries
       // are owned by the unified LLMService retry layer)
@@ -133,7 +234,22 @@ export class MistralClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string,
     options?: AdapterRequestOptions
-  ): AsyncIterable<LLMStreamEvent> {
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    request = applyPromptStructuredOutput(request);
+    yield* this.streamCompletion(
+      request,
+      { ...this.prepareCompletionParams(request), stream: true },
+      apiKey,
+      options
+    );
+  }
+
+  private async *streamCompletion(
+    request: InternalLLMChatRequest,
+    streamRequestOptions: Record<string, unknown>,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
     const choiceStates = new Map<number, MistralStreamChoiceState>();
     let responseId = "";
     let responseModel = request.modelId;
@@ -141,18 +257,14 @@ export class MistralClientAdapter implements ILLMClientAdapter {
     let usage: any | undefined;
 
     try {
-      const { mistral, requestOptions } = this.prepareCompletionRequest(request, apiKey);
-      const streamRequestOptions = {
-        ...requestOptions,
-        stream: true,
-      };
+      const mistral = this.createClient(apiKey);
 
       this.logger.info(`Making Mistral streaming API call for model: ${request.modelId}`);
       const transportOptions = this.createTransportOptions(options);
       const stream =
         Object.keys(transportOptions).length > 0
-          ? await mistral.chat.stream(streamRequestOptions, transportOptions as any)
-          : await mistral.chat.stream(streamRequestOptions);
+          ? await mistral.chat.stream(streamRequestOptions as any, transportOptions as any)
+          : await mistral.chat.stream(streamRequestOptions as any);
 
       let started = false;
       for await (const event of stream as AsyncIterable<any>) {
@@ -160,7 +272,132 @@ export class MistralClientAdapter implements ILLMClientAdapter {
         responseId = chunk?.id || responseId;
         responseModel = chunk?.model || responseModel;
         created = chunk?.created || created;
+        const evidenceEvents: AdapterLLMStreamEvent[] = [];
+        const publicEvents: AdapterLLMStreamEvent[] = [];
 
+        if (chunk?.usage) {
+          usage = chunk.usage;
+          const normalized = this.normalizeMistralUsage(chunk.usage);
+          if (normalized.usage) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                usage: normalized.usage,
+                usageEvidence: normalized.usageEvidence,
+              },
+            });
+            publicEvents.push({
+              type: "usage",
+              usage: normalized.usage,
+              observedEvidence: {
+                usageEvidence: normalized.usageEvidence,
+              },
+            });
+          }
+        }
+
+        for (const choice of chunk?.choices || []) {
+          const index = choice.index ?? 0;
+          const state = this.getStreamChoiceState(choiceStates, index);
+          const rawFinishReason =
+            choice.finishReason ?? choice.finish_reason;
+          state.finishReason = rawFinishReason ?? state.finishReason;
+          if (rawFinishReason != null) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index,
+                  finishReason: rawFinishReason,
+                  termination: normalizeTermination(rawFinishReason),
+                },
+              },
+            });
+          }
+
+          const rawDelta = choice.delta?.content;
+          const rawContentParts =
+            typeof rawDelta === "string"
+              ? [{ type: "text", text: rawDelta }]
+              : Array.isArray(rawDelta)
+                ? rawDelta.map((part: any) => {
+                    const thinkingText =
+                      part?.type === "thinking" &&
+                      Array.isArray(part.thinking)
+                        ? part.thinking
+                            .filter(
+                              (item: any) =>
+                                typeof item?.text === "string"
+                            )
+                            .map((item: any) => item.text)
+                            .join("")
+                        : undefined;
+                    return {
+                      type: String(part?.type ?? "unknown"),
+                      ...(typeof part?.text === "string" && {
+                        text: part.text,
+                      }),
+                      ...(thinkingText !== undefined && {
+                        text: thinkingText,
+                        reasoning: true,
+                      }),
+                      ...(toPreparedRequestValue(part) !== undefined && {
+                        value: toPreparedRequestValue(part),
+                      }),
+                    };
+                  })
+                : [];
+          if (typeof rawDelta === "string") {
+            state.rawContentParts.push({
+              type: "text",
+              text: rawDelta,
+            });
+          } else if (Array.isArray(rawDelta)) {
+            state.rawContentParts.push(
+              ...rawDelta.map((part: unknown) =>
+                toPreparedRequestValue(part)
+              ).filter((part: unknown) => part !== undefined)
+            );
+          }
+          const deltas = this.extractMistralContentDeltas(rawDelta);
+          if (rawContentParts.length > 0) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index,
+                  ...(deltas.content.length > 0 && {
+                    rawContentDelta: deltas.content.join(""),
+                  }),
+                  rawContentParts,
+                },
+              },
+            });
+          }
+          for (const reasoningDelta of deltas.reasoning) {
+            state.reasoning += reasoningDelta;
+            if (request.settings.reasoning?.exclude !== true) {
+              publicEvents.push({
+                type: "reasoning_delta",
+                delta: reasoningDelta,
+                index,
+              });
+            }
+          }
+
+          for (const contentDelta of deltas.content) {
+            state.content += contentDelta;
+            publicEvents.push({
+              type: "content_delta",
+              delta: contentDelta,
+              index,
+            });
+          }
+        }
+
+        for (const bufferedEvent of evidenceEvents) {
+          yield bufferedEvent;
+        }
         if (!started) {
           started = true;
           yield {
@@ -171,40 +408,8 @@ export class MistralClientAdapter implements ILLMClientAdapter {
             created,
           };
         }
-
-        if (chunk?.usage) {
-          usage = chunk.usage;
-          yield {
-            type: "usage",
-            usage: this.mapMistralUsage(chunk.usage),
-          };
-        }
-
-        for (const choice of chunk?.choices || []) {
-          const index = choice.index ?? 0;
-          const state = this.getStreamChoiceState(choiceStates, index);
-          state.finishReason = choice.finishReason || choice.finish_reason || state.finishReason;
-
-          const deltas = this.extractMistralContentDeltas(choice.delta?.content);
-          for (const reasoningDelta of deltas.reasoning) {
-            state.reasoning += reasoningDelta;
-            if (request.settings.reasoning?.exclude !== true) {
-              yield {
-                type: "reasoning_delta",
-                delta: reasoningDelta,
-                index,
-              };
-            }
-          }
-
-          for (const contentDelta of deltas.content) {
-            state.content += contentDelta;
-            yield {
-              type: "content_delta",
-              delta: contentDelta,
-              index,
-            };
-          }
+        for (const bufferedEvent of publicEvents) {
+          yield bufferedEvent;
         }
       }
 
@@ -229,6 +434,21 @@ export class MistralClientAdapter implements ILLMClientAdapter {
           created: partial.created,
           choices: partial.choices,
           usage: partial.usage,
+          usageEvidence: partial.usageEvidence,
+        };
+      } else if (usage) {
+        const normalizedUsage = normalizeUsage(usage, {
+          prompt: ["promptTokens", "prompt_tokens"],
+          completion: ["completionTokens", "completion_tokens"],
+          total: ["totalTokens", "total_tokens"],
+        });
+        errorResponse.partialResponse = {
+          id: responseId,
+          provider: request.providerId,
+          model: responseModel,
+          created,
+          choices: [],
+          ...normalizedUsage,
         };
       }
 
@@ -266,18 +486,27 @@ export class MistralClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string
   ): MistralPreparedRequest {
-    // Initialize Mistral client (Speakeasy SDK retry default is "none" - retries
-    // are owned by the unified LLMService retry layer)
-    const mistral = new Mistral({
+    return {
+      mistral: this.createClient(apiKey),
+      requestOptions: this.prepareCompletionParams(request),
+    };
+  }
+
+  private createClient(apiKey: string): Mistral {
+    return new Mistral({
       apiKey,
       serverURL: this.baseURL !== 'https://api.mistral.ai' ? this.baseURL : undefined,
     });
+  }
 
+  private prepareCompletionParams(
+    request: InternalLLMChatRequest
+  ): Record<string, unknown> {
     // Format messages for Mistral API
     const messages = this.formatMessages(request);
 
     // Build request options
-    const requestOptions: any = {
+    const requestOptions: Record<string, any> = {
       model: request.modelId,
       messages: messages,
       temperature: request.settings.temperature,
@@ -294,7 +523,11 @@ export class MistralClientAdapter implements ILLMClientAdapter {
 
     // Handle structured output configuration for Mistral
     // Mistral only supports json_object mode, no schema validation
-    if (request.settings.structuredOutput?.schema && request.settings.structuredOutput.enabled !== false) {
+    if (
+      request.settings.structuredOutput?.schema &&
+      request.settings.structuredOutput.enabled !== false &&
+      request.settings.structuredOutput.delivery !== "prompt"
+    ) {
       requestOptions.responseFormat = { type: 'json_object' };
       this.logger.warn(
         `Mistral does not support JSON schema validation. ` +
@@ -302,7 +535,7 @@ export class MistralClientAdapter implements ILLMClientAdapter {
       );
     }
 
-    return { mistral, requestOptions };
+    return requestOptions;
   }
 
   private createTransportOptions(options?: AdapterRequestOptions): { timeoutMs?: number; signal?: AbortSignal } {
@@ -330,6 +563,7 @@ export class MistralClientAdapter implements ILLMClientAdapter {
         content: "",
         reasoning: "",
         finishReason: null,
+        rawContentParts: [],
       };
       states.set(index, state);
     }
@@ -379,10 +613,13 @@ export class MistralClientAdapter implements ILLMClientAdapter {
         index,
         message: {
           role: "assistant",
-          content: state.content,
+          content:
+            state.rawContentParts.length > 0
+              ? state.rawContentParts
+              : state.content,
           ...(state.reasoning && { reasoning: state.reasoning }),
         },
-        finishReason: state.finishReason || "stop",
+        finishReason: state.finishReason,
       }));
 
     return {
@@ -395,12 +632,16 @@ export class MistralClientAdapter implements ILLMClientAdapter {
     };
   }
 
+  private normalizeMistralUsage(usage: any) {
+    return normalizeUsage(usage, {
+      prompt: ["promptTokens", "prompt_tokens"],
+      completion: ["completionTokens", "completion_tokens"],
+      total: ["totalTokens", "total_tokens"],
+    });
+  }
+
   private mapMistralUsage(usage: any) {
-    return {
-      prompt_tokens: usage.promptTokens || usage.prompt_tokens || 0,
-      completion_tokens: usage.completionTokens || usage.completion_tokens || 0,
-      total_tokens: usage.totalTokens || usage.total_tokens || 0,
-    };
+    return this.normalizeMistralUsage(usage).usage ?? {};
   }
 
   /**
@@ -485,35 +726,71 @@ export class MistralClientAdapter implements ILLMClientAdapter {
       throw new Error("No valid choices in Mistral completion response");
     }
 
+    const normalizedUsage = normalizeUsage(completion.usage, {
+      prompt: ["promptTokens", "prompt_tokens"],
+      completion: ["completionTokens", "completion_tokens"],
+      total: ["totalTokens", "total_tokens"],
+    });
+
     return {
       id: completion.id || `mistral-${Date.now()}`,
       provider: request.providerId,
       model: completion.model || request.modelId,
       created: completion.created || Math.floor(Date.now() / 1000),
       choices: completion.choices.map((c: any, index: number) => {
+        const providerContent = c.message?.content;
+        const extractedContent =
+          this.extractMistralContentDeltas(providerContent);
+        const rawContent = extractedContent.content.join("");
+        const rawFinishReason =
+          c.finishReason ?? c.finish_reason ?? null;
         const responseChoice: any = {
           message: {
             role: "assistant",
-            content: typeof c.message?.content === "string" ? c.message.content : "",
+            content: rawContent,
           },
-          finish_reason: c.finishReason || c.finish_reason || "stop",
+          rawContent,
+          ...(Array.isArray(providerContent) && {
+            rawContentParts: providerContent.map((part: any) => {
+              const thinkingText =
+                part?.type === "thinking" && Array.isArray(part.thinking)
+                  ? part.thinking
+                      .filter(
+                        (item: any) => typeof item?.text === "string"
+                      )
+                      .map((item: any) => item.text)
+                      .join("")
+                  : undefined;
+              return {
+                type: String(part?.type ?? "unknown"),
+                ...(typeof part?.text === "string" && { text: part.text }),
+                ...(thinkingText !== undefined && {
+                  text: thinkingText,
+                  reasoning: true,
+                }),
+                ...(toPreparedRequestValue(part) !== undefined && {
+                  value: toPreparedRequestValue(part),
+                }),
+              };
+            }),
+          }),
+          finish_reason: rawFinishReason,
+          termination: normalizeTermination(rawFinishReason),
           index: c.index ?? index,
         };
 
-        const reasoning = c.reasoning || c.message?.reasoning || c.message?.reasoningContent;
+        const reasoning =
+          c.reasoning ||
+          c.message?.reasoning ||
+          c.message?.reasoningContent ||
+          extractedContent.reasoning.join("");
         if (reasoning && request.settings.reasoning && !request.settings.reasoning.exclude) {
           responseChoice.reasoning = reasoning;
         }
 
         return responseChoice;
       }),
-      usage: completion.usage
-        ? {
-            prompt_tokens: completion.usage.promptTokens || completion.usage.prompt_tokens || 0,
-            completion_tokens: completion.usage.completionTokens || completion.usage.completion_tokens || 0,
-            total_tokens: completion.usage.totalTokens || completion.usage.total_tokens || 0,
-          }
-        : undefined,
+      ...normalizedUsage,
       object: "chat.completion",
     };
   }

--- a/src/llm/clients/MockClientAdapter.test.ts
+++ b/src/llm/clients/MockClientAdapter.test.ts
@@ -290,7 +290,7 @@ describe('MockClientAdapter', () => {
         events.push(event);
       }
 
-      expect(events[0]).toMatchObject({
+      expect(events.find((event) => event.type === "start")).toMatchObject({
         type: 'start',
         provider: 'openai',
         model: 'mock-model',

--- a/src/llm/clients/MockClientAdapter.ts
+++ b/src/llm/clients/MockClientAdapter.ts
@@ -6,15 +6,33 @@ import type {
   LLMFailureResponse,
   ApiProviderId,
   LLMSettings,
-  LLMStreamEvent,
 } from "../types";
 import type {
   ILLMClientAdapter,
   InternalLLMChatRequest,
   AdapterErrorCode,
   AdapterRequestOptions,
+  AdapterLLMStreamEvent,
+  AdapterPreparationContext,
+  AdapterPreparationResult,
+  AdapterPreparedRequest,
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
+import { normalizeTermination } from "../../shared/adapters/usageUtils";
+import {
+  applyPromptStructuredOutput,
+  createPreparedRequestView,
+  freezeProviderRequest,
+} from "./preparedAdapterUtils";
+
+const MOCK_ADAPTER_REVISION = "mock-adapter-v1";
+const MOCK_REQUEST_SHAPE_REVISION = "mock-chat-v1";
+const MOCK_HEURISTIC_ID = "mock:utf16-code-units-per-4";
+const MOCK_HEURISTIC_REVISION = "mock-token-estimator-v1";
+
+interface MockPreparedProviderRequest {
+  request: InternalLLMChatRequest;
+}
 
 /**
  * Mock client adapter for testing LLM functionality
@@ -33,6 +51,77 @@ export class MockClientAdapter implements ILLMClientAdapter {
     this.providerId = providerId;
   }
 
+  async prepareRequest(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult> {
+    request = applyPromptStructuredOutput(request);
+    const providerRequest = freezeProviderRequest<MockPreparedProviderRequest>({
+      request,
+    });
+    return {
+      prepared: {
+        mode: context.mode,
+        providerRequest,
+        requestView: createPreparedRequestView({
+          operation: "mock.chat",
+          mode: context.mode,
+          payload: {
+            model: request.modelId,
+            messages: request.messages,
+            settings: request.settings,
+          },
+          structuredOutput: request.settings.structuredOutput,
+        }),
+        promptAccounting: {
+          status: "available",
+          count: {
+            tokens: Math.ceil(
+              request.messages.reduce(
+                (total, message) => total + message.content.length,
+                0
+              ) / 4
+            ),
+            method: "heuristic",
+            tokenizerId: MOCK_HEURISTIC_ID,
+            tokenProfileRevision: MOCK_HEURISTIC_REVISION,
+            uncertaintyTokens: Math.ceil(
+              request.messages.reduce(
+                (total, message) => total + message.content.length,
+                0
+              ) / 8
+            ),
+          },
+        },
+        outputTokenLimit: context.outputTokenLimit,
+        bindings: {
+          adapterRevision: MOCK_ADAPTER_REVISION,
+          requestShapeRevision: MOCK_REQUEST_SHAPE_REVISION,
+        },
+      },
+    };
+  }
+
+  async sendPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    const providerRequest =
+      prepared.providerRequest as MockPreparedProviderRequest;
+    return this.sendMessage(providerRequest.request, apiKey, options);
+  }
+
+  async *streamPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    const providerRequest =
+      prepared.providerRequest as MockPreparedProviderRequest;
+    yield* this.streamMessage(providerRequest.request, apiKey, options);
+  }
+
   /**
    * Sends a mock message response based on request content
    *
@@ -45,6 +134,7 @@ export class MockClientAdapter implements ILLMClientAdapter {
     apiKey: string,
     options?: AdapterRequestOptions
   ): Promise<LLMResponse | LLMFailureResponse> {
+    request = applyPromptStructuredOutput(request);
     // Honor abort signals like a real adapter would
     if (options?.signal?.aborted) {
       return {
@@ -159,11 +249,55 @@ export class MockClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string,
     options?: AdapterRequestOptions
-  ): AsyncIterable<LLMStreamEvent> {
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    request = applyPromptStructuredOutput(request);
     const response = await this.sendMessage(request, apiKey, options);
     if (response.object === "error") {
       yield { type: "error", error: response };
       return;
+    }
+
+    const choice = response.choices[0];
+    if (choice) {
+      yield {
+        type: "adapter_evidence",
+        observedEvidence: {
+          choice: {
+            index: choice.index ?? 0,
+            finishReason: choice.finish_reason,
+            ...(choice.termination && {
+              termination: choice.termination,
+            }),
+          },
+        },
+      };
+    }
+    if (choice?.reasoning) {
+      yield {
+        type: "adapter_evidence",
+        observedEvidence: {
+          choice: {
+            index: choice.index ?? 0,
+            rawContentParts: [{
+              type: "reasoning",
+              text: choice.reasoning,
+              reasoning: true,
+            }],
+          },
+        },
+      };
+    }
+
+    let reasoningEvent: AdapterLLMStreamEvent | undefined;
+    if (
+      choice?.reasoning &&
+      request.settings.reasoning?.exclude !== true
+    ) {
+      reasoningEvent = {
+        type: "reasoning_delta",
+        delta: choice.reasoning,
+        index: choice.index ?? 0,
+      };
     }
 
     yield {
@@ -174,17 +308,13 @@ export class MockClientAdapter implements ILLMClientAdapter {
       created: response.created,
     };
 
-    const choice = response.choices[0];
-    if (choice?.reasoning && request.settings.reasoning?.exclude !== true) {
-      yield {
-        type: "reasoning_delta",
-        delta: choice.reasoning,
-        index: choice.index ?? 0,
-      };
+    if (reasoningEvent) {
+      yield reasoningEvent;
     }
 
     const content = choice?.message?.content || "";
     const chunks = content.match(/.{1,16}/gs) || [];
+    let observedRawContent = "";
     for (const chunk of chunks) {
       if (options?.signal?.aborted) {
         yield {
@@ -203,15 +333,36 @@ export class MockClientAdapter implements ILLMClientAdapter {
         return;
       }
 
+      observedRawContent += chunk;
       yield {
         type: "content_delta",
         delta: chunk,
         index: choice?.index ?? 0,
+        observedEvidence: {
+          choice: {
+            index: choice?.index ?? 0,
+            rawContentDelta: chunk,
+            rawAnswerAccounting: {
+              tokens: Math.floor(observedRawContent.length / 4),
+              method: "heuristic",
+              source: "library",
+              tokenizerId: MOCK_HEURISTIC_ID,
+              tokenProfileRevision: MOCK_HEURISTIC_REVISION,
+              reasoning: choice?.reasoning ? "excluded" : "unknown",
+            },
+          },
+        },
       };
     }
 
     if (response.usage) {
-      yield { type: "usage", usage: response.usage };
+      yield {
+        type: "usage",
+        usage: response.usage,
+        observedEvidence: {
+          usageEvidence: response.usageEvidence,
+        },
+      };
     }
 
     yield { type: "complete", response };
@@ -298,11 +449,13 @@ export class MockClientAdapter implements ILLMClientAdapter {
 
     // Apply maxTokens constraint (rough simulation)
     const originalLength = responseContent.length;
+    let truncatedByMaxTokens = false;
     if (request.settings.maxTokens && request.settings.maxTokens < 200) {
       const words = responseContent.split(" ");
       const maxWords = Math.max(1, Math.floor(request.settings.maxTokens / 4));
       if (words.length > maxWords) {
         responseContent = words.slice(0, maxWords).join(" ") + "...";
+        truncatedByMaxTokens = true;
       }
     }
 
@@ -324,11 +477,7 @@ export class MockClientAdapter implements ILLMClientAdapter {
 
     // Determine finish reason
     let finishReason = "stop";
-    if (
-      originalLength > responseContent.length &&
-      request.settings.maxTokens &&
-      mockTokenCount >= request.settings.maxTokens
-    ) {
+    if (truncatedByMaxTokens && originalLength > responseContent.length) {
       finishReason = "length";
     } else if (
       request.settings.stopSequences.some((seq: string) =>
@@ -346,7 +495,17 @@ export class MockClientAdapter implements ILLMClientAdapter {
         role: "assistant",
         content: responseContent,
       },
+      rawContent: responseContent,
+      rawAnswerAccounting: {
+        tokens: mockTokenCount,
+        method: "heuristic",
+        source: "library",
+        tokenizerId: MOCK_HEURISTIC_ID,
+        tokenProfileRevision: MOCK_HEURISTIC_REVISION,
+        reasoning: isReasoningTest ? "excluded" : "unknown",
+      },
       finish_reason: finishReason,
+      termination: normalizeTermination(finishReason),
       index: 0,
     };
     
@@ -365,6 +524,11 @@ export class MockClientAdapter implements ILLMClientAdapter {
         prompt_tokens: promptTokenCount,
         completion_tokens: mockTokenCount,
         total_tokens: promptTokenCount + mockTokenCount,
+      },
+      usageEvidence: {
+        prompt_tokens: { source: "heuristic" },
+        completion_tokens: { source: "heuristic" },
+        total_tokens: { source: "heuristic" },
       },
       object: "chat.completion",
     };

--- a/src/llm/clients/OpenAIClientAdapter.test.ts
+++ b/src/llm/clients/OpenAIClientAdapter.test.ts
@@ -127,6 +127,38 @@ describe('OpenAIClientAdapter', () => {
       expect(successResponse.usage?.total_tokens).toBe(30);
     });
 
+    it("injects prompt-delivered structured output exactly once on the legacy path", async () => {
+      mockCreate.mockResolvedValueOnce({
+        id: "chatcmpl-prompt-schema",
+        object: "chat.completion",
+        created: 1234567890,
+        model: "gpt-4.1",
+        choices: [{
+          index: 0,
+          message: { role: "assistant", content: "{\"ok\":true}" },
+          finish_reason: "stop",
+        }],
+      });
+      basicRequest.settings.structuredOutput = {
+        name: "result",
+        delivery: "prompt",
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+        },
+      };
+
+      await adapter.sendMessage(basicRequest, "test-api-key");
+
+      const params = mockCreate.mock.calls[0][0];
+      const content = String(params.messages[0].content);
+      expect(
+        content.match(/<GENAI_LITE_STRUCTURED_OUTPUT revision=/g)
+      ).toHaveLength(1);
+      expect(params).not.toHaveProperty("response_format");
+    });
+
     it('should map seed and never send llama.cpp-style sampling params', async () => {
       mockCreate.mockResolvedValueOnce({
         id: 'chatcmpl-seed',
@@ -452,7 +484,7 @@ describe('OpenAIClientAdapter', () => {
         signal: controller.signal,
         timeout: 5000,
       });
-      expect(events[0]).toMatchObject({
+      expect(events.find((event) => event.type === "start")).toMatchObject({
         type: 'start',
         provider: 'openai',
         model: 'gpt-4.1',
@@ -473,6 +505,67 @@ describe('OpenAIClientAdapter', () => {
         expect(complete.response.choices[0].finish_reason).toBe('stop');
         expect(complete.response.usage?.total_tokens).toBe(5);
       }
+    });
+
+    it("records every provider-chunk evidence item before its first public event", async () => {
+      mockCreate.mockResolvedValueOnce(streamFrom([{
+        id: "chatcmpl-evidence-order",
+        object: "chat.completion.chunk",
+        created: 1234567890,
+        model: "gpt-4.1",
+        choices: [{
+          index: 0,
+          delta: { content: "done" },
+          finish_reason: "length",
+        }],
+        usage: {
+          prompt_tokens: 7,
+          completion_tokens: 4,
+          total_tokens: 11,
+        },
+      }]));
+
+      const events = await collectEvents();
+      const startIndex = events.findIndex((event) => event.type === "start");
+      const evidenceBeforeStart = events.slice(0, startIndex).filter(
+        (event) => event.type === "adapter_evidence"
+      );
+
+      expect(startIndex).toBeGreaterThan(0);
+      expect(evidenceBeforeStart).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          observedEvidence: expect.objectContaining({
+            usage: {
+              prompt_tokens: 7,
+              completion_tokens: 4,
+              total_tokens: 11,
+            },
+            usageEvidence: expect.objectContaining({
+              prompt_tokens: expect.any(Object),
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          observedEvidence: {
+            choice: expect.objectContaining({
+              finishReason: "length",
+              termination: expect.objectContaining({
+                rawReason: "length",
+              }),
+            }),
+          },
+        }),
+        expect.objectContaining({
+          observedEvidence: {
+            choice: expect.objectContaining({
+              rawContentDelta: "done",
+            }),
+          },
+        }),
+      ]));
+      expect(events.slice(startIndex).map((event) => event.type)).toEqual(
+        expect.arrayContaining(["start", "usage", "content_delta", "complete"])
+      );
     });
 
     it('should preserve structured output, reasoning, logprobs, and sampling params', async () => {

--- a/src/llm/clients/OpenAIClientAdapter.ts
+++ b/src/llm/clients/OpenAIClientAdapter.ts
@@ -2,15 +2,23 @@
 // Handles request formatting, response parsing, and error mapping to standardized format.
 
 import OpenAI from "openai";
-import type { LLMResponse, LLMFailureResponse, LLMStreamEvent } from "../types";
+import type { LLMResponse, LLMFailureResponse } from "../types";
 import type {
   ILLMClientAdapter,
   InternalLLMChatRequest,
   AdapterRequestOptions,
+  AdapterLLMStreamEvent,
+  AdapterPreparationContext,
+  AdapterPreparationResult,
+  AdapterPreparedRequest,
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
 import { mapOpenAIChatLogprobs } from "../../shared/adapters/logprobsUtils";
+import {
+  normalizeTermination,
+  normalizeUsage,
+} from "../../shared/adapters/usageUtils";
 import { applyStrictSchemaConstraints } from "../../shared/adapters/schemaUtils";
 import {
   collectSystemContent,
@@ -18,11 +26,24 @@ import {
 } from "../../shared/adapters/systemMessageUtils";
 import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
+import {
+  applyPromptStructuredOutput,
+  createPreparedRequestView,
+  freezeProviderRequest,
+} from "./preparedAdapterUtils";
 
 interface OpenAICompletionRequest {
   openai: OpenAI;
   completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams;
 }
+
+interface OpenAIPreparedProviderRequest {
+  request: InternalLLMChatRequest;
+  completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams;
+}
+
+const OPENAI_ADAPTER_REVISION = "openai-adapter-v1";
+const OPENAI_REQUEST_SHAPE_REVISION = "openai-chat-completions-v1";
 
 interface OpenAIStreamChoiceState {
   content: string;
@@ -56,6 +77,96 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
     this.logger = config?.logger ?? createDefaultLogger();
   }
 
+  async prepareRequest(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult> {
+    try {
+      request = applyPromptStructuredOutput(request);
+      const baseParams = this.prepareCompletionParams(request);
+      const completionParams =
+        context.mode === "stream"
+          ? ({
+              ...baseParams,
+              stream: true,
+              stream_options: { include_usage: true },
+            } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming)
+          : baseParams;
+      const providerRequest =
+        freezeProviderRequest<OpenAIPreparedProviderRequest>({
+          request,
+          completionParams,
+        });
+
+      return {
+        prepared: {
+          mode: context.mode,
+          providerRequest,
+          requestView: createPreparedRequestView({
+            operation: "openai.chat.completions",
+            mode: context.mode,
+            payload: completionParams as unknown as Record<string, unknown>,
+            structuredOutput: request.settings.structuredOutput,
+            reasoningField: "reasoning_effort",
+          }),
+          promptAccounting: { status: "unavailable" },
+          outputTokenLimit: context.outputTokenLimit,
+          bindings: {
+            adapterRevision: OPENAI_ADAPTER_REVISION,
+            requestShapeRevision: OPENAI_REQUEST_SHAPE_REVISION,
+          },
+        },
+      };
+    } catch (error) {
+      return { error: this.createErrorResponse(error, request) };
+    }
+  }
+
+  async sendPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    const providerRequest =
+      prepared.providerRequest as OpenAIPreparedProviderRequest;
+    const request = providerRequest.request;
+    try {
+      const openai = this.createClient(apiKey);
+      const completionParams = structuredClone(
+        providerRequest.completionParams
+      ) as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming;
+      const transportOptions = this.createTransportOptions(options);
+      const completion =
+        Object.keys(transportOptions).length > 0
+          ? await openai.chat.completions.create(
+              completionParams,
+              transportOptions
+            )
+          : await openai.chat.completions.create(completionParams);
+      return this.createSuccessResponse(completion, request);
+    } catch (error) {
+      this.logger.error("OpenAI prepared API error:", error);
+      return this.createErrorResponse(error, request);
+    }
+  }
+
+  async *streamPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    const providerRequest =
+      prepared.providerRequest as OpenAIPreparedProviderRequest;
+    yield* this.streamCompletion(
+      providerRequest.request,
+      structuredClone(
+        providerRequest.completionParams
+      ) as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+      apiKey,
+      options
+    );
+  }
+
   /**
    * Sends a chat message to OpenAI's API
    *
@@ -68,6 +179,7 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
     apiKey: string,
     options?: AdapterRequestOptions
   ): Promise<LLMResponse | LLMFailureResponse> {
+    request = applyPromptStructuredOutput(request);
     try {
       const { openai, completionParams } = this.prepareCompletionRequest(request, apiKey);
 
@@ -108,7 +220,22 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string,
     options?: AdapterRequestOptions
-  ): AsyncIterable<LLMStreamEvent> {
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    request = applyPromptStructuredOutput(request);
+    const completionParams = {
+      ...this.prepareCompletionParams(request),
+      stream: true,
+      stream_options: { include_usage: true },
+    } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
+    yield* this.streamCompletion(request, completionParams, apiKey, options);
+  }
+
+  private async *streamCompletion(
+    request: InternalLLMChatRequest,
+    streamParams: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
     const choiceStates = new Map<number, OpenAIStreamChoiceState>();
     let responseId = "";
     let responseModel = request.modelId;
@@ -116,12 +243,7 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
     let usage: OpenAI.Completions.CompletionUsage | undefined;
 
     try {
-      const { openai, completionParams } = this.prepareCompletionRequest(request, apiKey);
-      const streamParams = {
-        ...completionParams,
-        stream: true,
-        stream_options: { include_usage: true },
-      } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
+      const openai = this.createClient(apiKey);
       const transportOptions = this.createTransportOptions(options);
       const stream =
         Object.keys(transportOptions).length > 0
@@ -133,7 +255,106 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
         responseId = chunk.id || responseId;
         responseModel = chunk.model || responseModel;
         created = chunk.created || created;
+        const evidenceEvents: AdapterLLMStreamEvent[] = [];
+        const publicEvents: AdapterLLMStreamEvent[] = [];
 
+        if (chunk.usage) {
+          usage = chunk.usage;
+          const normalized = normalizeUsage(
+            chunk.usage as unknown as Record<string, unknown>,
+            {
+              prompt: ["prompt_tokens"],
+              completion: ["completion_tokens"],
+              total: ["total_tokens"],
+            }
+          );
+          if (normalized.usage) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                usage: normalized.usage,
+                usageEvidence: normalized.usageEvidence,
+              },
+            });
+            publicEvents.push({
+              type: "usage",
+              usage: normalized.usage,
+              observedEvidence: {
+                usageEvidence: normalized.usageEvidence,
+              },
+            });
+          }
+        }
+
+        for (const choice of chunk.choices || []) {
+          const state = this.getStreamChoiceState(choiceStates, choice.index);
+          state.finishReason = choice.finish_reason ?? state.finishReason;
+          if (choice.finish_reason != null) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  finishReason: choice.finish_reason,
+                  termination: normalizeTermination(choice.finish_reason),
+                },
+              },
+            });
+          }
+          const delta = choice.delta as any;
+
+          const reasoningDelta = delta?.reasoning ?? delta?.reasoning_content;
+          if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
+            state.reasoning += reasoningDelta;
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  rawContentParts: [{
+                    type: "reasoning",
+                    text: reasoningDelta,
+                    reasoning: true,
+                  }],
+                },
+              },
+            });
+            if (request.settings.reasoning?.exclude !== true) {
+              publicEvents.push({
+                type: "reasoning_delta",
+                delta: reasoningDelta,
+                index: choice.index,
+              });
+            }
+          }
+
+          if (typeof delta?.content === "string" && delta.content.length > 0) {
+            state.content += delta.content;
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  rawContentDelta: delta.content,
+                },
+              },
+            });
+            publicEvents.push({
+              type: "content_delta",
+              delta: delta.content,
+              index: choice.index,
+            });
+          }
+
+          const mappedLogprobs = mapOpenAIChatLogprobs(choice.logprobs);
+          if (mappedLogprobs) {
+            state.logprobs.push(...((choice.logprobs as any)?.content || []));
+          }
+        }
+
+        for (const event of evidenceEvents) {
+          yield event;
+        }
         if (!started) {
           started = true;
           yield {
@@ -144,49 +365,8 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
             created,
           };
         }
-
-        if (chunk.usage) {
-          usage = chunk.usage;
-          yield {
-            type: "usage",
-            usage: {
-              prompt_tokens: chunk.usage.prompt_tokens,
-              completion_tokens: chunk.usage.completion_tokens,
-              total_tokens: chunk.usage.total_tokens,
-            },
-          };
-        }
-
-        for (const choice of chunk.choices || []) {
-          const state = this.getStreamChoiceState(choiceStates, choice.index);
-          state.finishReason = choice.finish_reason ?? state.finishReason;
-          const delta = choice.delta as any;
-
-          const reasoningDelta = delta?.reasoning ?? delta?.reasoning_content;
-          if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
-            state.reasoning += reasoningDelta;
-            if (request.settings.reasoning?.exclude !== true) {
-              yield {
-                type: "reasoning_delta",
-                delta: reasoningDelta,
-                index: choice.index,
-              };
-            }
-          }
-
-          if (typeof delta?.content === "string" && delta.content.length > 0) {
-            state.content += delta.content;
-            yield {
-              type: "content_delta",
-              delta: delta.content,
-              index: choice.index,
-            };
-          }
-
-          const mappedLogprobs = mapOpenAIChatLogprobs(choice.logprobs);
-          if (mappedLogprobs) {
-            state.logprobs.push(...((choice.logprobs as any)?.content || []));
-          }
+        for (const event of publicEvents) {
+          yield event;
         }
       }
 
@@ -225,6 +405,24 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
           created: partial.created,
           choices: partial.choices,
           usage: partial.usage,
+          usageEvidence: partial.usageEvidence,
+        };
+      } else if (usage) {
+        const normalizedUsage = normalizeUsage(
+          usage as unknown as Record<string, unknown>,
+          {
+            prompt: ["prompt_tokens"],
+            completion: ["completion_tokens"],
+            total: ["total_tokens"],
+          }
+        );
+        errorResponse.partialResponse = {
+          id: responseId,
+          provider: request.providerId,
+          model: responseModel,
+          created,
+          choices: [],
+          ...normalizedUsage,
         };
       }
       yield { type: "error", error: errorResponse };
@@ -257,12 +455,23 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string
   ): OpenAICompletionRequest {
-    const openai = new OpenAI({
+    return {
+      openai: this.createClient(apiKey),
+      completionParams: this.prepareCompletionParams(request),
+    };
+  }
+
+  private createClient(apiKey: string): OpenAI {
+    return new OpenAI({
       apiKey,
       ...(this.baseURL && { baseURL: this.baseURL }),
       maxRetries: 0, // retries are owned by the unified LLMService retry layer
     });
+  }
 
+  private prepareCompletionParams(
+    request: InternalLLMChatRequest
+  ): OpenAI.Chat.Completions.ChatCompletionCreateParams {
     const messages = this.formatMessages(request);
     const completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams =
       {
@@ -303,7 +512,11 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
       }
     }
 
-    if (request.settings.structuredOutput?.schema && request.settings.structuredOutput.enabled !== false) {
+    if (
+      request.settings.structuredOutput?.schema &&
+      request.settings.structuredOutput.enabled !== false &&
+      request.settings.structuredOutput.delivery !== "prompt"
+    ) {
       const so = request.settings.structuredOutput;
       // OpenAI strict mode additionally requires `required` to list every
       // property of each object schema.
@@ -320,7 +533,7 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
       } as any;
     }
 
-    return { openai, completionParams };
+    return completionParams;
   }
 
   private createTransportOptions(options?: AdapterRequestOptions) {
@@ -472,7 +685,9 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
         role: choice.message.role as "assistant",
         content: choice.message.content || "",
       },
+      rawContent: choice.message.content || "",
       finish_reason: choice.finish_reason,
+      termination: normalizeTermination(choice.finish_reason),
       index: choice.index,
     };
 
@@ -489,19 +704,22 @@ export class OpenAIClientAdapter implements ILLMClientAdapter {
       responseChoice.logprobs = logprobs;
     }
 
+    const normalizedUsage = normalizeUsage(
+      completion.usage as unknown as Record<string, unknown> | undefined,
+      {
+        prompt: ["prompt_tokens"],
+        completion: ["completion_tokens"],
+        total: ["total_tokens"],
+      }
+    );
+
     return {
       id: completion.id,
       provider: request.providerId,
       model: completion.model || request.modelId,
       created: completion.created,
       choices: [responseChoice],
-      usage: completion.usage
-        ? {
-            prompt_tokens: completion.usage.prompt_tokens,
-            completion_tokens: completion.usage.completion_tokens,
-            total_tokens: completion.usage.total_tokens,
-          }
-        : undefined,
+      ...normalizedUsage,
       object: "chat.completion",
     };
   }

--- a/src/llm/clients/OpenRouterClientAdapter.test.ts
+++ b/src/llm/clients/OpenRouterClientAdapter.test.ts
@@ -606,7 +606,7 @@ describe('OpenRouterClientAdapter', () => {
         stream_options: { include_usage: true },
         model: 'google/gemma-3-27b-it:free'
       }));
-      expect(events[0]).toMatchObject({
+      expect(events.find((event) => event.type === "start")).toMatchObject({
         type: 'start',
         provider: 'openrouter',
         id: 'gen-stream'

--- a/src/llm/clients/OpenRouterClientAdapter.ts
+++ b/src/llm/clients/OpenRouterClientAdapter.ts
@@ -2,21 +2,34 @@
 // Provides unified access to 100+ LLM models from various providers through a single API.
 
 import OpenAI from "openai";
-import type { LLMResponse, LLMFailureResponse, LLMStreamEvent } from "../types";
+import type { LLMResponse, LLMFailureResponse } from "../types";
 import type {
   ILLMClientAdapter,
   InternalLLMChatRequest,
   AdapterRequestOptions,
+  AdapterLLMStreamEvent,
+  AdapterPreparationContext,
+  AdapterPreparationResult,
+  AdapterPreparedRequest,
 } from "./types";
 import { ADAPTER_ERROR_CODES } from "./types";
 import { getCommonMappedErrorDetails } from "../../shared/adapters/errorUtils";
 import { mapOpenAIChatLogprobs } from "../../shared/adapters/logprobsUtils";
+import {
+  normalizeTermination,
+  normalizeUsage,
+} from "../../shared/adapters/usageUtils";
 import {
   collectSystemContent,
   prependSystemToFirstUserMessage,
 } from "../../shared/adapters/systemMessageUtils";
 import type { Logger } from "../../logging/types";
 import { createDefaultLogger } from "../../logging/defaultLogger";
+import {
+  applyPromptStructuredOutput,
+  createPreparedRequestView,
+  freezeProviderRequest,
+} from "./preparedAdapterUtils";
 
 /**
  * Configuration options for OpenRouterClientAdapter
@@ -36,6 +49,14 @@ interface OpenRouterCompletionRequest {
   openai: OpenAI;
   completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams;
 }
+
+interface OpenRouterPreparedProviderRequest {
+  request: InternalLLMChatRequest;
+  completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams;
+}
+
+const OPENROUTER_ADAPTER_REVISION = "openrouter-adapter-v1";
+const OPENROUTER_REQUEST_SHAPE_REVISION = "openrouter-chat-completions-v1";
 
 interface OpenRouterStreamChoiceState {
   content: string;
@@ -93,6 +114,96 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
     this.logger = config?.logger ?? createDefaultLogger();
   }
 
+  async prepareRequest(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult> {
+    try {
+      request = applyPromptStructuredOutput(request);
+      const baseParams = this.prepareCompletionParams(request);
+      const completionParams =
+        context.mode === "stream"
+          ? ({
+              ...baseParams,
+              stream: true,
+              stream_options: { include_usage: true },
+            } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming)
+          : baseParams;
+      const providerRequest =
+        freezeProviderRequest<OpenRouterPreparedProviderRequest>({
+          request,
+          completionParams,
+        });
+      return {
+        prepared: {
+          mode: context.mode,
+          providerRequest,
+          requestView: createPreparedRequestView({
+            operation: "openrouter.chat.completions",
+            mode: context.mode,
+            payload: completionParams as unknown as Record<string, unknown>,
+            structuredOutput: request.settings.structuredOutput,
+            reasoningField: "reasoning",
+            extensionFields: ["provider"],
+          }),
+          promptAccounting: { status: "unavailable" },
+          outputTokenLimit: context.outputTokenLimit,
+          bindings: {
+            adapterRevision: OPENROUTER_ADAPTER_REVISION,
+            requestShapeRevision: OPENROUTER_REQUEST_SHAPE_REVISION,
+          },
+        },
+      };
+    } catch (error) {
+      return { error: this.createErrorResponse(error, request) };
+    }
+  }
+
+  async sendPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): Promise<LLMResponse | LLMFailureResponse> {
+    const providerRequest =
+      prepared.providerRequest as OpenRouterPreparedProviderRequest;
+    const request = providerRequest.request;
+    try {
+      const openai = this.createClient(apiKey);
+      const completionParams = structuredClone(
+        providerRequest.completionParams
+      ) as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming;
+      const transportOptions = this.createTransportOptions(options);
+      const completion =
+        Object.keys(transportOptions).length > 0
+          ? await openai.chat.completions.create(
+              completionParams,
+              transportOptions
+            )
+          : await openai.chat.completions.create(completionParams);
+      return this.createSuccessResponse(completion, request);
+    } catch (error) {
+      this.logger.error("OpenRouter prepared API error:", error);
+      return this.createErrorResponse(error, request);
+    }
+  }
+
+  async *streamPrepared(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    const providerRequest =
+      prepared.providerRequest as OpenRouterPreparedProviderRequest;
+    yield* this.streamCompletion(
+      providerRequest.request,
+      structuredClone(
+        providerRequest.completionParams
+      ) as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+      apiKey,
+      options
+    );
+  }
+
   /**
    * Sends a chat message to OpenRouter API
    *
@@ -105,6 +216,7 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
     apiKey: string,
     options?: AdapterRequestOptions
   ): Promise<LLMResponse | LLMFailureResponse> {
+    request = applyPromptStructuredOutput(request);
     try {
       const { openai, completionParams } = this.prepareCompletionRequest(request, apiKey);
 
@@ -146,7 +258,22 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string,
     options?: AdapterRequestOptions
-  ): AsyncIterable<LLMStreamEvent> {
+  ): AsyncIterable<AdapterLLMStreamEvent> {
+    request = applyPromptStructuredOutput(request);
+    const streamParams = {
+      ...this.prepareCompletionParams(request),
+      stream: true,
+      stream_options: { include_usage: true },
+    } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
+    yield* this.streamCompletion(request, streamParams, apiKey, options);
+  }
+
+  private async *streamCompletion(
+    request: InternalLLMChatRequest,
+    streamParams: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent> {
     const choiceStates = new Map<number, OpenRouterStreamChoiceState>();
     let responseId = "";
     let responseModel = request.modelId;
@@ -154,12 +281,7 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
     let usage: OpenAI.Completions.CompletionUsage | undefined;
 
     try {
-      const { openai, completionParams } = this.prepareCompletionRequest(request, apiKey);
-      const streamParams = {
-        ...completionParams,
-        stream: true,
-        stream_options: { include_usage: true },
-      } as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
+      const openai = this.createClient(apiKey);
       const transportOptions = this.createTransportOptions(options);
       const stream =
         Object.keys(transportOptions).length > 0
@@ -171,7 +293,110 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
         responseId = chunk.id || responseId;
         responseModel = chunk.model || responseModel;
         created = chunk.created || created;
+        const evidenceEvents: AdapterLLMStreamEvent[] = [];
+        const publicEvents: AdapterLLMStreamEvent[] = [];
 
+        if (chunk.usage) {
+          usage = chunk.usage;
+          const normalized = normalizeUsage(
+            chunk.usage as unknown as Record<string, unknown>,
+            {
+              prompt: ["prompt_tokens"],
+              completion: ["completion_tokens"],
+              total: ["total_tokens"],
+            }
+          );
+          if (normalized.usage) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                usage: normalized.usage,
+                usageEvidence: normalized.usageEvidence,
+              },
+            });
+            publicEvents.push({
+              type: "usage",
+              usage: normalized.usage,
+              observedEvidence: {
+                usageEvidence: normalized.usageEvidence,
+              },
+            });
+          }
+        }
+
+        for (const choice of chunk.choices || []) {
+          const state = this.getStreamChoiceState(choiceStates, choice.index);
+          state.finishReason = choice.finish_reason ?? state.finishReason;
+          if (choice.finish_reason != null) {
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  finishReason: choice.finish_reason,
+                  termination: normalizeTermination(choice.finish_reason),
+                },
+              },
+            });
+          }
+          const delta = choice.delta as any;
+
+          const reasoningDelta = delta?.reasoning ?? delta?.reasoning_content;
+          if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
+            state.reasoning += reasoningDelta;
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  rawContentParts: [{
+                    type: "reasoning",
+                    text: reasoningDelta,
+                    reasoning: true,
+                  }],
+                },
+              },
+            });
+            if (request.settings.reasoning?.exclude !== true) {
+              publicEvents.push({
+                type: "reasoning_delta",
+                delta: reasoningDelta,
+                index: choice.index,
+              });
+            }
+          }
+
+          if (delta?.reasoning_details) {
+            state.reasoningDetails = delta.reasoning_details;
+          }
+
+          if (typeof delta?.content === "string" && delta.content.length > 0) {
+            state.content += delta.content;
+            evidenceEvents.push({
+              type: "adapter_evidence",
+              observedEvidence: {
+                choice: {
+                  index: choice.index,
+                  rawContentDelta: delta.content,
+                },
+              },
+            });
+            publicEvents.push({
+              type: "content_delta",
+              delta: delta.content,
+              index: choice.index,
+            });
+          }
+
+          const mappedLogprobs = mapOpenAIChatLogprobs(choice.logprobs);
+          if (mappedLogprobs) {
+            state.logprobs.push(...((choice.logprobs as any)?.content || []));
+          }
+        }
+
+        for (const event of evidenceEvents) {
+          yield event;
+        }
         if (!started) {
           started = true;
           yield {
@@ -182,53 +407,8 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
             created,
           };
         }
-
-        if (chunk.usage) {
-          usage = chunk.usage;
-          yield {
-            type: "usage",
-            usage: {
-              prompt_tokens: chunk.usage.prompt_tokens,
-              completion_tokens: chunk.usage.completion_tokens,
-              total_tokens: chunk.usage.total_tokens,
-            },
-          };
-        }
-
-        for (const choice of chunk.choices || []) {
-          const state = this.getStreamChoiceState(choiceStates, choice.index);
-          state.finishReason = choice.finish_reason ?? state.finishReason;
-          const delta = choice.delta as any;
-
-          const reasoningDelta = delta?.reasoning ?? delta?.reasoning_content;
-          if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
-            state.reasoning += reasoningDelta;
-            if (request.settings.reasoning?.exclude !== true) {
-              yield {
-                type: "reasoning_delta",
-                delta: reasoningDelta,
-                index: choice.index,
-              };
-            }
-          }
-
-          if (delta?.reasoning_details) {
-            state.reasoningDetails = delta.reasoning_details;
-          }
-
-          if (typeof delta?.content === "string" && delta.content.length > 0) {
-            state.content += delta.content;
-            yield {
-              type: "content_delta",
-              delta: delta.content,
-              index: choice.index,
-            };
-          }
-
-          const mappedLogprobs = mapOpenAIChatLogprobs(choice.logprobs);
-          if (mappedLogprobs) {
-            state.logprobs.push(...((choice.logprobs as any)?.content || []));
-          }
+        for (const event of publicEvents) {
+          yield event;
         }
       }
 
@@ -267,6 +447,24 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
           created: partial.created,
           choices: partial.choices,
           usage: partial.usage,
+          usageEvidence: partial.usageEvidence,
+        };
+      } else if (usage) {
+        const normalizedUsage = normalizeUsage(
+          usage as unknown as Record<string, unknown>,
+          {
+            prompt: ["prompt_tokens"],
+            completion: ["completion_tokens"],
+            total: ["total_tokens"],
+          }
+        );
+        errorResponse.partialResponse = {
+          id: responseId,
+          provider: request.providerId,
+          model: responseModel,
+          created,
+          choices: [],
+          ...normalizedUsage,
         };
       }
       yield { type: "error", error: errorResponse };
@@ -277,7 +475,14 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string
   ): OpenRouterCompletionRequest {
-    const openai = new OpenAI({
+    return {
+      openai: this.createClient(apiKey),
+      completionParams: this.prepareCompletionParams(request),
+    };
+  }
+
+  private createClient(apiKey: string): OpenAI {
+    return new OpenAI({
       apiKey,
       maxRetries: 0, // retries are owned by the unified LLMService retry layer
       baseURL: this.baseURL,
@@ -286,7 +491,11 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
         ...(this.siteTitle && { 'X-Title': this.siteTitle }),
       },
     });
+  }
 
+  private prepareCompletionParams(
+    request: InternalLLMChatRequest
+  ): OpenAI.Chat.Completions.ChatCompletionCreateParams {
     const messages = this.formatMessages(request);
     const completionParams: OpenAI.Chat.Completions.ChatCompletionCreateParams = {
       model: request.modelId,
@@ -346,7 +555,11 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
       }
     }
 
-    if (request.settings.structuredOutput?.schema && request.settings.structuredOutput.enabled !== false) {
+    if (
+      request.settings.structuredOutput?.schema &&
+      request.settings.structuredOutput.enabled !== false &&
+      request.settings.structuredOutput.delivery !== "prompt"
+    ) {
       const so = request.settings.structuredOutput;
       (completionParams as any).response_format = {
         type: 'json_schema',
@@ -379,7 +592,7 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
       (completionParams as any).reasoning = reasoning;
     }
 
-    return { openai, completionParams };
+    return completionParams;
   }
 
   private createTransportOptions(options?: AdapterRequestOptions) {
@@ -554,6 +767,15 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
       throw new Error("No valid choices in OpenRouter completion response");
     }
 
+    const normalizedUsage = normalizeUsage(
+      completion.usage as unknown as Record<string, unknown> | undefined,
+      {
+        prompt: ["prompt_tokens"],
+        completion: ["completion_tokens"],
+        total: ["total_tokens"],
+      }
+    );
+
     return {
       id: completion.id,
       provider: request.providerId,
@@ -565,7 +787,9 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
             role: "assistant",
             content: c.message.content || "",
           },
+          rawContent: c.message.content || "",
           finish_reason: c.finish_reason,
+          termination: normalizeTermination(c.finish_reason),
           index: c.index,
         };
 
@@ -588,13 +812,7 @@ export class OpenRouterClientAdapter implements ILLMClientAdapter {
 
         return mappedChoice;
       }),
-      usage: completion.usage
-        ? {
-            prompt_tokens: completion.usage.prompt_tokens,
-            completion_tokens: completion.usage.completion_tokens,
-            total_tokens: completion.usage.total_tokens,
-          }
-        : undefined,
+      ...normalizedUsage,
       object: "chat.completion",
     };
   }

--- a/src/llm/clients/accountingEvidence.test.ts
+++ b/src/llm/clients/accountingEvidence.test.ts
@@ -1,0 +1,369 @@
+import { AnthropicClientAdapter } from "./AnthropicClientAdapter";
+import { GeminiClientAdapter } from "./GeminiClientAdapter";
+import { LlamaCppClientAdapter } from "./LlamaCppClientAdapter";
+import { MistralClientAdapter } from "./MistralClientAdapter";
+import { MockClientAdapter } from "./MockClientAdapter";
+import { OpenAIClientAdapter } from "./OpenAIClientAdapter";
+import { OpenRouterClientAdapter } from "./OpenRouterClientAdapter";
+import type { InternalLLMChatRequest } from "./types";
+import type { LLMSettings } from "../types";
+
+function request(providerId: string): InternalLLMChatRequest {
+  return {
+    providerId,
+    modelId: "test-model",
+    messages: [{ role: "user", content: "hello" }],
+    settings: {
+      maxTokens: 128,
+      stopSequences: [],
+      temperature: 0,
+    } as unknown as Required<LLMSettings>,
+  };
+}
+
+describe("built-in accounting evidence", () => {
+  it("OpenAI retains raw content, raw termination, and provider usage evidence", () => {
+    const response = (new OpenAIClientAdapter() as any).createSuccessResponse(
+      {
+        id: "id",
+        model: "model",
+        created: 1,
+        choices: [{
+          index: 0,
+          finish_reason: "length",
+          message: { role: "assistant", content: " raw " },
+        }],
+        usage: { prompt_tokens: 0, completion_tokens: 2, total_tokens: 2 },
+      },
+      request("openai")
+    );
+
+    expect(response.choices[0]).toMatchObject({
+      rawContent: " raw ",
+      termination: {
+        rawReason: "length",
+        kind: "limit",
+        limit: "unknown",
+      },
+    });
+    expect(response.usage).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 2,
+      total_tokens: 2,
+    });
+    expect(response.usageEvidence.prompt_tokens.source).toBe("provider");
+  });
+
+  it("OpenRouter preserves absent usage and raw finish reason", () => {
+    const response = (new OpenRouterClientAdapter() as any).createSuccessResponse(
+      {
+        id: "id",
+        model: "model",
+        created: 1,
+        choices: [{
+          index: 0,
+          finish_reason: "tool_calls",
+          message: { role: "assistant", content: "" },
+        }],
+      },
+      request("openrouter")
+    );
+
+    expect(response.usage).toBeUndefined();
+    expect(response.choices[0].termination).toEqual({
+      rawReason: "tool_calls",
+      kind: "tool_call",
+    });
+  });
+
+  it("Anthropic keeps ordered raw parts and presence-aware usage", () => {
+    const response = (new AnthropicClientAdapter() as any).createSuccessResponse(
+      {
+        id: "id",
+        model: "model",
+        stop_reason: "max_tokens",
+        content: [
+          { type: "thinking", thinking: "reason" },
+          { type: "text", text: "answer" },
+        ],
+        usage: { input_tokens: 0 },
+      },
+      request("anthropic")
+    );
+
+    expect(response.usage).toEqual({ prompt_tokens: 0 });
+    expect(response.choices[0]).toMatchObject({
+      rawContent: "answer",
+      rawContentParts: [
+        { type: "thinking", text: "reason", reasoning: true },
+        { type: "text", text: "answer" },
+      ],
+      finish_reason: "length",
+      termination: {
+        rawReason: "max_tokens",
+        kind: "limit",
+        limit: "output",
+      },
+    });
+  });
+
+  it("Gemini never fabricates missing usage and preserves zero", () => {
+    const adapter = new GeminiClientAdapter() as any;
+    const withoutUsage = adapter.createSuccessResponse(
+      {
+        candidates: [{
+          finishReason: "STOP",
+          content: { parts: [{ text: "answer" }] },
+        }],
+      },
+      request("gemini")
+    );
+    const withZero = adapter.createSuccessResponse(
+      {
+        candidates: [{
+          finishReason: "MAX_TOKENS",
+          content: {
+            parts: [
+              { text: "thought", thought: true },
+              { text: "answer" },
+            ],
+          },
+        }],
+        usageMetadata: { promptTokenCount: 0 },
+      },
+      request("gemini")
+    );
+
+    expect(withoutUsage.usage).toBeUndefined();
+    expect(withZero.usage).toEqual({ prompt_tokens: 0 });
+    expect(withZero.choices[0].termination).toEqual({
+      rawReason: "MAX_TOKENS",
+      kind: "limit",
+      limit: "output",
+    });
+    expect(withZero.choices[0].rawContentParts).toEqual([
+      {
+        type: "thought",
+        text: "thought",
+        reasoning: true,
+        value: { text: "thought", thought: true },
+      },
+      {
+        type: "text",
+        text: "answer",
+        value: { text: "answer" },
+      },
+    ]);
+  });
+
+  it("preserves non-text provider parts as detached JSON-safe values", () => {
+    const anthropic = (new AnthropicClientAdapter() as any)
+      .createSuccessResponse(
+        {
+          id: "id",
+          model: "model",
+          stop_reason: "tool_use",
+          content: [
+            { type: "text", text: "calling" },
+            {
+              type: "tool_use",
+              id: "tool-1",
+              name: "lookup",
+              input: { city: "Paris" },
+            },
+          ],
+        },
+        request("anthropic")
+      );
+    const gemini = (new GeminiClientAdapter() as any)
+      .createSuccessResponse(
+        {
+          candidates: [{
+            finishReason: "STOP",
+            content: {
+              parts: [{
+                functionCall: {
+                  name: "lookup",
+                  args: { city: "Paris" },
+                },
+              }],
+            },
+          }],
+        },
+        request("gemini")
+      );
+
+    expect(anthropic.choices[0].rawContentParts[1]).toMatchObject({
+      type: "tool_use",
+      value: {
+        id: "tool-1",
+        name: "lookup",
+        input: { city: "Paris" },
+      },
+    });
+    expect(gemini.choices[0].rawContentParts[0]).toEqual({
+      type: "functionCall",
+      value: {
+        functionCall: {
+          name: "lookup",
+          args: { city: "Paris" },
+        },
+      },
+    });
+  });
+
+  it("Mistral preserves missing usage and unknown termination", () => {
+    const adapter = new MistralClientAdapter() as any;
+    const absent = adapter.createSuccessResponse(
+      {
+        id: "id",
+        choices: [{ message: { content: "answer" } }],
+      },
+      request("mistral")
+    );
+    const zero = adapter.createSuccessResponse(
+      {
+        id: "id",
+        choices: [{ message: { content: "answer" }, finishReason: "stop" }],
+        usage: { promptTokens: 0 },
+      },
+      request("mistral")
+    );
+
+    expect(absent.usage).toBeUndefined();
+    expect(absent.choices[0]).toMatchObject({
+      finish_reason: null,
+      termination: { rawReason: null, kind: "unknown" },
+    });
+    expect(zero.usage).toEqual({ prompt_tokens: 0 });
+  });
+
+  it("labels Mistral native structured output as JSON-only", async () => {
+    const internal = request("mistral");
+    internal.settings.structuredOutput = {
+      name: "answer",
+      schema: {
+        type: "object",
+        properties: { ok: { type: "boolean" } },
+      },
+      delivery: "native",
+    };
+    const result = await new MistralClientAdapter().prepareRequest(
+      internal,
+      {
+        mode: "complete",
+        modelInfo: {} as any,
+      }
+    );
+
+    expect(result).toMatchObject({
+      prepared: {
+        requestView: {
+          structuredOutput: {
+            delivery: "native",
+            enforcement: "json_only",
+          },
+        },
+      },
+    });
+    if ("prepared" in result) {
+      expect(result.prepared.requestView.structuredOutput?.schema)
+        .toBeUndefined();
+      expect(result.prepared.requestView.settings.responseFormat).toEqual({
+        type: "json_object",
+      });
+    }
+  });
+
+  it("llama.cpp keeps content before local cleanup", () => {
+    const raw = "<think>\n\n</think>\n\nanswer";
+    const response = (new LlamaCppClientAdapter() as any).createSuccessResponse(
+      {
+        id: "id",
+        model: "model",
+        created: 1,
+        choices: [{
+          index: 0,
+          finish_reason: "stop",
+          message: { role: "assistant", content: raw },
+        }],
+      },
+      request("llamacpp"),
+      {
+        localReasoning: {
+          nothinkPrefix: "<think>\n\n</think>\n\n",
+        },
+      }
+    );
+
+    expect(response.choices[0].rawContent).toBe(raw);
+    expect(response.choices[0].message.content).toBe("answer");
+  });
+
+  it("Mock retains legacy usage while labeling it heuristic", async () => {
+    const response = await (
+      new MockClientAdapter("mock") as any
+    ).createSuccessResponse(request("mock"), "hello", "hello");
+
+    expect(response.usage).toBeDefined();
+    expect(response.usageEvidence).toEqual({
+      prompt_tokens: { source: "heuristic" },
+      completion_tokens: { source: "heuristic" },
+      total_tokens: { source: "heuristic" },
+    });
+    expect(response.choices[0].rawAnswerAccounting.method).toBe("heuristic");
+  });
+
+  it("keeps normalized filtering aligned with provider-native reasons", () => {
+    const anthropic = (new AnthropicClientAdapter() as any)
+      .createSuccessResponse(
+        {
+          id: "id",
+          model: "model",
+          stop_reason: "refusal",
+          content: [{ type: "text", text: "declined" }],
+        },
+        request("anthropic")
+      );
+    const gemini = (new GeminiClientAdapter() as any)
+      .createSuccessResponse(
+        {
+          candidates: [{
+            finishReason: "RECITATION",
+            content: { parts: [{ text: "blocked" }] },
+          }],
+        },
+        request("gemini")
+      );
+
+    expect(anthropic.choices[0]).toMatchObject({
+      finish_reason: "content_filter",
+      termination: { rawReason: "refusal", kind: "content_filter" },
+    });
+    expect(gemini.choices[0]).toMatchObject({
+      finish_reason: "content_filter",
+      termination: { rawReason: "RECITATION", kind: "content_filter" },
+    });
+  });
+
+  it("reports mock max-token truncation as an ambiguous length limit", async () => {
+    const internal = request("mock");
+    internal.settings.maxTokens = 4;
+    const response = await new MockClientAdapter("mock").sendMessage(
+      internal,
+      "unused"
+    );
+
+    expect(response.object).toBe("chat.completion");
+    if (response.object === "chat.completion") {
+      expect(response.choices[0]).toMatchObject({
+        finish_reason: "length",
+        termination: {
+          rawReason: "length",
+          kind: "limit",
+          limit: "unknown",
+        },
+      });
+    }
+  });
+});

--- a/src/llm/clients/llamaCppState.test.ts
+++ b/src/llm/clients/llamaCppState.test.ts
@@ -1,0 +1,126 @@
+import { createLlamaCppStateBinding } from "./llamaCppState";
+
+const props = {
+  model_alias: "C:\\private\\models\\model.gguf",
+  model_path: "C:\\private\\models\\model.gguf",
+  chat_template: "{{ messages }}",
+  chat_template_caps: { supports_system_role: true },
+  bos_token: "<bos>",
+  eos_token: "<eos>",
+  build_info: { build: 123, commit: "abc" },
+};
+
+const models = {
+  object: "list",
+  data: [
+    {
+      id: "C:\\private\\models\\model.gguf",
+      meta: { n_ctx: 4096, n_vocab: 1000 },
+    },
+  ],
+};
+
+describe("llama.cpp observable state binding", () => {
+  it("is canonical, deterministic, and does not expose absolute paths", () => {
+    const first = createLlamaCppStateBinding(props, models)!;
+    const reordered = createLlamaCppStateBinding(
+      {
+        ...props,
+        build_info: { commit: "abc", build: 123 },
+      },
+      models
+    )!;
+    expect(first).toEqual(reordered);
+    expect(JSON.stringify(first)).not.toContain("C:\\private");
+    expect(first.metadata.model).toBe("model.gguf");
+  });
+
+  it.each([
+    ["template", { ...props, chat_template: "{{ changed }}" }, models],
+    [
+      "build",
+      { ...props, build_info: { build: 124, commit: "abc" } },
+      models,
+    ],
+    [
+      "model",
+      { ...props, model_path: "D:\\models\\other.gguf" },
+      {
+        ...models,
+        data: [{ ...models.data[0], id: "D:\\models\\other.gguf" }],
+      },
+    ],
+  ])("changes when observable %s state changes", (_, nextProps, nextModels) => {
+    const before = createLlamaCppStateBinding(props, models)!;
+    const after = createLlamaCppStateBinding(nextProps, nextModels)!;
+    expect(after.serverStateFingerprint).not.toBe(
+      before.serverStateFingerprint
+    );
+  });
+
+  it("is unavailable when required observable fields are absent", () => {
+    expect(
+      createLlamaCppStateBinding(
+        { ...props, chat_template: undefined },
+        models
+      )
+    ).toBeUndefined();
+  });
+
+  it("distinguishes full model identities with the same basename", () => {
+    const first = createLlamaCppStateBinding(
+      { ...props, model_path: "C:\\models\\model.gguf" },
+      models
+    )!;
+    const second = createLlamaCppStateBinding(
+      { ...props, model_path: "D:\\other\\model.gguf" },
+      models
+    )!;
+
+    expect(first.metadata.model).toBe(second.metadata.model);
+    expect(first.serverStateFingerprint).not.toBe(
+      second.serverStateFingerprint
+    );
+    expect(JSON.stringify(second)).not.toContain("D:\\other");
+  });
+
+  it("selects the requested router model independent of list order", () => {
+    const routerModels = {
+      object: "list",
+      data: [
+        { id: "first.gguf", meta: { n_ctx: 2048 } },
+        { id: "selected.gguf", meta: { n_ctx: 8192 } },
+      ],
+    };
+    const reversed = {
+      ...routerModels,
+      data: [...routerModels.data].reverse(),
+    };
+    const selectedProps = {
+      ...props,
+      model_alias: "selected.gguf",
+      model_path: "C:\\models\\selected.gguf",
+    };
+
+    expect(
+      createLlamaCppStateBinding(
+        selectedProps,
+        routerModels,
+        "selected.gguf"
+      )
+    ).toEqual(
+      createLlamaCppStateBinding(
+        selectedProps,
+        reversed,
+        "selected.gguf"
+      )
+    );
+    expect(
+      createLlamaCppStateBinding(
+        selectedProps,
+        routerModels,
+        "missing.gguf"
+      )
+    ).toBeUndefined();
+  });
+});

--- a/src/llm/clients/llamaCppState.ts
+++ b/src/llm/clients/llamaCppState.ts
@@ -1,0 +1,119 @@
+import { createHash } from "node:crypto";
+import type {
+  LlamaCppModelsResponse,
+  LlamaCppPropsResponse,
+} from "./LlamaCppServerClient";
+
+export interface LlamaCppStateBinding {
+  serverStateFingerprint: string;
+  chatTemplateFingerprint: string;
+  metadata: {
+    model: string;
+    modelAlias?: string;
+    buildInfo: string;
+  };
+}
+
+function basename(value: string): string {
+  const normalized = value.replace(/\\/g, "/");
+  return normalized.slice(normalized.lastIndexOf("/") + 1);
+}
+
+/** Selects the observable model addressed by a router-mode request. */
+export function selectLlamaCppModel(
+  models: LlamaCppModelsResponse,
+  selectedModel?: string
+): LlamaCppModelsResponse["data"][number] | undefined {
+  if (!selectedModel) {
+    return models.data.length === 1 ? models.data[0] : undefined;
+  }
+  const selectedBasename = basename(selectedModel);
+  const matches = models.data.filter((model) => {
+    const candidates = [model.id, ...(model.aliases ?? [])];
+    return candidates.some(
+      (candidate) =>
+        candidate === selectedModel ||
+        basename(candidate) === selectedBasename
+    );
+  });
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  return models.data.length === 1 ? models.data[0] : undefined;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      result[key] = canonicalize(
+        (value as Record<string, unknown>)[key]
+      );
+    }
+    return result;
+  }
+  return value;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/**
+ * Creates a privacy-preserving binding over observable model/server/template
+ * state. Absolute local model paths never leave this helper.
+ */
+export function createLlamaCppStateBinding(
+  props: LlamaCppPropsResponse,
+  models: LlamaCppModelsResponse,
+  selectedModel?: string
+): LlamaCppStateBinding | undefined {
+  const model = selectLlamaCppModel(models, selectedModel);
+  if (
+    !model?.id ||
+    typeof props.chat_template !== "string" ||
+    props.build_info === undefined
+  ) {
+    return undefined;
+  }
+
+  const observableModelIdentity =
+    typeof props.model_path === "string" ? props.model_path : model.id;
+  const modelName = basename(observableModelIdentity);
+  const modelAlias =
+    typeof props.model_alias === "string"
+      ? basename(props.model_alias)
+      : undefined;
+  const buildInfo = stableJson(props.build_info);
+  const chatTemplateFingerprint = sha256(props.chat_template);
+  const observable = {
+    model: modelName,
+    modelIdentityFingerprint: sha256(
+      observableModelIdentity.replace(/\\/g, "/")
+    ),
+    modelAlias,
+    modelMeta: model.meta,
+    buildInfo: props.build_info,
+    chatTemplate: props.chat_template,
+    chatTemplateCaps: props.chat_template_caps,
+    bosToken: props.bos_token,
+    eosToken: props.eos_token,
+  };
+
+  return {
+    serverStateFingerprint: sha256(stableJson(observable)),
+    chatTemplateFingerprint,
+    metadata: {
+      model: modelName,
+      ...(modelAlias && { modelAlias }),
+      buildInfo,
+    },
+  };
+}

--- a/src/llm/clients/preparedAdapterUtils.ts
+++ b/src/llm/clients/preparedAdapterUtils.ts
@@ -1,0 +1,259 @@
+import type {
+  PreparedCallMode,
+  PreparedProviderMessageView,
+  PreparedProviderRequestView,
+  PreparedRequestValue,
+  PreparedStructuredOutputView,
+  StructuredOutputSettings,
+} from "../types";
+import type { InternalLLMChatRequest } from "./types";
+
+export const PROMPT_STRUCTURED_OUTPUT_REVISION = "prompt-schema-v1";
+
+function cloneValue<T>(value: T): T {
+  return structuredClone(value);
+}
+
+/** Recursively freezes an adapter-owned plain request graph. */
+export function deepFreeze<T>(value: T): T {
+  if (
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function") ||
+    Object.isFrozen(value)
+  ) {
+    return value;
+  }
+
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(child);
+  }
+  return Object.freeze(value);
+}
+
+/** Clones and freezes a provider payload so SDK mutation cannot affect redispatch. */
+export function freezeProviderRequest<T>(value: T): T {
+  return deepFreeze(cloneValue(value));
+}
+
+/** Converts provider-owned data into a detached JSON-safe library value. */
+export function toPreparedRequestValue(
+  value: unknown
+): PreparedRequestValue | undefined {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : String(value);
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map(toPreparedRequestValue)
+      .filter((item): item is PreparedRequestValue => item !== undefined);
+  }
+  if (typeof value === "object") {
+    const result: Record<string, PreparedRequestValue> = {};
+    for (const [key, child] of Object.entries(
+      value as Record<string, unknown>
+    )) {
+      const converted = toPreparedRequestValue(child);
+      if (converted !== undefined) {
+        result[key] = converted;
+      }
+    }
+    return result;
+  }
+  return undefined;
+}
+
+function normalizeMessages(value: unknown): PreparedProviderMessageView[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((message) => {
+    const record =
+      message && typeof message === "object"
+        ? (message as Record<string, unknown>)
+        : {};
+    const content =
+      toPreparedRequestValue(record.content ?? record.parts ?? "") ?? "";
+    return {
+      role: String(record.role ?? "unknown"),
+      content,
+    };
+  });
+}
+
+function structuredOutputView(
+  settings: StructuredOutputSettings | undefined,
+  payload: Record<string, unknown>
+): PreparedStructuredOutputView | undefined {
+  if (!settings?.schema || settings.enabled === false) {
+    return undefined;
+  }
+  const delivery = settings.delivery ?? "native";
+  if (delivery === "prompt") {
+    return {
+      delivery,
+      enforcement: "instruction_only",
+      name: settings.name,
+      schema: toPreparedRequestValue(settings.schema) ?? {},
+      promptRevision: PROMPT_STRUCTURED_OUTPUT_REVISION,
+    };
+  }
+
+  const responseFormat = payload.response_format as
+    | Record<string, unknown>
+    | undefined;
+  const jsonSchema = responseFormat?.json_schema as
+    | Record<string, unknown>
+    | undefined;
+  const outputConfig = payload.output_config as
+    | Record<string, unknown>
+    | undefined;
+  const outputFormat = outputConfig?.format as
+    | Record<string, unknown>
+    | undefined;
+  const config = payload.config as Record<string, unknown> | undefined;
+  const nativeSchema =
+    jsonSchema?.schema ??
+    responseFormat?.schema ??
+    outputFormat?.schema ??
+    config?.responseSchema;
+  const nativeName =
+    typeof jsonSchema?.name === "string" ? jsonSchema.name : undefined;
+  return {
+    delivery,
+    enforcement: nativeSchema === undefined ? "json_only" : "provider",
+    ...(nativeName !== undefined && { name: nativeName }),
+    ...(nativeSchema !== undefined && {
+      schema: toPreparedRequestValue(nativeSchema) ?? {},
+    }),
+  };
+}
+
+export interface PreparedViewOptions {
+  operation: string;
+  mode: PreparedCallMode;
+  payload: Record<string, unknown>;
+  structuredOutput?: StructuredOutputSettings;
+  messageField?: string;
+  systemField?: string;
+  reasoningField?: string;
+  extensionFields?: readonly string[];
+}
+
+/** Builds the stable inspection view from the same canonical provider payload. */
+export function createPreparedRequestView(
+  options: PreparedViewOptions
+): PreparedProviderRequestView {
+  const messageField = options.messageField ?? "messages";
+  const systemField = options.systemField ?? "system";
+  const excluded = new Set([
+    messageField,
+    systemField,
+    options.reasoningField,
+    ...(options.extensionFields ?? []),
+  ].filter((field): field is string => field !== undefined));
+  const settings: Record<string, PreparedRequestValue> = {};
+  for (const [key, value] of Object.entries(options.payload)) {
+    if (excluded.has(key)) {
+      continue;
+    }
+    const converted = toPreparedRequestValue(value);
+    if (converted !== undefined) {
+      settings[key] = converted;
+    }
+  }
+
+  const extensions: Record<string, PreparedRequestValue> = {};
+  for (const field of options.extensionFields ?? []) {
+    const converted = toPreparedRequestValue(options.payload[field]);
+    if (converted !== undefined) {
+      extensions[field] = converted;
+    }
+  }
+
+  const systemInstruction = toPreparedRequestValue(
+    options.payload[systemField]
+  );
+  const reasoning = options.reasoningField
+    ? toPreparedRequestValue(options.payload[options.reasoningField])
+    : undefined;
+
+  return deepFreeze({
+    operation: options.operation,
+    mode: options.mode,
+    messages: normalizeMessages(options.payload[messageField]),
+    ...(systemInstruction !== undefined && { systemInstruction }),
+    ...(structuredOutputView(options.structuredOutput, options.payload) && {
+      structuredOutput: structuredOutputView(
+        options.structuredOutput,
+        options.payload
+      ),
+    }),
+    ...(reasoning !== undefined && { reasoning }),
+    settings,
+    ...(Object.keys(extensions).length > 0 && { extensions }),
+  });
+}
+
+/** Deterministic instruction used for explicit prompt-delivered structured output. */
+export function createPromptStructuredOutputInstruction(
+  settings: StructuredOutputSettings
+): string {
+  return [
+    `<GENAI_LITE_STRUCTURED_OUTPUT revision="${PROMPT_STRUCTURED_OUTPUT_REVISION}" name="${settings.name}">`,
+    "Return only valid JSON matching this schema. Do not include markdown fences or commentary.",
+    JSON.stringify(settings.schema),
+    "</GENAI_LITE_STRUCTURED_OUTPUT>",
+  ].join("\n");
+}
+
+/**
+ * Injects explicit prompt-delivered schema guidance before provider formatting.
+ *
+ * Native delivery is untouched. The final user message is extended when one
+ * exists; otherwise a user message is appended so provider role alternation
+ * remains the adapter's responsibility.
+ */
+export function applyPromptStructuredOutput(
+  request: InternalLLMChatRequest
+): InternalLLMChatRequest {
+  const structuredOutput = request.settings.structuredOutput;
+  if (
+    !structuredOutput?.schema ||
+    structuredOutput.enabled === false ||
+    structuredOutput.delivery !== "prompt"
+  ) {
+    return request;
+  }
+
+  const messages = request.messages.map((message) => ({ ...message }));
+  const instruction = createPromptStructuredOutputInstruction(structuredOutput);
+  if (messages.some((message) => message.content.includes(instruction))) {
+    return request;
+  }
+  let targetIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].role === "user") {
+      targetIndex = index;
+      break;
+    }
+  }
+
+  if (targetIndex >= 0) {
+    messages[targetIndex].content =
+      `${messages[targetIndex].content}\n\n${instruction}`;
+  } else {
+    messages.push({ role: "user", content: instruction });
+  }
+
+  return {
+    ...request,
+    messages,
+  };
+}

--- a/src/llm/clients/types.ts
+++ b/src/llm/clients/types.ts
@@ -5,8 +5,19 @@ import type {
   LLMChatRequest,
   LLMResponse,
   LLMFailureResponse,
+  LLMRawAnswerAccounting,
+  LLMRawContentPart,
   LLMSettings,
   LLMStreamEvent,
+  LLMTermination,
+  LLMUsage,
+  LLMUsageEvidence,
+  ModelInfo,
+  PreparedCallMode,
+  PreparedPromptAccounting,
+  PreparedProviderRequestView,
+  PreparedRequestBindings,
+  EffectiveOutputTokenLimit,
 } from "../types";
 
 /**
@@ -30,6 +41,65 @@ export interface AdapterRequestOptions {
   /** Request timeout in milliseconds (mapped to each SDK's timeout mechanism) */
   timeoutMs?: number;
 }
+
+/** Raw/provenance evidence observed by an adapter while streaming. */
+export interface AdapterStreamObservedEvidence {
+  choice?: {
+    index: number;
+    rawContentDelta?: string;
+    rawContentParts?: LLMRawContentPart[];
+    rawAnswerAccounting?: LLMRawAnswerAccounting;
+    finishReason?: string | null;
+    termination?: LLMTermination;
+  };
+  usage?: LLMUsage;
+  usageEvidence?: LLMUsageEvidence;
+}
+
+/**
+ * Stream event emitted by adapters before the service assigns an attempt ID.
+ *
+ * Existing adapters may keep emitting the legacy LLMStreamEvent union. Built-in
+ * adapters can attach evidence to a public event or emit an adapter-only
+ * evidence event, which LLMService consumes without forwarding.
+ */
+export type AdapterLLMStreamEvent =
+  | (LLMStreamEvent & {
+      observedEvidence?: AdapterStreamObservedEvidence;
+    })
+  | {
+      type: "adapter_evidence";
+      observedEvidence: AdapterStreamObservedEvidence;
+    };
+
+/** Context supplied to credential-free adapter preparation. */
+export interface AdapterPreparationContext {
+  mode: PreparedCallMode;
+  modelInfo: ModelInfo;
+  outputTokenLimit?: EffectiveOutputTokenLimit;
+  /** Opaque adapter-owned state captured during dynamic model resolution. */
+  providerState?: unknown;
+}
+
+/** Opaque adapter-owned command plus stable inspection evidence. */
+export interface AdapterPreparedRequest<TProviderRequest = unknown> {
+  mode: PreparedCallMode;
+  providerRequest: TProviderRequest;
+  requestView: PreparedProviderRequestView;
+  promptAccounting: PreparedPromptAccounting;
+  outputTokenLimit?: EffectiveOutputTokenLimit;
+  bindings: PreparedRequestBindings;
+}
+
+/** Result of credential-free adapter preparation. */
+export type AdapterPreparationResult =
+  | { prepared: AdapterPreparedRequest }
+  | { error: LLMFailureResponse };
+
+/** Result of revalidating observable prepared-call bindings. */
+export type AdapterRevalidationResult =
+  | { valid: true }
+  | { valid: false; error: LLMFailureResponse };
 
 /**
  * Interface that all LLM client adapters must implement
@@ -69,7 +139,38 @@ export interface ILLMClientAdapter {
     request: InternalLLMChatRequest,
     apiKey: string,
     options?: AdapterRequestOptions
-  ): AsyncIterable<LLMStreamEvent>;
+  ): AsyncIterable<AdapterLLMStreamEvent>;
+
+  /**
+   * Optional credential-free canonical preparation capability.
+   *
+   * Built-in adapters implement this. Legacy custom adapters remain
+   * source-compatible and are reported as unsupported when it is absent.
+   */
+  prepareRequest?(
+    request: InternalLLMChatRequest,
+    context: AdapterPreparationContext
+  ): Promise<AdapterPreparationResult>;
+
+  /** Dispatches a canonical non-streaming provider request. */
+  sendPrepared?(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): Promise<LLMResponse | LLMFailureResponse>;
+
+  /** Dispatches a canonical streaming provider request. */
+  streamPrepared?(
+    prepared: AdapterPreparedRequest,
+    apiKey: string,
+    options?: AdapterRequestOptions
+  ): AsyncIterable<AdapterLLMStreamEvent>;
+
+  /** Revalidates locally observable state before an inference request. */
+  revalidatePreparedRequest?(
+    prepared: AdapterPreparedRequest,
+    options?: AdapterRequestOptions
+  ): Promise<AdapterRevalidationResult>;
 
   /**
    * Optional method to validate API key format before making requests
@@ -108,6 +209,14 @@ export const ADAPTER_ERROR_CODES = {
   REQUEST_TIMEOUT: "REQUEST_TIMEOUT",
   /** The request was cancelled via AbortSignal (never retried) */
   REQUEST_ABORTED: "REQUEST_ABORTED",
+  /** The adapter does not implement canonical prepared calls. */
+  PREPARED_CALL_UNSUPPORTED: "PREPARED_CALL_UNSUPPORTED",
+  /** Observable local state changed after preparation. */
+  PREPARED_CALL_STALE: "PREPARED_CALL_STALE",
+  /** A prepared handle is invalid, forged, or belongs to another service. */
+  INVALID_PREPARED_CALL: "INVALID_PREPARED_CALL",
+  /** A prepared handle was dispatched with the wrong mode. */
+  PREPARED_CALL_MODE_MISMATCH: "PREPARED_CALL_MODE_MISMATCH",
 } as const;
 
 /**

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -1954,7 +1954,8 @@ export function validateLLMSettings(settings: Partial<LLMSettings>): string[] {
       if (
         settings.llamacpp.grammar &&
         settings.structuredOutput?.schema &&
-        settings.structuredOutput.enabled !== false
+        settings.structuredOutput.enabled !== false &&
+        settings.structuredOutput.delivery !== "prompt"
       ) {
         errors.push(
           "llamacpp.grammar and structuredOutput are mutually exclusive (llama-server rejects both together)"
@@ -2052,6 +2053,14 @@ export function validateLLMSettings(settings: Partial<LLMSettings>): string[] {
       // enabled must be boolean if present
       if (so.enabled !== undefined && typeof so.enabled !== "boolean") {
         errors.push("structuredOutput.enabled must be a boolean");
+      }
+
+      if (
+        so.delivery !== undefined &&
+        so.delivery !== "native" &&
+        so.delivery !== "prompt"
+      ) {
+        errors.push("structuredOutput.delivery must be 'native' or 'prompt'");
       }
 
       // strict must be boolean if present

--- a/src/llm/preparedTypes.test.ts
+++ b/src/llm/preparedTypes.test.ts
@@ -1,0 +1,128 @@
+import { validateLLMSettings } from "./config";
+import type {
+  LLMFailureResponse,
+  LLMServiceStreamEvent,
+  LLMStreamEvent,
+  PreparedCompleteCall,
+  PreparedPromptAccounting,
+  PreparedStreamCall,
+} from "./types";
+import type {
+  ILLMClientAdapter,
+  InternalLLMChatRequest,
+} from "./clients/types";
+
+describe("prepared-call public contracts", () => {
+  it("requires evidence when prepared accounting is available", () => {
+    const countOnly: PreparedPromptAccounting = {
+      status: "available",
+      count: { tokens: 12, method: "exact" },
+    };
+    const boundOnly: PreparedPromptAccounting = {
+      status: "available",
+      upperBound: {
+        tokens: 16,
+        certificate: {
+          id: "test",
+          derivation: "fixture",
+          provenance: "unit test",
+          targetProfileRevision: "target-v1",
+        },
+      },
+    };
+
+    // @ts-expect-error available accounting must contain a count or bound
+    const empty: PreparedPromptAccounting = { status: "available" };
+
+    expect(countOnly.status).toBe("available");
+    expect(boundOnly.status).toBe("available");
+    expect(empty.status).toBe("available");
+  });
+
+  it("keeps complete and stream handles nominally distinct", () => {
+    const send = (_prepared: PreparedCompleteCall): void => undefined;
+    const stream = (_prepared: PreparedStreamCall): void => undefined;
+    const complete = {} as PreparedCompleteCall;
+    const streaming = {} as PreparedStreamCall;
+
+    send(complete);
+    stream(streaming);
+    // @ts-expect-error stream handles cannot be sent through the complete dispatcher
+    send(streaming);
+    // @ts-expect-error complete handles cannot be sent through the stream dispatcher
+    stream(complete);
+  });
+
+  it("requires attempt IDs on service stream events", () => {
+    const event: LLMServiceStreamEvent = {
+      attemptId: "attempt-1",
+      type: "content_delta",
+      delta: "hello",
+      index: 0,
+    };
+    // @ts-expect-error service events always carry an attempt ID
+    const missing: LLMServiceStreamEvent = {
+      type: "content_delta",
+      delta: "hello",
+      index: 0,
+    };
+
+    expect(event.attemptId).toBe("attempt-1");
+    expect(missing.type).toBe("content_delta");
+  });
+
+  it("keeps legacy adapter implementations source-compatible", async () => {
+    const failure: LLMFailureResponse = {
+      provider: "legacy",
+      model: "legacy-model",
+      object: "error",
+      error: { message: "fixture" },
+    };
+    const legacy: ILLMClientAdapter = {
+      async sendMessage(_request: InternalLLMChatRequest) {
+        return failure;
+      },
+      async *streamMessage() {
+        const event: LLMStreamEvent = {
+          type: "content_delta",
+          delta: "legacy",
+          index: 0,
+        };
+        yield event;
+      },
+    };
+
+    expect(legacy.prepareRequest).toBeUndefined();
+    await expect(
+      legacy.sendMessage({} as InternalLLMChatRequest, "unused")
+    ).resolves.toBe(failure);
+    const stream = legacy.streamMessage!(
+      {} as InternalLLMChatRequest,
+      "unused"
+    );
+    await expect(stream[Symbol.asyncIterator]().next()).resolves.toMatchObject({
+      value: { type: "content_delta", delta: "legacy" },
+    });
+  });
+
+  it("validates explicit structured-output delivery", () => {
+    const base = {
+      name: "answer",
+      schema: { type: "object" as const },
+    };
+
+    expect(
+      validateLLMSettings({
+        structuredOutput: { ...base, delivery: "prompt" },
+      })
+    ).toEqual([]);
+    expect(
+      validateLLMSettings({
+        structuredOutput: {
+          ...base,
+          delivery: "invalid" as "native",
+        },
+      })
+    ).toContain("structuredOutput.delivery must be 'native' or 'prompt'");
+  });
+});

--- a/src/llm/services/.summary_long.md
+++ b/src/llm/services/.summary_long.md
@@ -5,6 +5,11 @@ The services directory contains LLM-specific service classes extracted from the 
 
 **Note**: Generic services like PresetManager and AdapterRegistry have been moved to `src/shared/services/` as part of the Phase 3.5 refactoring, where they serve both LLM and Image services.
 
+Structured-output validation now treats `delivery: "native"` as provider
+enforcement and `delivery: "prompt"` as an explicit instruction-only fallback.
+Prompt delivery bypasses native-capability rejection while retaining ordinary
+request/schema validation.
+
 ## Key Components
 
 ### RequestValidator.ts
@@ -69,6 +74,10 @@ Resolves model information from either preset IDs or direct provider/model IDs. 
 - Comprehensive error handling with specific error codes
 - Validates provider support before model lookup
 - Merges preset settings with user settings (user takes precedence)
+- For llama.cpp, requests one adapter preparation snapshot and returns it as
+  opaque `adapterPreparationState`; detected capabilities, resolved defaults,
+  exact prompt counting, and later dispatch revalidation therefore share one
+  observed model/build/template state
 - **Flexible model validation**: When a model ID is not found in configuration:
   - For providers with `allowUnknownModels: true` (e.g., llamacpp, mock): Creates fallback ModelInfo silently
   - For other providers (e.g., openai, anthropic): Logs warning but creates fallback ModelInfo and allows request to proceed

--- a/src/llm/services/.summary_short.md
+++ b/src/llm/services/.summary_short.md
@@ -4,11 +4,11 @@ Purpose: Contains LLM-specific service classes extracted from LLMService.ts, eac
 
 ## Files:
 
-- `RequestValidator.ts`: Validates LLM request structure including messages format, role validation, settings validation, and reasoning capability checks.
+- `RequestValidator.ts`: Validates request/settings/reasoning plus explicit native-versus-prompt structured-output delivery and capability branching.
 - `RequestValidator.test.ts`: Tests the RequestValidator's message validation, settings validation, and reasoning settings validation logic.
 - `SettingsManager.ts`: Merges user settings with model/provider defaults (including the new flat sampling params topK/minP/repeatPenalty/seed, logprobs/topLogprobs, the llamacpp namespace, and vendor defaultSettings/reasoningDefaultSettings overlays for detected models), filters out unsupported parameters based on provider/model capabilities, and validates settings extracted from template metadata.
 - `SettingsManager.test.ts`: Tests the SettingsManager's settings merging logic and parameter filtering functionality.
-- `ModelResolver.ts`: Resolves model information from either preset IDs or direct provider/model IDs, validating provider support and creating fallback ModelInfo for unknown models with flexible validation based on provider configuration.
+- `ModelResolver.ts`: Resolves preset/direct models and unknown-model fallbacks; for llama.cpp it carries one opaque model/build/template snapshot into preparation so detected capabilities and dispatch binding stay coherent.
 - `ModelResolver.test.ts`: Tests the ModelResolver's preset resolution, direct ID resolution, fallback model creation, and flexible validation behavior.
 
 ## Note:

--- a/src/llm/services/ModelResolver.test.ts
+++ b/src/llm/services/ModelResolver.test.ts
@@ -230,6 +230,42 @@ describe('ModelResolver', () => {
       expect(result.modelInfo?.structuredOutput?.supported).toBe(true);
     });
 
+    it("carries one llama.cpp resolution snapshot into adapter preparation", async () => {
+      const snapshot = {
+        kind: "llamacpp-preparation-v1",
+        selectedModel: "llamacpp",
+        detectedCaps: {
+          defaultSettings: { temperature: 0.6 },
+          localReasoning: { toggleKwarg: "enable_thinking" },
+        },
+        stateBinding: {
+          serverStateFingerprint: "state-a",
+          chatTemplateFingerprint: "template-a",
+          metadata: { model: "model-a.gguf", buildInfo: "{}" },
+        },
+      };
+      const getPreparationSnapshot = jest
+        .fn()
+        .mockResolvedValue(snapshot);
+      const getModelCapabilities = jest.fn();
+      mockAdapterRegistry.getAdapter.mockReturnValue({
+        getPreparationSnapshot,
+        getModelCapabilities,
+      } as any);
+
+      const result = await resolver.resolve({
+        providerId: "llamacpp",
+        modelId: "llamacpp",
+      });
+
+      expect(getPreparationSnapshot).toHaveBeenCalledWith("llamacpp");
+      expect(getModelCapabilities).not.toHaveBeenCalled();
+      expect(result.adapterPreparationState).toBe(snapshot);
+      expect(result.modelInfo?.defaultSettings).toEqual({
+        temperature: 0.6,
+      });
+    });
+
     it('should keep the generic llamacpp entry unchanged when detection fails', async () => {
       mockAdapterRegistry.getAdapter.mockReturnValue({
         getModelCapabilities: jest.fn().mockResolvedValue(null),

--- a/src/llm/services/ModelResolver.ts
+++ b/src/llm/services/ModelResolver.ts
@@ -37,6 +37,7 @@ export interface ModelResolution {
   modelId?: string;
   modelInfo?: ModelInfo;
   settings?: LLMSettings;
+  adapterPreparationState?: unknown;
   error?: LLMFailureResponse;
 }
 
@@ -46,8 +47,9 @@ export interface ModelResolution {
 export interface ModelResolutionOptions {
   /**
    * Whether resolution may query local provider adapters for dynamic model
-   * capabilities. Defaults to true for sendMessage(), but public capability
-   * preflight uses false so it remains no-network/no-adapter.
+   * capabilities and an opaque preparation snapshot. Defaults to true for
+   * sendMessage(), but public capability preflight uses false so it remains
+   * no-network/no-adapter.
    */
   detectLocalCapabilities?: boolean;
 }
@@ -114,11 +116,15 @@ export class ModelResolver {
 
       // Overlay detected GGUF capabilities for llama.cpp presets (the server decides
       // which model is actually loaded, regardless of the preset's modelId)
+      let adapterPreparationState: unknown;
       if (preset.providerId === 'llamacpp' && detectLocalCapabilities) {
-        const detected = await this.detectLlamaCppCapabilities();
-        if (detected) {
-          modelInfo = { ...modelInfo, ...detected };
+        const detected = await this.detectLlamaCppCapabilities(
+          preset.modelId
+        );
+        if (detected.capabilities) {
+          modelInfo = { ...modelInfo, ...detected.capabilities };
         }
+        adapterPreparationState = detected.preparationState;
       }
 
       // Merge preset settings with user settings
@@ -131,7 +137,10 @@ export class ModelResolver {
         providerId: preset.providerId,
         modelId: preset.modelId,
         modelInfo,
-        settings
+        settings,
+        ...(adapterPreparationState !== undefined && {
+          adapterPreparationState,
+        }),
       };
     }
 
@@ -175,8 +184,13 @@ export class ModelResolver {
     // decides which model is actually loaded, so detected capabilities and vendor
     // default settings must overlay whatever the registry says.
     let detectedCapabilities: Partial<ModelInfo> | undefined;
+    let adapterPreparationState: unknown;
     if (options.providerId === 'llamacpp' && detectLocalCapabilities) {
-      detectedCapabilities = await this.detectLlamaCppCapabilities();
+      const detected = await this.detectLlamaCppCapabilities(
+        options.modelId
+      );
+      detectedCapabilities = detected.capabilities;
+      adapterPreparationState = detected.preparationState;
     }
 
     if (modelInfo) {
@@ -219,7 +233,10 @@ export class ModelResolver {
       providerId: options.providerId,
       modelId: options.modelId,
       modelInfo,
-      settings: options.settings
+      settings: options.settings,
+      ...(adapterPreparationState !== undefined && {
+        adapterPreparationState,
+      }),
     };
   }
 
@@ -228,18 +245,31 @@ export class ModelResolver {
    * its detected capabilities (cached inside the adapter). Returns undefined when
    * the server is unreachable or the model is not recognized.
    */
-  private async detectLlamaCppCapabilities(): Promise<Partial<ModelInfo> | undefined> {
+  private async detectLlamaCppCapabilities(
+    modelId?: string
+  ): Promise<{
+    capabilities?: Partial<ModelInfo>;
+    preparationState?: unknown;
+  }> {
     try {
       const adapter = this.adapterRegistry.getAdapter('llamacpp') as any;
-      // Check if adapter has the getModelCapabilities method
+      if (
+        adapter &&
+        typeof adapter.getPreparationSnapshot === "function"
+      ) {
+        const snapshot = await adapter.getPreparationSnapshot(modelId);
+        return {
+          capabilities: snapshot.detectedCaps || undefined,
+          preparationState: snapshot,
+        };
+      }
       if (adapter && typeof adapter.getModelCapabilities === 'function') {
-        const capabilities = await adapter.getModelCapabilities();
-        return capabilities || undefined;
+        const capabilities = await adapter.getModelCapabilities(modelId);
+        return { capabilities: capabilities || undefined };
       }
     } catch (error) {
       this.logger.warn('Failed to detect GGUF model capabilities:', error);
-      // Continue with fallback
     }
-    return undefined;
+    return {};
   }
 }

--- a/src/llm/services/RequestValidator.test.ts
+++ b/src/llm/services/RequestValidator.test.ts
@@ -335,6 +335,28 @@ describe('RequestValidator', () => {
       expect(result).toBeNull();
     });
 
+    it("allows explicit prompt delivery without native provider support", () => {
+      const result = validator.validateStructuredOutputSettings(
+        mockModelWithoutStructuredOutput,
+        { ...validStructuredOutput, delivery: "prompt" },
+        baseRequest
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("rejects an invalid structured-output delivery value at runtime", () => {
+      const result = validator.validateStructuredOutputSettings(
+        mockModelWithStructuredOutput,
+        { ...validStructuredOutput, delivery: "invalid" as any },
+        baseRequest
+      );
+
+      expect(result?.error.code).toBe(
+        "structured_output_invalid_delivery"
+      );
+    });
+
     it('should pass validation for models with partial support (no strict mode)', () => {
       const result = validator.validateStructuredOutputSettings(
         mockModelWithPartialSupport,

--- a/src/llm/services/RequestValidator.ts
+++ b/src/llm/services/RequestValidator.ts
@@ -191,6 +191,37 @@ export class RequestValidator {
       return null;
     }
 
+    if (
+      structuredOutput.delivery !== undefined &&
+      structuredOutput.delivery !== "native" &&
+      structuredOutput.delivery !== "prompt"
+    ) {
+      return {
+        provider: request.providerId!,
+        model: request.modelId!,
+        error: {
+          message:
+            "structuredOutput.delivery must be either 'native' or 'prompt'.",
+          type: "validation_error",
+          code: "structured_output_invalid_delivery",
+          param: "settings.structuredOutput.delivery",
+        },
+        object: "error",
+      };
+    }
+
+    // Explicit prompt delivery is instruction-only and does not require a
+    // provider-native structured-output capability.
+    if (structuredOutput.delivery === "prompt") {
+      if (structuredOutput.strict !== false) {
+        this.logger.warn(
+          `Prompt-delivered structured output for ${request.modelId} is instruction-only; ` +
+          `strict provider enforcement is not available.`
+        );
+      }
+      return null;
+    }
+
     // If model has explicit structuredOutput capabilities defined, check them
     if (modelInfo.structuredOutput !== undefined) {
       if (!modelInfo.structuredOutput.supported) {

--- a/src/llm/services/SettingsManager.ts
+++ b/src/llm/services/SettingsManager.ts
@@ -425,6 +425,18 @@ export class SettingsManager {
           soValidated.name = value.name;
         }
 
+        if (
+          'delivery' in value &&
+          value.delivery !== 'native' &&
+          value.delivery !== 'prompt'
+        ) {
+          this.logger.warn(
+            `Invalid structuredOutput.delivery value in template. Must be 'native' or 'prompt'.`
+          );
+        } else if ('delivery' in value) {
+          soValidated.delivery = value.delivery;
+        }
+
         if ('schema' in value && typeof value.schema !== 'object') {
           this.logger.warn(`Invalid structuredOutput.schema value in template. Must be an object.`);
         } else if ('schema' in value) {

--- a/src/llm/tokenization/.summary_long.md
+++ b/src/llm/tokenization/.summary_long.md
@@ -1,0 +1,16 @@
+# Tokenization Architecture
+
+The tokenization directory separates content point counts from fully prepared
+message accounting. Profiles are available only when bundled js-tiktoken rank
+data matches pinned SHA-256 revisions and proves all 256 byte values are
+ordinary tokens. Model-to-profile mapping has its own revision.
+
+`countTextTokens()` treats special-token literals as ordinary text and returns
+exact evidence for verified profiles. `estimateTextTokens()` is explicitly
+heuristic. Unknown provider/model mappings are unavailable.
+
+`codePointBoundToTokenUpperBound()` uses the four-byte UTF-8 scalar maximum and
+target byte completeness. `retokenizationUpperBound()` covers text decoded from
+ordinary source-generation tokens, including conservative invalid-byte
+replacement expansion. Neither API accepts or applies a consumer/session
+heuristic margin, and both reject unsafe arithmetic.

--- a/src/llm/tokenization/.summary_short.md
+++ b/src/llm/tokenization/.summary_short.md
@@ -1,0 +1,13 @@
+# Directory: src/llm/tokenization/
+
+Purpose: Public evidence-bearing token profiles, exact ordinary-text counting,
+and proof-backed structural retokenization/code-point bounds with no consumer
+safety margin.
+
+## Files
+
+- `types.ts`: Profile, resolution, count, and bound result types.
+- `profiles.ts`: Hash-verified cl100k/o200k profiles, model mapping, exact content counting, and explicit heuristic estimation.
+- `bounds.ts`: Safe-integer certificate arithmetic for retokenization and Unicode code-point bounds.
+- `index.ts`: Public tokenization barrel.
+- `tokenization.test.ts`: Hash, adversarial text, decoded-token, overflow, exact-zero-margin, and numeric double-margin tests.

--- a/src/llm/tokenization/bounds.ts
+++ b/src/llm/tokenization/bounds.ts
@@ -1,0 +1,168 @@
+import type { TokenBoundCertificateRef } from "../types";
+import type {
+  TokenBoundResult,
+  TokenProfile,
+} from "./types";
+import { getTokenProfileById } from "./profiles";
+
+function invalidBound(message: string): TokenBoundResult {
+  return {
+    status: "error",
+    error: { code: "INVALID_TOKEN_BOUND", message },
+  };
+}
+
+function checkedMultiply(left: number, right: number): number | undefined {
+  if (left === 0 || right === 0) {
+    return 0;
+  }
+  if (left > Math.floor(Number.MAX_SAFE_INTEGER / right)) {
+    return undefined;
+  }
+  return left * right;
+}
+
+function validateNonnegativeSafeInteger(
+  value: number,
+  name: string
+): TokenBoundResult | undefined {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    return invalidBound(`${name} must be a nonnegative safe integer.`);
+  }
+  return undefined;
+}
+
+function validateProfile(
+  profile: TokenProfile
+): { profile: TokenProfile } | { reason: string } {
+  const current = getTokenProfileById(profile.id);
+  if (
+    !current ||
+    current.revision !== profile.revision ||
+    current.rankHash !== profile.rankHash
+  ) {
+    return {
+      reason: `Token profile '${profile.id}' is unavailable or its pinned rank revision changed.`,
+    };
+  }
+  if (!current.byteComplete) {
+    return {
+      reason: `Token profile '${profile.id}' has no byte-completeness proof.`,
+    };
+  }
+  return { profile: current };
+}
+
+/**
+ * Returns a structural retokenization bound for ordinary source-generation
+ * tokens. No consumer/session margin is accepted or applied.
+ */
+export function retokenizationUpperBound(
+  sourceTokenBound: number,
+  sourceProfile: TokenProfile,
+  targetProfile: TokenProfile
+): TokenBoundResult {
+  const invalid = validateNonnegativeSafeInteger(
+    sourceTokenBound,
+    "sourceTokenBound"
+  );
+  if (invalid) {
+    return invalid;
+  }
+  const sourceValidation = validateProfile(sourceProfile);
+  const targetValidation = validateProfile(targetProfile);
+  if ("reason" in sourceValidation) {
+    return {
+      status: "unavailable",
+      reason: sourceValidation.reason,
+    };
+  }
+  if ("reason" in targetValidation) {
+    return {
+      status: "unavailable",
+      reason: targetValidation.reason,
+    };
+  }
+  const certifiedSource = sourceValidation.profile;
+  const certifiedTarget = targetValidation.profile;
+
+  // TextDecoder replacement can turn each invalid source byte into a three-byte
+  // UTF-8 U+FFFD sequence. A byte-complete target needs at most one token per
+  // resulting byte. This intentionally does not claim an n -> n identity bound.
+  const decodedBytes = checkedMultiply(
+    sourceTokenBound,
+    certifiedSource.maximumDecodedBytesPerToken
+  );
+  const tokens = decodedBytes === undefined
+    ? undefined
+    : checkedMultiply(decodedBytes, 3);
+  if (tokens === undefined) {
+    return {
+      status: "error",
+      error: {
+        code: "TOKEN_BOUND_OVERFLOW",
+        message: "The retokenization upper bound exceeds Number.MAX_SAFE_INTEGER.",
+      },
+    };
+  }
+
+  const certificate: TokenBoundCertificateRef = {
+    id: `ordinary-retokenization-v1:${certifiedSource.id}:${certifiedTarget.id}`,
+    derivation:
+      "sourceTokens * maxSourceDecodedBytesPerToken * 3 replacement expansion * 1 targetTokenPerByte",
+    provenance:
+      "Pinned js-tiktoken rank hashes; ordinary generation tokens only; special/control tokens excluded.",
+    sourceProfileRevision: certifiedSource.revision,
+    targetProfileRevision: certifiedTarget.revision,
+  };
+  return {
+    status: "available",
+    upperBound: { tokens, certificate },
+  };
+}
+
+/**
+ * Converts a Unicode code-point bound to a structural token bound for a
+ * byte-complete target profile. No heuristic safety margin is involved.
+ */
+export function codePointBoundToTokenUpperBound(
+  codePointBound: number,
+  targetProfile: TokenProfile
+): TokenBoundResult {
+  const invalid = validateNonnegativeSafeInteger(
+    codePointBound,
+    "codePointBound"
+  );
+  if (invalid) {
+    return invalid;
+  }
+  const profileValidation = validateProfile(targetProfile);
+  if ("reason" in profileValidation) {
+    return { status: "unavailable", reason: profileValidation.reason };
+  }
+  const certifiedTarget = profileValidation.profile;
+  const tokens = checkedMultiply(codePointBound, 4);
+  if (tokens === undefined) {
+    return {
+      status: "error",
+      error: {
+        code: "TOKEN_BOUND_OVERFLOW",
+        message: "The code-point upper bound exceeds Number.MAX_SAFE_INTEGER.",
+      },
+    };
+  }
+  return {
+    status: "available",
+    upperBound: {
+      tokens,
+      certificate: {
+        id: `unicode-code-points-to-${certifiedTarget.id}-v1`,
+        derivation:
+          "codePoints * 4 UTF-8 bytesPerCodePoint * 1 targetTokenPerByte",
+        provenance:
+          "Unicode scalar/replacement UTF-8 maximum and pinned byte-complete js-tiktoken ranks.",
+        targetProfileRevision: certifiedTarget.revision,
+      },
+    },
+  };
+}

--- a/src/llm/tokenization/index.ts
+++ b/src/llm/tokenization/index.ts
@@ -1,0 +1,18 @@
+export type {
+  TokenBoundResult,
+  TokenCountResult,
+  TokenProfile,
+  TokenProfileId,
+  TokenProfileResolution,
+} from "./types";
+export { TOKEN_PROFILE_MAPPING_REVISION } from "./types";
+export {
+  countTextTokens,
+  estimateTextTokens,
+  getTokenProfileById,
+  resolveTokenProfile,
+} from "./profiles";
+export {
+  codePointBoundToTokenUpperBound,
+  retokenizationUpperBound,
+} from "./bounds";

--- a/src/llm/tokenization/profiles.ts
+++ b/src/llm/tokenization/profiles.ts
@@ -1,0 +1,221 @@
+import { createHash } from "node:crypto";
+import { getEncoding, type Tiktoken } from "js-tiktoken";
+import type { ApiProviderId, PreparedPromptTokenCount } from "../types";
+import {
+  TOKEN_PROFILE_MAPPING_REVISION,
+  type TokenCountResult,
+  type TokenProfile,
+  type TokenProfileId,
+  type TokenProfileResolution,
+} from "./types";
+
+interface RankData {
+  pat_str: string;
+  special_tokens: Record<string, number>;
+  bpe_ranks: string;
+}
+
+interface ProfileDefinition {
+  id: TokenProfileId;
+  expectedHash: string;
+  revision: string;
+  loadRanks: () => RankData;
+}
+
+function loadRankData(moduleId: string): RankData {
+  const loaded = require(moduleId) as RankData | { default: RankData };
+  return "default" in loaded ? loaded.default : loaded;
+}
+
+const DEFINITIONS: Record<TokenProfileId, ProfileDefinition> = {
+  cl100k_base: {
+    id: "cl100k_base",
+    expectedHash:
+      "9b9ea7feb9945beda9196f3691a3cc2d0f339aec498bbae285ce6aded387455c",
+    revision: "js-tiktoken-1.0.21:cl100k:9b9ea7feb994",
+    loadRanks: () => loadRankData("js-tiktoken/ranks/cl100k_base"),
+  },
+  o200k_base: {
+    id: "o200k_base",
+    expectedHash:
+      "de7eb511338b0e23589a3cae2dceb8dd66c2a9fd70dbf7ea778fd9df9f175d45",
+    revision: "js-tiktoken-1.0.21:o200k:de7eb511338b",
+    loadRanks: () => loadRankData("js-tiktoken/ranks/o200k_base"),
+  },
+};
+
+const profileCache = new Map<TokenProfileId, TokenProfile | null>();
+const tokenizerCache = new Map<TokenProfileId, Tiktoken>();
+
+function hashRankData(ranks: RankData): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        pat_str: ranks.pat_str,
+        special_tokens: ranks.special_tokens,
+        bpe_ranks: ranks.bpe_ranks,
+      })
+    )
+    .digest("hex");
+}
+
+function deriveRankProperties(
+  ranks: RankData
+): { byteComplete: boolean; maximumDecodedBytesPerToken: number } {
+  const encodedTokens = ranks.bpe_ranks.split(" ").slice(2);
+  const singleBytes = new Set<number>();
+  let maximumDecodedBytesPerToken = 0;
+  for (const encodedToken of encodedTokens) {
+    const bytes = Buffer.from(encodedToken, "base64");
+    maximumDecodedBytesPerToken = Math.max(
+      maximumDecodedBytesPerToken,
+      bytes.length
+    );
+    if (bytes.length === 1) {
+      singleBytes.add(bytes[0]);
+    }
+  }
+  return {
+    byteComplete: singleBytes.size === 256,
+    maximumDecodedBytesPerToken,
+  };
+}
+
+export function getTokenProfileById(
+  id: TokenProfileId
+): TokenProfile | undefined {
+  if (profileCache.has(id)) {
+    return profileCache.get(id) ?? undefined;
+  }
+  const definition = DEFINITIONS[id];
+  if (!definition) {
+    return undefined;
+  }
+  const ranks = definition.loadRanks();
+  const rankHash = hashRankData(ranks);
+  const properties = deriveRankProperties(ranks);
+  if (
+    rankHash !== definition.expectedHash ||
+    !properties.byteComplete ||
+    properties.maximumDecodedBytesPerToken <= 0
+  ) {
+    profileCache.set(id, null);
+    return undefined;
+  }
+  const profile: TokenProfile = Object.freeze({
+    id,
+    tokenizerId: `js-tiktoken:${id}`,
+    revision: definition.revision,
+    encoding: id,
+    rankHash,
+    ordinaryTextOnly: true,
+    byteComplete: true,
+    maximumDecodedBytesPerToken: properties.maximumDecodedBytesPerToken,
+  });
+  profileCache.set(id, profile);
+  return profile;
+}
+
+function mappedProfileId(
+  provider: ApiProviderId,
+  model: string
+): TokenProfileId | undefined {
+  if (provider !== "openai") {
+    return undefined;
+  }
+  const o200kModels = new Set([
+    "gpt-5.2",
+    "gpt-5.1",
+    "gpt-5-mini-2025-08-07",
+    "gpt-5-nano-2025-08-07",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4.1-nano",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "chatgpt-4o-latest",
+    "o1",
+    "o3",
+    "o3-mini",
+    "o4-mini",
+  ]);
+  if (o200kModels.has(model)) {
+    return "o200k_base";
+  }
+  const cl100kModels = new Set([
+    "gpt-4",
+    "gpt-4-turbo",
+    "gpt-3.5-turbo",
+  ]);
+  if (cl100kModels.has(model)) {
+    return "cl100k_base";
+  }
+  return undefined;
+}
+
+export function resolveTokenProfile(
+  provider: ApiProviderId,
+  model: string
+): TokenProfileResolution {
+  const id = mappedProfileId(provider, model);
+  const profile = id ? getTokenProfileById(id) : undefined;
+  if (!profile) {
+    return {
+      status: "unavailable",
+      provider,
+      model,
+      mappingRevision: TOKEN_PROFILE_MAPPING_REVISION,
+      reason: id
+        ? `Tokenizer rank data for '${id}' did not match its pinned revision.`
+        : `No verified token profile is registered for ${provider}/${model}.`,
+    };
+  }
+  return {
+    status: "available",
+    provider,
+    model,
+    mappingRevision: TOKEN_PROFILE_MAPPING_REVISION,
+    profile,
+  };
+}
+
+function getTokenizer(profile: TokenProfile): Tiktoken {
+  let tokenizer = tokenizerCache.get(profile.id);
+  if (!tokenizer) {
+    tokenizer = getEncoding(profile.encoding);
+    tokenizerCache.set(profile.id, tokenizer);
+  }
+  return tokenizer;
+}
+
+/** Counts ordinary text exactly for a pinned, hash-verified profile. */
+export function countTextTokens(
+  text: string,
+  profile: TokenProfile
+): TokenCountResult {
+  const current = getTokenProfileById(profile.id);
+  if (!current || current.revision !== profile.revision) {
+    return {
+      status: "unavailable",
+      reason: `Token profile '${profile.id}' is not available at revision '${profile.revision}'.`,
+    };
+  }
+  const count: PreparedPromptTokenCount = {
+    tokens: getTokenizer(current).encode(text, [], []).length,
+    method: "exact",
+    tokenizerId: current.tokenizerId,
+    tokenProfileRevision: current.revision,
+  };
+  return { status: "available", count };
+}
+
+/** Explicit generic estimate; never returned as an exact or certified bound. */
+export function estimateTextTokens(text: string): PreparedPromptTokenCount {
+  return {
+    tokens: Math.ceil(text.length / 4),
+    method: "heuristic",
+    tokenizerId: "utf16-code-units-per-4",
+    tokenProfileRevision: "generic-utf16-estimator-v1",
+    uncertaintyTokens: Math.ceil(text.length / 8),
+  };
+}

--- a/src/llm/tokenization/tokenization.test.ts
+++ b/src/llm/tokenization/tokenization.test.ts
@@ -1,0 +1,209 @@
+import { getEncoding } from "js-tiktoken";
+import {
+  codePointBoundToTokenUpperBound,
+  countTextTokens,
+  getTokenProfileById,
+  resolveTokenProfile,
+  retokenizationUpperBound,
+} from ".";
+import type { TokenProfile } from ".";
+
+describe("token profiles and certified structural bounds", () => {
+  const cl100k = getTokenProfileById("cl100k_base")!;
+  const o200k = getTokenProfileById("o200k_base")!;
+
+  it("loads only hash-verified byte-complete profiles", () => {
+    expect(cl100k.rankHash).toHaveLength(64);
+    expect(o200k.rankHash).toHaveLength(64);
+    expect(cl100k.byteComplete).toBe(true);
+    expect(o200k.byteComplete).toBe(true);
+    expect(cl100k.maximumDecodedBytesPerToken).toBe(128);
+    expect(o200k.maximumDecodedBytesPerToken).toBe(128);
+  });
+
+  it("maps only verified provider/model aliases", () => {
+    expect(resolveTokenProfile("openai", "gpt-4.1").status).toBe("available");
+    expect(resolveTokenProfile("openai", "gpt-4").status).toBe("available");
+    expect(resolveTokenProfile("anthropic", "claude-unknown")).toMatchObject({
+      status: "unavailable",
+    });
+    for (const unknown of [
+      "gpt-5000",
+      "gpt-4oops",
+      "gpt-5-totally-unknown",
+    ]) {
+      expect(resolveTokenProfile("openai", unknown)).toMatchObject({
+        status: "unavailable",
+      });
+    }
+  });
+
+  it.each([
+    "",
+    "plain ASCII and\ncontrols\u0000",
+    "漢字かなカナ dense script",
+    "e\u0301 vs é",
+    "👨‍👩‍👧‍👦 ✈️ 🧑🏽‍💻",
+    "\u{10ffff}",
+    "\ud800 lone surrogate",
+    "<|endoftext|> is ordinary literal text",
+  ])("counts adversarial ordinary text exactly: %p", (text) => {
+    const result = countTextTokens(text, o200k);
+    expect(result.status).toBe("available");
+    if (result.status === "available") {
+      expect(result.count.method).toBe("exact");
+      expect(result.count.uncertaintyTokens).toBeUndefined();
+      expect(result.count.tokens).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("certifies four target tokens per Unicode code point", () => {
+    const samples = [
+      "ascii",
+      "漢字",
+      "e\u0301",
+      "👨‍👩‍👧‍👦",
+      "\u0000\u{10ffff}",
+      "\ud800",
+    ];
+    for (const sample of samples) {
+      const codePoints = Array.from(sample).length;
+      const bound = codePointBoundToTokenUpperBound(codePoints, o200k);
+      const actual = countTextTokens(sample, o200k);
+      expect(bound.status).toBe("available");
+      expect(actual.status).toBe("available");
+      if (bound.status === "available" && actual.status === "available") {
+        expect(actual.count.tokens).toBeLessThanOrEqual(
+          bound.upperBound.tokens
+        );
+      }
+    }
+  });
+
+  it("bounds decoded ordinary source-token sequences without assuming identity", () => {
+    const sourceTokenizer = getEncoding("cl100k_base");
+    const targetTokenizer = getEncoding("o200k_base");
+    const sourceTokens = sourceTokenizer.encode(
+      "ASCII 漢字 👨‍👩‍👧‍👦 \u0000 combining e\u0301",
+      [],
+      []
+    );
+    const sequences = [
+      sourceTokens,
+      [...sourceTokens].reverse(),
+      sourceTokens.filter((_, index) => index % 2 === 0),
+    ];
+    for (const sequence of sequences) {
+      const decoded = sourceTokenizer.decode(sequence);
+      const actualTargetTokens = targetTokenizer.encode(decoded, [], []).length;
+      const bound = retokenizationUpperBound(
+        sequence.length,
+        cl100k,
+        o200k
+      );
+      expect(bound.status).toBe("available");
+      if (bound.status === "available") {
+        expect(actualTargetTokens).toBeLessThanOrEqual(
+          bound.upperBound.tokens
+        );
+        expect(bound.upperBound.tokens).toBeGreaterThanOrEqual(sequence.length);
+      }
+    }
+  });
+
+  it("proves the consumer heuristic margin cannot be charged twice", () => {
+    // The certified API accepts only structural inputs: 175 code points and a
+    // target profile. It has no consumer/session margin parameter.
+    expect(codePointBoundToTokenUpperBound.length).toBe(2);
+    const result = codePointBoundToTokenUpperBound(175, o200k);
+    expect(result.status).toBe("available");
+    if (result.status !== "available") {
+      throw new Error("Expected a certified structural bound");
+    }
+    const promptTokenUpperBound = result.upperBound.tokens;
+    expect(promptTokenUpperBound).toBe(700);
+
+    const rawCapacity = 1000;
+    const heuristicMargin = 100;
+    const outputBound = 150;
+    const countingSlack = 25;
+    const effectiveCapacity = rawCapacity - heuristicMargin;
+    expect(promptTokenUpperBound + outputBound + countingSlack).toBe(875);
+    expect(
+      promptTokenUpperBound + outputBound + countingSlack <= effectiveCapacity
+    ).toBe(true);
+
+    const incorrectlyDuplicatedMargin =
+      promptTokenUpperBound +
+      outputBound +
+      countingSlack +
+      heuristicMargin;
+    expect(incorrectlyDuplicatedMargin).toBe(975);
+    expect(incorrectlyDuplicatedMargin <= effectiveCapacity).toBe(false);
+  });
+
+  it("uses zero heuristic margin for exact profile evidence", () => {
+    const result = countTextTokens("exact profile fixture", o200k);
+    expect(result.status).toBe("available");
+    if (result.status === "available") {
+      const heuristicMargin = 0;
+      const countingSlack = 2;
+      expect(result.count.method).toBe("exact");
+      expect(result.count.uncertaintyTokens).toBeUndefined();
+      expect(
+        result.count.tokens + countingSlack + heuristicMargin
+      ).toBe(result.count.tokens + countingSlack);
+    }
+  });
+
+  it("rejects unsafe input and detects safe-integer overflow", () => {
+    expect(codePointBoundToTokenUpperBound(-1, o200k)).toMatchObject({
+      status: "error",
+      error: { code: "INVALID_TOKEN_BOUND" },
+    });
+    expect(
+      codePointBoundToTokenUpperBound(Number.MAX_SAFE_INTEGER, o200k)
+    ).toMatchObject({
+      status: "error",
+      error: { code: "TOKEN_BOUND_OVERFLOW" },
+    });
+    expect(
+      retokenizationUpperBound(Number.MAX_SAFE_INTEGER, cl100k, o200k)
+    ).toMatchObject({
+      status: "error",
+      error: { code: "TOKEN_BOUND_OVERFLOW" },
+    });
+  });
+
+  it("never trusts caller-modified certificate constants", () => {
+    const forged = {
+      ...cl100k,
+      maximumDecodedBytesPerToken: 1,
+    };
+    const canonical = retokenizationUpperBound(1, cl100k, o200k);
+    const supplied = retokenizationUpperBound(1, forged, o200k);
+
+    expect(canonical.status).toBe("available");
+    expect(supplied).toEqual(canonical);
+    if (supplied.status === "available") {
+      expect(supplied.upperBound.tokens).toBe(384);
+    }
+  });
+
+  it("reports runtime-forged profile identifiers as unavailable", () => {
+    const forged = {
+      ...o200k,
+      id: "unsupported_profile",
+    } as unknown as TokenProfile;
+
+    expect(countTextTokens("text", forged)).toMatchObject({
+      status: "unavailable",
+    });
+    expect(retokenizationUpperBound(10, forged, o200k)).toMatchObject({
+      status: "unavailable",
+    });
+    expect(codePointBoundToTokenUpperBound(10, forged)).toMatchObject({
+      status: "unavailable",
+    });
+  });
+});

--- a/src/llm/tokenization/types.ts
+++ b/src/llm/tokenization/types.ts
@@ -1,0 +1,57 @@
+import type {
+  ApiProviderId,
+  PreparedPromptTokenCount,
+  PreparedPromptTokenUpperBound,
+} from "../types";
+
+export type TokenProfileId = "cl100k_base" | "o200k_base";
+
+export interface TokenProfile {
+  id: TokenProfileId;
+  tokenizerId: `js-tiktoken:${TokenProfileId}`;
+  revision: string;
+  encoding: TokenProfileId;
+  rankHash: string;
+  ordinaryTextOnly: true;
+  byteComplete: true;
+  maximumDecodedBytesPerToken: number;
+}
+
+export const TOKEN_PROFILE_MAPPING_REVISION = "model-token-profile-map-v1";
+
+export type TokenProfileResolution =
+  | {
+      status: "available";
+      provider: ApiProviderId;
+      model: string;
+      mappingRevision: typeof TOKEN_PROFILE_MAPPING_REVISION;
+      profile: TokenProfile;
+    }
+  | {
+      status: "unavailable";
+      provider: ApiProviderId;
+      model: string;
+      mappingRevision: typeof TOKEN_PROFILE_MAPPING_REVISION;
+      reason: string;
+    };
+
+export type TokenCountResult =
+  | { status: "available"; count: PreparedPromptTokenCount }
+  | { status: "unavailable"; reason: string };
+
+export type TokenBoundResult =
+  | {
+      status: "available";
+      upperBound: PreparedPromptTokenUpperBound;
+    }
+  | {
+      status: "unavailable";
+      reason: string;
+    }
+  | {
+      status: "error";
+      error: {
+        code: "INVALID_TOKEN_BOUND" | "TOKEN_BOUND_OVERFLOW";
+        message: string;
+      };
+    };

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -99,6 +99,18 @@ export interface StructuredOutputSettings {
   enabled?: boolean;
 
   /**
+   * How the schema is delivered to the model.
+   *
+   * `native` uses the provider's structured-output facility and remains the
+   * compatibility default. `prompt` injects a deterministic instruction into
+   * the prepared messages and provides instruction-only (not provider-enforced)
+   * guidance.
+   *
+   * @default "native"
+   */
+  delivery?: "native" | "prompt";
+
+  /**
    * Name for the schema (required by most providers).
    * Should be a descriptive identifier like 'person_info' or 'weather_data'.
    */
@@ -163,12 +175,47 @@ export interface StructuredOutputSupport {
   source: CapabilitySource;
 }
 
+/** Availability of a token-counting capability. */
+export type TokenCountingAvailability =
+  | "exact"
+  | "model"
+  | "heuristic"
+  | "unavailable"
+  | "runtime";
+
+/** Provenance for a known context-window value. */
+export interface ContextWindowCapability {
+  tokens: number;
+  source: "registry" | "detected" | "provider" | "fallback";
+}
+
 /**
  * Capability summary for a provider/model pair.
  */
 export interface ModelCapabilities {
   /** Structured-output support status */
   structuredOutput: StructuredOutputSupport;
+  /** Known context window and provenance, when available. */
+  contextWindow?: ContextWindowCapability;
+  /** Synchronous content-counting availability. */
+  contentTokenCounting?: TokenCountingAvailability;
+  /** Fully prepared message-counting availability. */
+  preparedMessageTokenCounting?: TokenCountingAvailability;
+  /** Tokenizer/profile identity when statically known. */
+  tokenProfileId?: string;
+  /** Revision of the model-to-profile mapping table. */
+  tokenProfileMappingRevision?: string;
+  /** Whether prompt usage is normally reported (not a per-response guarantee). */
+  reportsPromptUsage?: boolean;
+  /** Whether completion usage is normally reported (not a per-response guarantee). */
+  reportsCompletionUsage?: boolean;
+  /** Whether provider evidence distinguishes context from output limits. */
+  distinguishesLimitCause?: boolean;
+  /** Available structured-output delivery paths. */
+  structuredOutputDelivery?: {
+    native: StructuredOutputSupport;
+    prompt: "instruction_only";
+  };
 }
 
 /**
@@ -547,6 +594,212 @@ export interface ModelCapabilitiesResult {
   modelInfo: ModelInfo;
   /** Structured-output support status for this provider/model pair */
   structuredOutput: StructuredOutputSupport;
+  /** Full additive capability summary. */
+  capabilities: ModelCapabilities;
+}
+
+// ============================================================================
+// Prepared-call and token-accounting types
+// ============================================================================
+
+/** Dispatch mode fixed when a request is prepared. */
+export type PreparedCallMode = "complete" | "stream";
+
+/** JSON-safe value used by stable, library-owned inspection views. */
+export type PreparedRequestValue =
+  | null
+  | boolean
+  | number
+  | string
+  | PreparedRequestValue[]
+  | { [key: string]: PreparedRequestValue };
+
+/** A provider-facing message after deterministic role/content conversion. */
+export interface PreparedProviderMessageView {
+  role: string;
+  content: PreparedRequestValue;
+}
+
+/** Structured-output delivery visible in a prepared request. */
+export interface PreparedStructuredOutputView {
+  delivery: "native" | "prompt";
+  enforcement: "provider" | "json_only" | "instruction_only";
+  name?: string;
+  schema?: PreparedRequestValue;
+  /** Version of the deterministic prompt instruction, when prompt-delivered. */
+  promptRevision?: string;
+}
+
+/**
+ * Stable semantic view of a provider request.
+ *
+ * This deliberately contains library-owned JSON values rather than SDK
+ * request instances or transport/authentication state.
+ */
+export interface PreparedProviderRequestView {
+  operation: string;
+  mode: PreparedCallMode;
+  messages: PreparedProviderMessageView[];
+  systemInstruction?: PreparedRequestValue;
+  structuredOutput?: PreparedStructuredOutputView;
+  reasoning?: PreparedRequestValue;
+  settings: { [key: string]: PreparedRequestValue };
+  extensions?: { [key: string]: PreparedRequestValue };
+}
+
+/** Evidence-bearing point count for a fully prepared prompt. */
+export interface PreparedPromptTokenCount {
+  tokens: number;
+  method: "exact" | "model" | "heuristic";
+  tokenizerId?: string;
+  tokenProfileRevision?: string;
+  uncertaintyTokens?: number;
+}
+
+/** Reference to a revision-pinned proof used for a structural bound. */
+export interface TokenBoundCertificateRef {
+  id: string;
+  derivation: string;
+  provenance: string;
+  sourceProfileRevision?: string;
+  targetProfileRevision: string;
+}
+
+/** Certified structural upper bound for a fully prepared prompt. */
+export interface PreparedPromptTokenUpperBound {
+  tokens: number;
+  certificate: TokenBoundCertificateRef;
+}
+
+/** Prepared accounting is available only when at least one evidence form exists. */
+export type PreparedPromptAccounting =
+  | {
+      status: "available";
+      count: PreparedPromptTokenCount;
+      upperBound?: PreparedPromptTokenUpperBound;
+    }
+  | {
+      status: "available";
+      count?: undefined;
+      upperBound: PreparedPromptTokenUpperBound;
+    }
+  | { status: "unavailable" };
+
+/** Provenance for the output-token field that dispatch will enforce. */
+export type OutputTokenLimitSource =
+  | "request"
+  | "preset"
+  | "model_default"
+  | "library_default"
+  | "provider_default";
+
+/** Verified model/provider cap that changed an output-token request. */
+export interface OutputTokenLimitClamp {
+  tokens: number;
+  source: "model_hard_limit" | "provider_hard_limit";
+}
+
+/** Effective provider output-token setting and its accounting semantics. */
+export interface EffectiveOutputTokenLimit {
+  tokens: number;
+  source: OutputTokenLimitSource;
+  requestedTokens?: number;
+  clamp?: OutputTokenLimitClamp;
+  counts:
+    | "visible_output"
+    | "visible_and_reasoning"
+    | "provider_defined"
+    | "unknown";
+}
+
+/** Revisions and observable state to which a prepared call is bound. */
+export interface PreparedRequestBindings {
+  adapterRevision: string;
+  requestShapeRevision: string;
+  tokenProfileRevision?: string;
+  providerEndpointRevision?: string;
+  serverStateFingerprint?: string;
+  chatTemplateFingerprint?: string;
+}
+
+/** Read-only inspection returned for a prepared call. */
+export interface PreparedRequestInspection {
+  provider: ApiProviderId;
+  model: string;
+  mode: PreparedCallMode;
+  request: PreparedProviderRequestView;
+  promptAccounting: PreparedPromptAccounting;
+  outputTokenLimit?: EffectiveOutputTokenLimit;
+  bindings: PreparedRequestBindings;
+}
+
+declare const preparedCallBrand: unique symbol;
+
+/** Opaque service-owned handle for an immutable prepared call. */
+export interface PreparedCall<TMode extends PreparedCallMode> {
+  readonly mode: TMode;
+  readonly [preparedCallBrand]: TMode;
+  /** Prepared calls intentionally have no replayable serialized form. */
+  toJSON(): never;
+}
+
+/** Prepared handle accepted by sendPrepared(). */
+export type PreparedCompleteCall = PreparedCall<"complete">;
+
+/** Prepared handle accepted by streamPrepared(). */
+export type PreparedStreamCall = PreparedCall<"stream">;
+
+/** Result of preparing a mode-bound call. */
+export type PrepareMessageResult<TMode extends PreparedCallMode> =
+  | PreparedCall<TMode>
+  | LLMFailureResponse;
+
+/** Normalized provider termination with the original reason retained. */
+export interface LLMTermination {
+  rawReason: string | null;
+  kind:
+    | "stop"
+    | "limit"
+    | "content_filter"
+    | "tool_call"
+    | "other"
+    | "unknown";
+  limit?: "output" | "context" | "unknown";
+}
+
+/** Library-owned ordered content part retained before response flattening. */
+export interface LLMRawContentPart {
+  type: string;
+  text?: string;
+  value?: PreparedRequestValue;
+  reasoning?: boolean;
+}
+
+/** Evidence for a token count over pre-normalization answer content. */
+export interface LLMRawAnswerAccounting {
+  tokens: number;
+  method: "exact" | "model" | "heuristic";
+  source: "provider" | "library";
+  tokenizerId?: string;
+  tokenProfileRevision?: string;
+  reasoning:
+    | "included_native"
+    | "included_extracted"
+    | "excluded"
+    | "unknown";
+}
+
+/** Provenance for an individual normalized usage field. */
+export interface LLMUsageFieldEvidence {
+  source: "provider" | "derived" | "heuristic";
+  providerField?: string;
+}
+
+/** Field-level provenance for normalized usage values. */
+export interface LLMUsageEvidence {
+  prompt_tokens?: LLMUsageFieldEvidence;
+  completion_tokens?: LLMUsageFieldEvidence;
+  total_tokens?: LLMUsageFieldEvidence;
 }
 
 /**
@@ -556,6 +809,14 @@ export interface LLMChoice {
   message: LLMMessage;
   finish_reason: string | null;
   index?: number;
+  /** Exact text received before reasoning/tag/whitespace normalization. */
+  rawContent?: string;
+  /** Ordered library-owned parts retained when flattening would lose boundaries. */
+  rawContentParts?: LLMRawContentPart[];
+  /** Token evidence over rawContent, when a suitable profile is available. */
+  rawAnswerAccounting?: LLMRawAnswerAccounting;
+  /** Raw and normalized termination evidence. */
+  termination?: LLMTermination;
   /** Reasoning/thinking content (if available and not excluded) */
   reasoning?: string;
   /** Provider-specific reasoning details that need to be preserved */
@@ -593,6 +854,8 @@ export interface LLMResponse {
   created: number;
   choices: LLMChoice[];
   usage?: LLMUsage;
+  /** Provenance for each normalized usage field. */
+  usageEvidence?: LLMUsageEvidence;
   object: 'chat.completion';
 }
 
@@ -653,7 +916,11 @@ export type LLMRequestCapabilityValidationResult =
   | LLMRequestCapabilityValidationFailure;
 
 /**
- * Streaming event emitted by LLMService.streamMessage().
+ * Legacy adapter-facing stream event.
+ *
+ * Existing custom adapters may continue constructing this shape without an
+ * attempt ID. LLMService stamps every public event and returns
+ * LLMServiceStreamEvent.
  */
 export type LLMStreamEvent =
   | {
@@ -685,6 +952,11 @@ export type LLMStreamEvent =
       type: "error";
       error: LLMFailureResponse;
     };
+
+/** Stream event emitted by LLMService with a stable physical attempt ID. */
+export type LLMServiceStreamEvent = LLMStreamEvent & {
+  attemptId: string;
+};
 
 /**
  * Information about a supported LLM provider
@@ -743,6 +1015,16 @@ export interface ModelInfo {
   supportsSystemMessage?: boolean;
   description?: string;
   maxTokens?: number;
+  /** Verified hard output-token cap; distinct from the default maxTokens setting. */
+  hardOutputTokenLimit?: {
+    tokens: number;
+    source: "model_hard_limit" | "provider_hard_limit";
+    counts:
+      | "visible_output"
+      | "visible_and_reasoning"
+      | "provider_defined"
+      | "unknown";
+  };
   supportsImages?: boolean;
   supportsPromptCache: boolean;
   /** @deprecated Use reasoning instead */

--- a/src/prompting/.summary_long.md
+++ b/src/prompting/.summary_long.md
@@ -3,6 +3,11 @@
 ## Overview
 The prompting directory provides a comprehensive suite of utilities for advanced prompt engineering in LLM applications. It represents a significant refactoring from the original utils directory, with a clearer separation of concerns and more descriptive naming. The module is organized around the prompt engineering lifecycle: template rendering, content preparation, and response parsing.
 
+`content.ts` retains the numeric `countTokens()` contract while routing verified
+cl100k/o200k models through the profile registry. The evidence-bearing APIs and
+certified bounds live in `src/llm/tokenization/`; heuristic fallback remains
+visible only through the legacy wrapper or explicit estimator.
+
 ## Key Components
 
 ### index.ts

--- a/src/prompting/.summary_short.md
+++ b/src/prompting/.summary_short.md
@@ -7,7 +7,7 @@ Purpose: Contains sophisticated utilities for prompt engineering, including temp
 - `index.ts`: Central export point for all prompting utilities, providing a clean API for template rendering, content preparation, and response parsing.
 - `template.ts`: Implements a sophisticated micro-templating engine with variable substitution, conditional ternary logic, and intelligent newline handling.
 - `template.test.ts`: Comprehensive test suite for the template engine, validating variable substitution, ternary expressions, nested templates, and newline trimming behavior.
-- `content.ts`: Provides content preparation utilities including token counting using OpenAI's tiktoken, smart content previews, and random variable extraction for few-shot learning.
+- `content.ts`: Provides the compatible numeric `countTokens` wrapper over verified encoding profiles (with legacy heuristic fallback), smart previews, and random-variable extraction.
 - `content.test.ts`: Tests content preparation utilities including token counting accuracy across models, smart preview truncation logic, and random variable extraction.
 - `parser.ts`: Provides utilities for parsing structured content from LLM responses using XML-style tags, role tags for message creation, extracting thinking blocks from responses, extracting content between arbitrary open/close markers (extractMarkerDelimitedContent, used for local-model reasoning traces), and parsing template metadata from <META> blocks.
 - `parser.test.ts`: Tests structured content parsing functionality, including tag extraction, handling of missing tags, and multiline content parsing.

--- a/src/prompting/content.ts
+++ b/src/prompting/content.ts
@@ -6,7 +6,17 @@
  * help prepare the "ingredients" that will be used in prompt construction.
  */
 
-import { Tiktoken, encodingForModel, TiktokenModel } from 'js-tiktoken';
+import {
+  Tiktoken,
+  encodingForModel,
+  getEncodingNameForModel,
+  TiktokenModel,
+} from 'js-tiktoken';
+import {
+  countTextTokens,
+  getTokenProfileById,
+  type TokenProfileId,
+} from "../llm/tokenization";
 
 const tokenizerCache = new Map<TiktokenModel, Tiktoken>();
 
@@ -29,6 +39,16 @@ function getTokenizer(model: TiktokenModel): Tiktoken {
 export function countTokens(text: string, model: TiktokenModel = 'gpt-4'): number {
   if (!text) return 0;
   try {
+    const encoding = getEncodingNameForModel(model);
+    if (encoding === "cl100k_base" || encoding === "o200k_base") {
+      const profile = getTokenProfileById(encoding as TokenProfileId);
+      if (profile) {
+        const result = countTextTokens(text, profile);
+        if (result.status === "available") {
+          return result.count.tokens;
+        }
+      }
+    }
     const tokenizer = getTokenizer(model);
     return tokenizer.encode(text).length;
   } catch (error) {

--- a/src/prompting/index.ts
+++ b/src/prompting/index.ts
@@ -8,10 +8,26 @@
  */
 
 // Template rendering
-export { renderTemplate } from './template';
+export { renderTemplate } from "./template";
 
 // Content preparation utilities
-export { countTokens, getSmartPreview, extractRandomVariables } from './content';
+export { countTokens, getSmartPreview, extractRandomVariables } from "./content";
+export {
+  codePointBoundToTokenUpperBound,
+  countTextTokens,
+  estimateTextTokens,
+  getTokenProfileById,
+  resolveTokenProfile,
+  retokenizationUpperBound,
+  TOKEN_PROFILE_MAPPING_REVISION
+} from "../llm/tokenization";
+export type {
+  TokenBoundResult,
+  TokenCountResult,
+  TokenProfile,
+  TokenProfileId,
+  TokenProfileResolution
+} from "../llm/tokenization";
 
 // Response parsing
 export {
@@ -20,7 +36,7 @@ export {
   extractMarkerDelimitedContent,
   parseRoleTags,
   parseTemplateWithMetadata
-} from './parser';
+} from "./parser";
 
 // Types
-export type { TemplateMetadata } from './parser';
+export type { TemplateMetadata } from "./parser";

--- a/src/shared/adapters/usageUtils.test.ts
+++ b/src/shared/adapters/usageUtils.test.ts
@@ -1,0 +1,118 @@
+import {
+  mergeUsageRecords,
+  normalizeTermination,
+  normalizeUsage,
+} from "./usageUtils";
+
+const aliases = {
+  prompt: ["promptTokens", "prompt_tokens"],
+  completion: ["completionTokens", "completion_tokens"],
+  total: ["totalTokens", "total_tokens"],
+} as const;
+
+describe("usageUtils", () => {
+  it("preserves absence instead of fabricating zero", () => {
+    expect(normalizeUsage(undefined, aliases)).toEqual({});
+    expect(normalizeUsage({}, aliases)).toEqual({});
+    expect(normalizeUsage({ unrelated: 2 }, aliases)).toEqual({});
+  });
+
+  it("preserves explicit zero and the selected provider alias", () => {
+    expect(
+      normalizeUsage(
+        {
+          promptTokens: 0,
+          prompt_tokens: 9,
+          completion_tokens: 0,
+          total_tokens: 0,
+        },
+        aliases
+      )
+    ).toEqual({
+      usage: {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+      },
+      usageEvidence: {
+        prompt_tokens: {
+          source: "provider",
+          providerField: "promptTokens",
+        },
+        completion_tokens: {
+          source: "provider",
+          providerField: "completion_tokens",
+        },
+        total_tokens: {
+          source: "provider",
+          providerField: "total_tokens",
+        },
+      },
+    });
+  });
+
+  it("derives total only when both operands are present", () => {
+    expect(normalizeUsage({ promptTokens: 4 }, aliases).usage).toEqual({
+      prompt_tokens: 4,
+    });
+    expect(
+      normalizeUsage(
+        { promptTokens: 4, completionTokens: 6 },
+        aliases
+      )
+    ).toEqual({
+      usage: {
+        prompt_tokens: 4,
+        completion_tokens: 6,
+        total_tokens: 10,
+      },
+      usageEvidence: {
+        prompt_tokens: {
+          source: "provider",
+          providerField: "promptTokens",
+        },
+        completion_tokens: {
+          source: "provider",
+          providerField: "completionTokens",
+        },
+        total_tokens: { source: "derived" },
+      },
+    });
+  });
+
+  it("merges streaming fragments without zero-filling", () => {
+    expect(
+      mergeUsageRecords(
+        { input_tokens: 5 },
+        { output_tokens: 0 }
+      )
+    ).toEqual({ input_tokens: 5, output_tokens: 0 });
+    expect(
+      mergeUsageRecords(
+        { input_tokens: 5, output_tokens: 2 },
+        { input_tokens: undefined, output_tokens: Number.NaN }
+      )
+    ).toEqual({ input_tokens: 5, output_tokens: 2 });
+  });
+
+  it("retains raw termination and keeps generic limits ambiguous", () => {
+    expect(normalizeTermination("length")).toEqual({
+      rawReason: "length",
+      kind: "limit",
+      limit: "unknown",
+    });
+    expect(normalizeTermination("max_tokens", "output")).toEqual({
+      rawReason: "max_tokens",
+      kind: "limit",
+      limit: "output",
+    });
+    expect(normalizeTermination(undefined)).toEqual({
+      rawReason: null,
+      kind: "unknown",
+    });
+    expect(normalizeTermination("tool_use")).toEqual({
+      rawReason: "tool_use",
+      kind: "tool_call",
+    });
+  });
+});

--- a/src/shared/adapters/usageUtils.ts
+++ b/src/shared/adapters/usageUtils.ts
@@ -1,0 +1,154 @@
+import type {
+  LLMTermination,
+  LLMUsage,
+  LLMUsageEvidence,
+  LLMUsageFieldEvidence,
+} from "../../llm/types";
+
+export interface UsageAliases {
+  prompt: readonly string[];
+  completion: readonly string[];
+  total: readonly string[];
+}
+
+export interface NormalizedUsage {
+  usage?: LLMUsage;
+  usageEvidence?: LLMUsageEvidence;
+}
+
+function readFiniteNumber(
+  source: Record<string, unknown>,
+  aliases: readonly string[]
+): { value: number; field: string } | undefined {
+  for (const field of aliases) {
+    const value = source[field];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return { value, field };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Maps provider usage without converting absence to zero.
+ *
+ * The first present finite alias wins, including an explicit zero. Total is
+ * derived only when both prompt and completion values exist.
+ */
+export function normalizeUsage(
+  source: Record<string, unknown> | null | undefined,
+  aliases: UsageAliases
+): NormalizedUsage {
+  if (!source) {
+    return {};
+  }
+
+  const prompt = readFiniteNumber(source, aliases.prompt);
+  const completion = readFiniteNumber(source, aliases.completion);
+  const providerTotal = readFiniteNumber(source, aliases.total);
+  const derivedTotal =
+    providerTotal === undefined && prompt !== undefined && completion !== undefined
+      ? prompt.value + completion.value
+      : undefined;
+
+  const usage: LLMUsage = {
+    ...(prompt && { prompt_tokens: prompt.value }),
+    ...(completion && { completion_tokens: completion.value }),
+    ...(providerTotal && { total_tokens: providerTotal.value }),
+    ...(derivedTotal !== undefined && { total_tokens: derivedTotal }),
+  };
+
+  if (Object.keys(usage).length === 0) {
+    return {};
+  }
+
+  const providerEvidence = (
+    field: string
+  ): LLMUsageFieldEvidence => ({
+    source: "provider",
+    providerField: field,
+  });
+  const usageEvidence: LLMUsageEvidence = {
+    ...(prompt && { prompt_tokens: providerEvidence(prompt.field) }),
+    ...(completion && {
+      completion_tokens: providerEvidence(completion.field),
+    }),
+    ...(providerTotal && {
+      total_tokens: providerEvidence(providerTotal.field),
+    }),
+    ...(derivedTotal !== undefined && {
+      total_tokens: { source: "derived" as const },
+    }),
+  };
+
+  return { usage, usageEvidence };
+}
+
+/** Presence-aware merge for usage fragments received during streaming. */
+export function mergeUsageRecords(
+  current: Record<string, unknown> | undefined,
+  update: Record<string, unknown> | null | undefined
+): Record<string, unknown> | undefined {
+  if (!update) {
+    return current;
+  }
+  return {
+    ...(current ?? {}),
+    ...Object.fromEntries(
+      Object.entries(update).filter(
+        ([, value]) =>
+          value !== undefined &&
+          (typeof value !== "number" || Number.isFinite(value))
+      )
+    ),
+  };
+}
+
+/** Normalizes a raw provider finish/stop reason without inventing a cause. */
+export function normalizeTermination(
+  rawReason: string | null | undefined,
+  limit?: "output" | "context" | "unknown"
+): LLMTermination {
+  if (rawReason === null || rawReason === undefined || rawReason === "") {
+    return { rawReason: rawReason ?? null, kind: "unknown" };
+  }
+
+  const normalized = rawReason.toLowerCase();
+  if (
+    normalized === "stop" ||
+    normalized === "end_turn" ||
+    normalized === "stop_sequence"
+  ) {
+    return { rawReason, kind: "stop" };
+  }
+  if (
+    normalized === "length" ||
+    normalized === "max_tokens" ||
+    normalized === "max_tokens_reached" ||
+    normalized === "max_output_tokens"
+  ) {
+    return { rawReason, kind: "limit", limit: limit ?? "unknown" };
+  }
+  if (
+    normalized === "content_filter" ||
+    normalized === "safety" ||
+    normalized === "blocked" ||
+    normalized === "refusal" ||
+    normalized === "recitation" ||
+    normalized === "prohibited_content" ||
+    normalized === "spii" ||
+    normalized === "blocklist"
+  ) {
+    return { rawReason, kind: "content_filter" };
+  }
+  if (
+    normalized === "tool_calls" ||
+    normalized === "tool_call" ||
+    normalized === "tool_use" ||
+    normalized === "function_call"
+  ) {
+    return { rawReason, kind: "tool_call" };
+  }
+
+  return { rawReason, kind: "other" };
+}


### PR DESCRIPTION
## Summary

- add credential-free, mode-bound prepared LLM calls with immutable semantic inspection and identical redispatch
- preserve truthful raw content, usage provenance, token accounting, termination evidence, and cancellation partials across every built-in adapter
- add hash-verified token profiles, certified structural bounds without consumer margins, and exact active-template llama.cpp counting with stale-state rejection
- harden streaming to one terminal event per attempt and publish the complete v0.15.0 API and documentation

## Verification

- npm test -- --runInBand --silent: 43 suites, 1,019 tests passed
- npm run build
- npm audit --omit=dev --audit-level=high: 0 vulnerabilities
- npm pack --dry-run: 105 files, no tokenizer asset expansion
- npm run test:packed-api
- live llama.cpp prepared-counting E2E against the running Gemma server