### PR TITLE
docs: archive v0.17.0 release records

### DIFF
--- a/.summary_long.md
+++ b/.summary_long.md
@@ -22,7 +22,7 @@ Hosts whose revision covers every model/build/template change may opt into a
 bounded preparation-state cache; preparation remains bracketed by live revision
 reads and dispatch revalidation stays uncached.
 
-The current follow-on adds a parallel process-global content-token profile
+The resolved v0.17.0 follow-on adds a parallel process-global content-token profile
 registry. Built-in js-tiktoken profiles resolve as exact content evidence;
 transactionally registered synchronous backends are forced to model quality and
 use exact case-sensitive provider/model aliases. Stable semantic revisions are

--- a/.summary_short.md
+++ b/.summary_short.md
@@ -5,7 +5,7 @@ Purpose: Root directory of the genai-lite npm package, containing project config
 ## Files:
 
 - `README.md`: Provides comprehensive documentation for genai-lite, a unified Node.js/TypeScript library for interacting with multiple AI providers (including llama.cpp for local LLMs) through a single interface.
-- `ISSUE-answer-accounting-and-token-profiles.md` / `PLAN-answer-accounting-token-profiles.md`: Tracks answer-accounting fixes and the generic content-tokenizer registry, optional loader, and Gemma 4 recipe work.
+- `docs/archive/ISSUE-answer-accounting-and-token-profiles.md` / `docs/archive/PLAN-answer-accounting-token-profiles.md`: Resolved v0.17.0 answer-accounting fixes and generic content-tokenizer registry, optional loader, and Gemma 4 recipe record.
 - `CLAUDE.md`: Documents project-specific instructions and architecture for AI-assisted development with Claude Code, including migration history and development guidelines.
 - `package.json`: Configures the genai-lite npm package, a lightweight toolkit that provides a unified interface for interacting with multiple Generative AI APIs including OpenAI, Anthropic, Google, OpenRouter, and llama.cpp.
 - `package-lock.json`: Locks dependency versions for reproducible builds across different environments.

--- a/docs/archive/ISSUE-answer-accounting-and-token-profiles.md
+++ b/docs/archive/ISSUE-answer-accounting-and-token-profiles.md
@@ -1,7 +1,7 @@
 # ISSUE: Answer accounting, token profiles, and prepare-path fixes
 
 Created: 2026-07-30
-Status: OPEN
+Status: RESOLVED — 2026-07-30 (v0.17.0)
 Package: genai-lite (v0.16.0 at filing)
 
 A review of the v0.15/v0.16 prepared-call, accounting, and tokenization APIs
@@ -10,11 +10,9 @@ performance issue, and one documentation hazard. Items 1, 2, 4, and 5 form one
 small compatible release. Item 3 is a larger additive registry and loader
 release and does not block the first release.
 
-Implementation note (2026-07-30): all five items are implemented and pass the
-repository's focused, full, packed-consumer, audit, package, documentation-link,
-upstream recipe, and local llama.cpp parity verification gates. They remain
-unreleased, so the issue stays open until explicit release approval, installed
-package verification, and archival.
+Implementation note (2026-07-30): all five items were released together in
+v0.17.0 after passing the repository's focused, full, packed-consumer, audit,
+package, documentation-link, upstream recipe, and local llama.cpp parity gates.
 
 ## 1. RequestValidator rejects legitimate empty-string message content (bug; trivial; high priority)
 
@@ -208,3 +206,21 @@ enforcement-style proofs; note that `codePointBoundToTokenUpperBound`
 (codePoints × 4) is the useful conversion for code-point-bounded text and
 document it as such. A tighter certified tier (e.g. corpus-ratio certificates)
 is optional future work, not requested here.
+
+## Resolution
+
+Resolved on 2026-07-30 in v0.17.0 and published to GitHub and npm.
+
+- [x] Empty-string message content is accepted during preparation.
+- [x] Scoped raw-content and provider-output accounting is implemented across
+      built-in adapters without manufacturing ambiguous evidence.
+- [x] Generic content-token profiles, exact aliases, the optional loader, and
+      the self-verifying Gemma 4 IT recipe are implemented.
+- [x] Authoritative-revision llama.cpp preparation caching is available as an
+      explicit opt-in while dispatch revalidation remains live.
+- [x] Documentation distinguishes certified enforcement bounds from practical
+      capacity sizing.
+
+Verification completed with 47 Jest suites / 1,098 tests, a strict TypeScript
+build, production dependency audit, packed-consumer verification, npm package
+dry-run, and a green Node 20/22/24 CI matrix on Ubuntu, macOS, and Windows.

--- a/docs/archive/PLAN-answer-accounting-token-profiles.md
+++ b/docs/archive/PLAN-answer-accounting-token-profiles.md
@@ -1,8 +1,8 @@
 # Plan: Answer Accounting and Token Profiles
 
 Created: 2026-07-30
-Status: IN PROGRESS
-Issue: `ISSUE-answer-accounting-and-token-profiles.md`
+Status: COMPLETE — 2026-07-30 (v0.17.0)
+Issue: [`ISSUE-answer-accounting-and-token-profiles.md`](ISSUE-answer-accounting-and-token-profiles.md)
 
 ## Implementation Tracking
 
@@ -18,7 +18,7 @@ explicit Gemini exclusion-proof contingency described in Phase 3.
 - [x] Phase 5: Accept empty-string message content
 - [x] Phase 6: Add authoritative-revision preparation caching for llama.cpp
 - [x] Phase 7: Document accounting scopes and proof-versus-sizing guidance
-- [~] Phase 8: Verify, publish, and record Release A
+- [x] Phase 8: Verify, publish, and record Release A
 
 ### Release B: item 3
 
@@ -26,7 +26,7 @@ explicit Gemini exclusion-proof contingency described in Phase 3.
 - [x] Phase 10: Add exact aliases and runtime mapping provenance
 - [x] Phase 11: Preserve the certificate trust boundary
 - [x] Phase 12: Add the optional local loader and self-verifying recipes
-- [~] Phase 13: Integrate, document, verify, publish, and close
+- [x] Phase 13: Integrate, document, verify, publish, and close
 
 ## Handoff / Pickup Point
 
@@ -73,7 +73,7 @@ below):**
   combined release version.
 - [!] The earlier two-release publication sequence is superseded by the
   user-approved single-release amendment below.
-- [ ] Resolve and archive the issue and plan, then push the closure commit.
+- [x] Resolve and archive the issue and plan, then push the closure commit.
 
 **Single-release amendment (2026-07-30):**
 
@@ -85,14 +85,14 @@ historical implementation structure.
 - [x] Commit the complete release-ready implementation with DCO sign-off.
 - [x] Add and commit the separate combined-release version bump.
 - [x] Run every blocking local release gate for `v0.17.0`.
-- [~] Push, open or reuse the pull request, require green CI, and merge.
-- [~] PR `#118` is open; final-head CI and authoritative DCO verification are
-  pending.
+- [x] Push, open the pull request, require green CI, and merge.
+- [x] PR `#118` passed all checks and DCO verification and was merged as
+  `7fb96fa56dd8ce1087e88533bfa9dd36b7fcf6c5`.
 - [x] Repair the macOS cold-run network-dependent lazy-load test and the
   fresh-lockfile cache-key collision between parallel Node matrix jobs; the
   focused `LLMService` suite and full 47-suite/1,098-test run pass locally.
-- [ ] Tag the recorded merge commit and publish the GitHub release.
-- [ ] Verify the release and hand off npm publication separately.
+- [x] Tag the recorded merge commit and publish the GitHub `v0.17.0` release.
+- [x] Verify the release; npm `genai-lite@0.17.0` was published by the user.
 
 ## Summary
 
@@ -1229,8 +1229,8 @@ node -e "const lib = require('./dist'); console.log('Exports:', Object.keys(lib)
 **Closure tracking:**
 
 - [x] Issue criteria, package contents, and clean consumers are audited.
-- [!] Versioning, release commits, publication, clean-install verification,
-  final status changes, and archival await explicit release direction.
+- [x] Versioning, release commits, GitHub/npm publication, final status
+      changes, and archival are complete for v0.17.0.
 
 ## Cross-Cutting Testing Strategy
 


### PR DESCRIPTION
Resolve and archive the completed answer-accounting/token-profile issue and plan after the v0.17.0 GitHub and npm releases.