### PR TITLE
fix: make tokenizer loading bundle-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,5 +76,7 @@ jobs:
         run: npm ci
       - name: Build project
         run: npm run build
+      - name: Validate packed consumers and Rollup bundling
+        run: npm run test:packed-api
       - name: Validate package
         run: npm pack --dry-run

--- a/.summary_long.md
+++ b/.summary_long.md
@@ -39,6 +39,13 @@ The same patch release also treats the adapter-less mock provider as an
 intentional fallback, keeping unexpected missing-adapter warnings while
 demoting the healthy mock case to debug logging.
 
+The v0.17.2 follow-up makes built-in js-tiktoken ranks statically analyzable,
+lazy, defensively snapshotted, and fail-closed. The optional tokenizer loader
+accepts a statically imported peer namespace plus a validated caller-asserted
+version, while preserving installed-peer discovery. Loader and recipe subpaths
+use rank-free semantic identity, and packed Rollup verification exercises both
+rank families and the injected loader without dynamic-require configuration.
+
 ## Key Components
 ### README.md
 ## Overview
@@ -134,15 +141,15 @@ Documents the completed migration from Electron dependency to standalone Node.js
 
 ### package.json
 ## Purpose
-This package.json file configures genai-lite v0.17.1, a lightweight and portable toolkit designed to provide a unified interface for interacting with various Generative AI APIs. The package is published under the MIT license and maintained by Luigi Acerbi.
+This package.json file configures genai-lite v0.17.2, a lightweight and portable toolkit designed to provide a unified interface for interacting with various Generative AI APIs. The package is published under the MIT license and maintained by Luigi Acerbi.
 
 ## Key Settings
 - **Package name**: genai-lite
-- **Version**: 0.17.1
+- **Version**: 0.17.2
 - **Entry points**: 
   - Main: dist/index.js
   - Types: dist/index.d.ts
-  - Additional export for the prompting submodule
+  - Additional exports for prompting, tokenizer loader, and tokenizer recipes
 - **Module system**: CommonJS output exposed through both `require` and `import` export conditions
 - **TypeScript support**: Full type definitions included
 - **License**: MIT (permissive open source)
@@ -256,7 +263,7 @@ The root directory establishes a well-organized project structure:
 2. **Configuration Layer**: TypeScript, Jest, and npm configurations
 3. **Source Code**: All implementation in src/ directory
 4. **Build System**: TypeScript compilation to dist/
-5. **Testing Infrastructure**: Jest with TypeScript support (1,110 tests across 47 suites)
+5. **Testing Infrastructure**: Jest with TypeScript support (1,134 tests across 49 suites)
 6. **Provider Support**: Cloud (OpenAI, Anthropic, Google, Mistral, OpenRouter) + Local (llama.cpp)
 
 ## Internal Dependencies

--- a/.summary_short.md
+++ b/.summary_short.md
@@ -8,6 +8,7 @@ Purpose: Root directory of the genai-lite npm package, containing project config
 - `docs/archive/ISSUE-answer-accounting-and-token-profiles.md` / `docs/archive/PLAN-answer-accounting-token-profiles.md`: Resolved v0.17.0 answer-accounting fixes and generic content-tokenizer registry, optional loader, and Gemma 4 recipe record.
 - `docs/archive/ISSUE-content-registry-late-registration.md` / `docs/archive/PLAN-content-registry-late-registration.md`: Resolved v0.17.1 append-only late content-token registration lifecycle and implementation record.
 - `docs/archive/ISSUE-mock-provider-adapter-warning.md`: Resolved v0.17.1 intentional-fallback logging fix for the adapter-less mock provider.
+- `docs/archive/ISSUE-tokenizer-loader-injectable-peer.md` / `docs/archive/PLAN-tokenizer-loader-injectable-peer.md`: Resolved v0.17.2 tokenizer-loader injection, lazy rank loading, fail-closed profiles, and packed Rollup verification record.
 - `CLAUDE.md`: Documents project-specific instructions and architecture for AI-assisted development with Claude Code, including migration history and development guidelines.
 - `package.json`: Configures the genai-lite npm package, a lightweight toolkit that provides a unified interface for interacting with multiple Generative AI APIs including OpenAI, Anthropic, Google, OpenRouter, and llama.cpp.
 - `package-lock.json`: Locks dependency versions for reproducible builds across different environments.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ registerContentTokenProfileConfiguration({
 });
 ```
 
+Bundled ESM applications can statically import the optional peer and pass
+`tokenizersPeer: { module: tokenizersModule, packageVersion: "0.1.3" }` to
+`loadContentTokenizerProfile()`. This avoids loader-relative runtime resolution;
+the asserted version is validated and recorded in runtime provenance. See the
+guide below for the complete injection and bundler contract.
+
 Registration is process-global, synchronous, transactional, and append-only.
 Reads do not close the registry, but existing backend IDs and aliases cannot be
 replaced. Re-query a previously unavailable resolution or capability after a

--- a/docs/archive/ISSUE-tokenizer-loader-injectable-peer.md
+++ b/docs/archive/ISSUE-tokenizer-loader-injectable-peer.md
@@ -1,7 +1,7 @@
 # Tokenizer loader: injectable peer, lazy rank chain, guarded rank loading
 
 Filed: 2026-08-05, by palimpsest-engine
-Status: OPEN
+Status: RESOLVED — 2026-08-05 (v0.17.2)
 Package: genai-lite 0.17.1
 
 Consumer context: Electron GUI, electron-vite/Rollup — the genai-lite root bundled into an
@@ -56,6 +56,27 @@ estimate profile. Ask: route rank-loading failures into the same graceful path t
 the tokenization layer uses (an unavailable/estimate result), so a broken rank table is a
 capability loss, not an exception.
 
+## Acceptance criteria
+
+- [x] `loadContentTokenizerProfile()` accepts a statically imported, caller-injected
+  `@huggingface/tokenizers` module and validated asserted package version while
+  preserving the installed-peer path when injection is omitted.
+- [x] Importing the root, prompting, tokenizer-loader, or tokenizer-recipes entry
+  does not eagerly evaluate `js-tiktoken` or its rank modules; the three focused
+  subpaths also avoid `base64-js` (the root may load it independently through a
+  provider SDK).
+- [x] The cl100k and o200k rank modules are referenced through separate literal,
+  statically analyzable lazy loads and retain their pinned hashes and identities.
+- [x] Rank/runtime load, evaluation, validation, construction, and encode failures
+  degrade to unavailable evidence without escaping through model capability or
+  response-accounting APIs; legacy `countTokens()` retains its documented heuristic.
+- [x] Packed declarations typecheck both without the optional peer and with an
+  injected real peer namespace, without peer-owned types leaking into genai-lite
+  declarations.
+- [x] A packed Rollup ESM bundle runs without `dynamicRequireTargets` or loader
+  externalization, counts with both built-in rank families, and loads a warm
+  tokenizer recipe through the injected peer path.
+
 ## Reproduction sketch for 3+4
 
 ```bash
@@ -73,3 +94,21 @@ The consumer-side picture — externalized loader, staged loose closure
 palimpsest-engine's `docs/devlogs/2026-08-05-packaged-runtime-dependencies.md`. Asks 1 and 2
 would shrink that staged closure; asks 3 and 4 close a live crash we are otherwise fixing
 consumer-side with bundler configuration.
+
+## Resolution
+
+Resolved on 2026-08-05 for v0.17.2. The loader now accepts a validated,
+caller-injected tokenizer runtime/version while preserving installed-peer
+discovery. Built-in cl100k/o200k profiles use literal lazy rank loads,
+hash-verified defensive snapshots, and the js-tiktoken lite runtime; rank and
+runtime failures return unavailable evidence instead of escaping through
+capability or response-accounting APIs. The legacy prompting wrapper remains
+lazy and retains its documented numeric heuristic fallback.
+
+Verification passed 49 Jest suites (1,134 tests), the TypeScript build, packed
+peer-free and injected-peer declaration checks, real Rollup ESM execution for
+both built-in rank families and the injected real peer, package dry-run,
+compiled export smoke testing, and the production high-severity audit. The
+full-tree audit retains one known dev-only `brace-expansion` advisory through
+Jest/ts-jest. Independent doublecheck findings were fixed and rechecked. No
+commit, push, tag, release, publication, or real-provider E2E call was made.

--- a/docs/archive/PLAN-tokenizer-loader-injectable-peer.md
+++ b/docs/archive/PLAN-tokenizer-loader-injectable-peer.md
@@ -1,0 +1,625 @@
+# Plan: Tokenizer Loader Injectable Peer
+
+Created: 2026-08-05
+
+Status: COMPLETE — 2026-08-05 (v0.17.2)
+
+Approved: 2026-08-05
+
+Issue: [ISSUE-tokenizer-loader-injectable-peer.md](ISSUE-tokenizer-loader-injectable-peer.md)
+
+Target: genai-lite 0.17.2
+
+## Summary
+
+Make the optional content-tokenizer loader safe to inline into an Electron/Rollup
+ESM main bundle by accepting a caller-injected `@huggingface/tokenizers` runtime,
+while preserving the existing installed-peer path. Refactor built-in
+js-tiktoken profiles to use statically visible lazy rank loads and the lite
+runtime, then make every built-in load/count failure fail closed as unavailable
+evidence rather than escaping into model selection or response processing.
+
+The work also removes the second eager full-js-tiktoken evaluation path in the
+legacy prompting utility. It verifies the exact consumer scenario with a real
+packed Rollup build, but does not claim to remove js-tiktoken from npm's
+installed dependency graph or to provide universal bundle-size guarantees.
+
+## Complexity
+
+Moderate and cross-cutting. The implementation changes a public options type,
+optional-peer provenance, certificate-adjacent rank loading, the legacy token
+counting wrapper, package verification, CI, and user/developer documentation.
+
+## Confirmed Current State
+
+- `genai-lite/tokenizer-loader` imports semantic-revision computation through
+  `contentProfiles.ts`, which imports `profiles.ts`; `profiles.ts` eagerly
+  evaluates the full `js-tiktoken` entry and `base64-js`.
+- The root package has a second eager full-js-tiktoken value import in
+  `src/prompting/content.ts`, independent of the loader chain.
+- TypeScript's CommonJS output turns the loader's variable dynamic import into
+  a computed `require`, and the two rank specifiers are also hidden behind a
+  computed `require(moduleId)`.
+- A simulated `o200k_base` rank-load failure escapes from
+  `resolveTokenProfile("openai", "gpt-5.1")` today.
+- `LLMService` already has the desired downstream degradation shape:
+  unavailable content-profile resolution becomes
+  `contentTokenCounting: "unavailable"`, and unavailable answer counting is
+  omitted.
+- The archived v0.17.0 plan deliberately accepted loader externalization as a
+  bundler fallback. This plan supersedes only that limitation; it preserves the
+  recipe, provenance, model-quality, and certificate trust boundaries.
+- `js-tiktoken@1.0.21` remains an exact production dependency. Its installed
+  package is approximately 21.4 MiB, and this plan does not change that fact.
+
+## Public Contract Decision
+
+Keep all existing calls source-compatible and add one optional grouped field:
+
+```typescript
+interface ContentTokenizerRuntimeModule {
+  readonly Tokenizer: unknown;
+}
+
+interface ContentTokenizerPeer {
+  readonly module: ContentTokenizerRuntimeModule;
+  readonly packageVersion: string;
+}
+
+interface LoadContentTokenizerProfileOptions {
+  cacheDir: string;
+  allowDownload: boolean;
+  signal?: AbortSignal;
+  tokenizersPeer?: ContentTokenizerPeer;
+}
+```
+
+The exact structural spelling may be tightened during implementation only if a
+packed TypeScript consumer proves that `import * as tokenizersModule from
+"@huggingface/tokenizers"` remains directly assignable without a cast. Public
+declarations must not import peer-owned types.
+
+Contract rules:
+
+1. Omitting `tokenizersPeer` retains automatic installed-peer discovery,
+   nearest-manifest version validation, late missing-peer errors, and current
+   CJS/ESM behavior.
+2. Supplying `tokenizersPeer` bypasses `createRequire(__filename)`, installed
+   module resolution, and package-manifest discovery.
+3. `packageVersion` on an injected peer is explicitly caller-asserted because a
+   bundled namespace has no authoritative installed package path. It is still
+   validated against `^0.1.3` and stamped into runtime provenance.
+4. An unsupported or indeterminate asserted version produces
+   `TOKENIZER_PEER_VERSION_UNSUPPORTED`; a malformed module or failing module
+   constructor produces `TOKENIZER_LOAD_FAILED`.
+5. Abort and recipe/options validation continue to happen before peer,
+   filesystem, or network work.
+6. Exact-key validation remains strict for the top-level options and injected
+   peer object, including every combination of `signal` and `tokenizersPeer`.
+7. Existing `LoadContentTokenizerProfileOptions` exports from
+   `genai-lite/tokenizer-recipes` remain available. The new peer/module types
+   and the options type are also re-exported from
+   `genai-lite/tokenizer-loader` for discoverability.
+
+## Behavioral Invariants
+
+- Built-in profile IDs, rank hashes, tokenizer IDs, profile revisions, and
+  `TOKEN_PROFILE_MAPPING_REVISION` do not change if parity tests pass.
+- The exact/model/certificate trust distinction does not change. Injected
+  recipe backends remain model-quality and cannot enter certificate APIs.
+- Rank module load, module shape, hash, or byte-completeness failure makes the
+  corresponding built-in profile unavailable and is cached as such.
+- The js-tiktoken lite runtime is loaded only when a built-in tiktoken profile
+  is resolved or counted, not when the package root, prompting utilities, or
+  tokenizer-loader subpath is imported.
+- Immediately after structural validation, rank data is copied into a canonical
+  defensive snapshot: primitive fields are copied, `special_tokens` is cloned
+  and frozen, and the outer object is frozen. Hashing, property derivation, and
+  counting use that cached snapshot, never the rank module's shared mutable
+  export.
+- Tokenizer construction or encoding failure returns an unavailable
+  `TokenCountResult`; it does not throw across the public evidence boundary.
+- `resolveTokenProfile`, `resolveContentTokenProfile`, capability inspection,
+  certified bounds, and response accounting remain non-throwing when a built-in
+  tokenizer is unavailable.
+- Exact/certified APIs never silently manufacture a heuristic estimate.
+  `estimateTextTokens()` remains explicit, while legacy `countTokens()` keeps
+  its documented numeric heuristic fallback.
+- `cl100k_base` and `o200k_base` remain reserved built-in IDs even when their
+  artifacts or runtime are unavailable.
+- Ordinary synchronous counting performs no filesystem, network, dynamic
+  import, or peer-resolution work after a recipe backend is returned.
+
+## Scope
+
+- **In scope**:
+  - Injectable optional-peer module plus validated caller-asserted version.
+  - A rank-free semantic-revision dependency boundary for the loader subpath.
+  - Literal lazy cl100k/o200k rank loads and lazy `js-tiktoken/lite` use.
+  - Root-import runtime laziness for the legacy prompting `countTokens` module.
+  - Guarded rank/runtime/count failure paths and unconditional built-in ID
+    reservation.
+  - Unit, service, packed-consumer, and actual Rollup regression coverage.
+  - CI, public documentation, certificate-maintenance notes, summaries, issue
+    resolution, and v0.17.2 release metadata.
+- **Out of scope**:
+  - Removing, optionalizing, or changing the exact version of the
+    `js-tiktoken` production dependency.
+  - Guaranteeing that arbitrary bundlers omit all lazy modules or rank bytes
+    from their output; the guaranteed outcomes are static analyzability,
+    non-throwing execution, and measured module-evaluation behavior.
+  - Adding dual ESM/CJS package output or changing the package export format.
+  - Adding tokenizer families, aliases, recipes, or certificate profiles.
+  - Changing structural certificate arithmetic or heuristic estimation.
+  - Publishing to npm, pushing commits/tags, or creating a GitHub release
+    without separate explicit authorization.
+
+## Phases
+
+### Phase 1: Freeze Acceptance Criteria and Separate Semantic Identity
+
+**Goal**: Establish a rank-free loader dependency boundary and turn the four
+issue asks into testable acceptance criteria before behavior changes.
+
+**Files**:
+
+- `ISSUE-tokenizer-loader-injectable-peer.md`
+- `src/llm/tokenization/contentProfiles.ts`
+- `src/llm/tokenization/contentProfileIdentity.ts` (new)
+- `src/llm/tokenization/index.ts`
+- `src/llm/tokenization/loader/index.ts`
+- `src/llm/tokenization/recipes/gemma4.ts`
+- `src/llm/tokenization/recipes/recipes.test.ts`
+- `src/index.ts`
+
+**Work**:
+
+- [x] Add an acceptance checklist to the issue covering injected loading, import
+  laziness, statically visible rank modules, graceful unavailability, packed
+  types, and Rollup execution.
+- [x] Extract semantic-provenance canonicalization and
+  `computeContentTokenizerSemanticRevision()` into a small internal module that
+  imports only Node crypto and tokenization types.
+- [x] Import that helper directly from the loader and built-in recipe so neither the
+  loader nor recipes subpath traverses `contentProfiles.ts -> profiles.ts`.
+- [x] Preserve the current root export name and behavior. Existing internal imports
+  may be redirected or compatibly re-exported; no public import changes.
+
+**Steps**:
+
+1. Move the semantic domain separator, canonicalization, stable ordering, and
+   digest computation without changing the canonical JSON input.
+2. Keep runtime-provenance and registry-state validation in
+   `contentProfiles.ts`.
+3. Update the tokenization barrel, loader, and built-in recipe imports to the
+   rank-free module.
+4. Run existing semantic-revision fixtures before continuing; every digest must
+   remain byte-for-byte identical.
+
+**Verification**:
+
+- [x] Existing semantic revision and mapping revision fixtures are unchanged.
+- [x] Importing the loader or recipes subpath has no dependency edge to
+  `profiles.ts`.
+- [x] Root and subpath public exports remain source-compatible.
+- [x] The issue contains concrete, checkable acceptance criteria.
+
+### Phase 2: Make Built-In Profiles Lazy, Static, and Fail-Closed
+
+**Goal**: Remove computed rank loading and the eager full-js-tiktoken import
+while retaining exact counts and certificate identities.
+
+**Files**:
+
+- `src/llm/tokenization/profiles.ts`
+- `src/llm/tokenization/bounds.ts`
+- `src/llm/tokenization/profiles.failure.test.ts` (new)
+- `src/llm/tokenization/tokenization.test.ts`
+- `src/llm/tokenization/contentProfiles.ts`
+- `src/llm/tokenization/contentProfiles.test.ts`
+
+**Work**:
+
+- [x] Replace `loadRankData(moduleId)` with two functions containing literal
+  synchronous requires for:
+  - `js-tiktoken/ranks/cl100k_base`
+  - `js-tiktoken/ranks/o200k_base`
+- [x] Replace the full `js-tiktoken` value import with a type-only lite import and a
+  literal lazy `require("js-tiktoken/lite")`.
+- [x] Instantiate `Tiktoken` from the verified cached rank snapshot instead of
+  calling `getEncoding()`, which embeds every rank family through the full
+  entry.
+- [x] Validate loaded rank/module shapes before property access. Catch require,
+  evaluation, hash, byte-property, lite-runtime, constructor, and encode
+  failures at the lowest boundary that can return unavailable evidence.
+- [x] Copy verified rank fields into an immutable canonical snapshot before caching
+  them, so later mutation of a shared rank-module export cannot change counts
+  covered by the verified hash/certificate identity.
+- [x] Cache successful profiles, verified rank snapshots, tokenizer instances, and
+  terminal profile-unavailable results without conflating profile verification
+  with an individual text-count failure.
+- [x] Generalize failure reasons so a load/evaluation failure is not falsely
+  described only as a hash mismatch; do not expose filesystem paths or raw
+  bundler internals in the stable public reason.
+- [x] Reserve built-in IDs by identity rather than by successful profile loading.
+  Alias validation may still require an available built-in target, preserving
+  the current transactional contract.
+- [x] Add isolated failure, mutation, and lite-runtime regressions.
+
+**Steps**:
+
+1. Introduce one internal built-in-ID predicate/set shared by profile and
+   registry validation.
+2. Add literal rank thunks and a safe CommonJS/default-export unwrapping check.
+3. Verify rank data, make and freeze its defensive snapshot, and cache that
+   snapshot before publishing a frozen `TokenProfile`.
+4. Add lazy lite-runtime construction from that exact cached object.
+5. Guard resolution, count, and certificate revalidation callers so failures
+   return their existing unavailable shapes.
+6. Compare the new lite construction against `getEncoding()` on empty, ASCII,
+   multilingual, combining-mark, emoji/ZWJ, control, special-literal, lone
+   surrogate, and long-text fixtures.
+
+**Verification**:
+
+- [x] Both built-in hashes, revisions, maximum decoded byte values, and existing
+  exact token counts are unchanged.
+- [x] Each rank require has a literal statically analyzable specifier.
+- [x] A mocked rank require/evaluation/shape/hash failure never throws from
+  profile, content-profile, bound, or capability APIs.
+- [x] A mocked lite constructor or encode failure returns unavailable count
+  evidence.
+- [x] Repeated reads after terminal rank failure remain non-throwing and do not
+  retry module evaluation.
+- [x] Mutating a rank module's exported object after first resolution cannot
+  alter subsequent counts or the cached verified snapshot.
+- [x] A registered backend cannot claim either built-in ID during rank failure.
+- [x] No heuristic count appears in an exact/certificate failure result.
+
+### Phase 3: Remove the Independent Eager Root Import
+
+**Goal**: Make importing `genai-lite` and prompting utilities avoid evaluating
+the full js-tiktoken entry while preserving the legacy numeric API.
+
+**Files**:
+
+- `src/prompting/content.ts`
+- `src/prompting/content.test.ts`
+- `src/prompting/index.ts`
+- `src/index.ts`
+
+**Work**:
+
+- [x] Convert `Tiktoken`/`TiktokenModel` imports to type-only imports where needed.
+- [x] Route mapped cl100k/o200k OpenAI models through the built-in profile layer
+  without first loading the full js-tiktoken model-mapping entry.
+- [x] Load the full `js-tiktoken` entry through one literal synchronous lazy require
+  only for legacy models not covered by the verified profiles.
+- [x] Preserve `countTokens()`'s empty-string behavior, supported legacy models,
+  tokenizer caching, and catch-to-heuristic numeric fallback.
+
+**Steps**:
+
+1. Add an internal lazy accessor for the legacy js-tiktoken module.
+2. Attempt the verified built-in model mapping first.
+3. Fall back to the legacy module only when the built-in mapping is absent or
+   exact counting is unavailable.
+4. Extend content tests to distinguish exact mapped behavior, legacy exact
+   behavior, and invalid-model heuristic fallback.
+
+**Verification**:
+
+- [x] Requiring the package root or prompting subpath does not add
+  `js-tiktoken` to Node's module cache. Prompting, recipes, and loader subpaths
+  also avoid `base64-js`; the root's unrelated Google SDK edge is recorded and
+  must not be mistaken for the tiktoken chain.
+- [x] Resolving/counting a mapped built-in loads only the relevant rank plus the
+  lite runtime, not `js-tiktoken/dist/index.cjs` or unrelated ranks.
+- [x] A legacy non-cl100k/o200k model still uses js-tiktoken exact counting.
+- [x] Invalid models retain `Math.ceil(text.length / 4)` fallback behavior.
+
+### Phase 4: Add the Injectable Peer Path
+
+**Goal**: Allow a statically imported peer namespace to be supplied without any
+loader-owned path or module resolution.
+
+**Files**:
+
+- `src/llm/tokenization/recipes/types.ts`
+- `src/llm/tokenization/recipes/index.ts`
+- `src/llm/tokenization/loader/index.ts`
+- `src/llm/tokenization/loader/tokenizerLoader.test.ts`
+
+**Work**:
+
+- [x] Add genai-lite-owned structural peer/module types and the optional
+  `tokenizersPeer` field without referencing optional-peer declarations.
+- [x] Re-export loader-facing types from the loader subpath while retaining current
+  recipe-subpath type exports.
+- [x] Split peer handling into shared validation plus two resolution modes:
+  installed discovery and caller injection.
+- [x] Validate the injected peer before artifact provisioning and initialize the
+  tokenizer through the same sanitize/self-test/backend path as the discovered
+  peer.
+- [x] Keep runtime provenance `{ packageName: "@huggingface/tokenizers",
+  packageVersion, loaderImplementationRevision }`; document that only the
+  injected version's source is caller assertion rather than manifest proof.
+
+**Steps**:
+
+1. Define the additive types with JSDoc describing trust and bundling use.
+2. Replace enumerated optional-key combinations with strict validation that is
+   maintainable for both optional fields and still rejects unknown keys.
+3. Add `resolveInjectedPeer()` and retain `resolveInstalledPeer()` as the
+   default.
+4. Reuse version-range and module-shape validation in both paths.
+5. Verify abort-before-work ordering for the injected path.
+
+**Verification**:
+
+- [x] Every pre-existing options object remains valid without modification.
+- [x] A supported injected peer loads a warm recipe, passes self-tests, returns
+  a synchronous backend, and stamps the asserted version.
+- [x] Injection succeeds in an environment where the peer cannot be resolved
+  from the loader package location.
+- [x] Unsupported/indeterminate asserted versions and malformed modules map to
+  the existing precise loader error codes.
+- [x] The default missing/present/unsupported/evaluation-failure cases retain
+  their current codes and actionable messages.
+- [x] Abort, recipe validation, cache integrity, download, and concurrency
+  guarantees remain unchanged.
+
+### Phase 5: Verify Service Degradation and Packed Bundling
+
+**Goal**: Reproduce the consumer's failure in automation and prove the fixed
+package works without consumer-specific dynamic-require configuration.
+
+**Files**:
+
+- `src/llm/LLMService.contentProfiles.test.ts`
+- `src/llm/LLMService.contentProfiles.failure.test.ts` (new)
+- `scripts/verify-packed-prepared-api.js`
+- `.github/workflows/ci.yml`
+- `package.json` only if a clearer verification script name is needed
+
+**Work**:
+
+- [x] Add an isolated service regression where o200k rank loading fails before
+  module import. Capability inspection must resolve with unavailable content
+  counting, and response processing must omit library-generated raw-content
+  accounting rather than reject.
+- [x] Keep a peer-free TypeScript fixture and typecheck it before installing the
+  optional peer. After installation, typecheck a separate injected-peer fixture
+  that passes an actual `import * as tokenizersModule` namespace to
+  `tokenizersPeer` without a cast; give each fixture an explicit tsconfig or
+  invocation so the ordering cannot be obscured.
+- [x] Before installing the optional peer in the isolated consumer, use separate
+  CJS and ESM fixtures to prove that an injected structural test runtime can
+  load the warm fixture and that ordinary missing-peer behavior remains
+  late/actionable when injection is absent.
+- [x] Add child-process `require.cache` assertions for root, prompting, recipes, and
+  loader imports, then for one built-in resolution/count.
+- [x] Install exactly pinned Rollup, node-resolve, CommonJS, and JSON plugin versions only
+  in the verifier's temporary consumer; do not add them to root dependencies or
+  `package-lock.json`.
+- [x] Bundle an ESM entry with no `dynamicRequireTargets` that:
+  1. imports the packed root, then resolves and counts through both
+     `openai/gpt-5.1` (`o200k_base`) and `openai/gpt-4` (`cl100k_base`);
+  2. statically imports `@huggingface/tokenizers`;
+  3. imports the packed loader, injects that namespace/version, loads the warm
+     fixture, and verifies ordinary special-literal counting and provenance.
+- [x] Execute the generated ESM bundle under Node. Inspect Rollup's module graph for
+  the loader-only entry to ensure the semantic-identity split excludes
+  js-tiktoken and base64-js from that subpath graph.
+- [x] Run `npm run test:packed-api` in the single Ubuntu package-validation CI job,
+  avoiding the nine-platform unit-test matrix.
+
+**Verification**:
+
+- [x] The exact issue reproduction bundles and executes without
+  `dynamicRequireTargets` or externalizing `genai-lite/tokenizer-loader`.
+- [x] No generated `commonjsRequire` failure is reached for either rank.
+- [x] The injected path never evaluates `createRequire(__filename)`.
+- [x] Loader-only bundling contains no tiktoken/base64 dependency edge.
+- [x] Packed CJS and ESM consumers pass with the peer missing, discovered, and
+  structurally injected; the bundled ESM consumer additionally passes with the
+  real statically imported peer namespace.
+- [x] Packed public declarations typecheck without installing the optional peer,
+  except in the fixture that intentionally imports it.
+- [x] CI durably runs the packed/Rollup regression once per change.
+
+### Phase 6: Documentation, Release Record, and Closure
+
+**Goal**: Document the exact guarantee and close the issue according to the
+repository convention once every gate passes.
+
+**Files**:
+
+- `README.md`
+- `genai-lite-docs/prepared-calls-and-accounting.md`
+- `genai-lite-docs/typescript-reference.md`
+- `genai-lite-docs/llm-service.md`
+- `genai-lite-docs/prompting-utilities.md`
+- `docs/dev/token-bound-certificates.md`
+- `.summary_short.md`, `.summary_long.md`
+- `src/.summary_long.md`
+- `src/llm/.summary_long.md`
+- `src/llm/tokenization/.summary_short.md`
+- `src/llm/tokenization/.summary_long.md`
+- `src/prompting/.summary_short.md`
+- `src/prompting/.summary_long.md`
+- `package.json`, `package-lock.json`
+- `ISSUE-tokenizer-loader-injectable-peer.md`
+- `PLAN-tokenizer-loader-injectable-peer.md`
+- `docs/archive/`
+
+**Work**:
+
+- [x] Keep `prepared-calls-and-accounting.md` as the authoritative consumer guide:
+  document automatic and injected peer modes, supported-version validation,
+  caller-asserted injected provenance, a statically imported example, and
+  externalization as a fallback rather than a requirement.
+- [x] Document the new types/import paths and precise error behavior in the
+  TypeScript reference.
+- [x] Keep the README example short: retain automatic installation, mention the
+  injected bundler path, and link to the authoritative guide.
+- [x] Clarify in LLM docs that tokenizer load/validation failures make content
+  capability unavailable without crashing.
+- [x] Update prompting docs only for the root/module-evaluation laziness and legacy
+  fallback behavior actually verified.
+- [x] Expand the certificate guide's fail-closed rule from hash mismatch to rank
+  load/evaluation/shape/validation failure, including permanent built-in ID
+  reservation. State that profile identities/revisions remain unchanged.
+- [x] State explicitly that laziness does not remove the production dependency or
+  promise arbitrary-bundler byte elimination.
+- [x] Refresh only summaries whose owned behavior changed. Do not create a new user
+  guide, troubleshooting duplicate, devlog, changelog, or completion report;
+  the archived plan is the durable design record.
+- [x] Update package and lockfile versions to 0.17.2 after all implementation gates
+  pass.
+- [x] Complete the issue acceptance checklist and add its `## Resolution` section
+  with date/version. Complete this plan's verification tracking and add its own
+  `## Resolution` section. Set the records to `Status: RESOLVED` and
+  `Status: COMPLETE` respectively, with the date and v0.17.2, then move both to
+  `docs/archive/` and update references to their archived paths.
+- [x] Perform and record a manual local-link inspection for the changed Markdown;
+  no repository-wide link checker is introduced by this work.
+
+**Verification**:
+
+- [x] Every new public type, option, resolution mode, provenance qualification,
+  error path, and bundler guarantee appears in authoritative docs.
+- [x] Documentation distinguishes runtime evaluation, Rollup analyzability,
+  bundle reachability, and npm installed footprint.
+- [x] A manual inspection confirms that changed Markdown links and archived
+  issue/plan references resolve, and the result is recorded in the resolution.
+- [x] Package and lockfile versions agree at 0.17.2.
+- [x] Issue acceptance criteria are checked only after their corresponding
+  automated/manual gates pass.
+- [x] The plan is marked complete and has a resolution record before archival.
+- [x] No publish, push, tag, release, or commit occurs without separate user
+  authorization.
+
+## Testing Strategy
+
+### Focused implementation loop
+
+```powershell
+npm.cmd test -- tokenization.test.ts profiles.failure.test.ts contentProfiles.test.ts tokenizerLoader.test.ts content.test.ts LLMService.contentProfiles.test.ts
+npm.cmd run build
+npm.cmd run test:packed-api
+```
+
+### Final repository gates
+
+```powershell
+npm.cmd test
+npm.cmd run build
+npm.cmd run test:packed-api
+npm.cmd audit --omit=dev --audit-level=high
+npm.cmd audit --audit-level=high
+npm.cmd pack --dry-run
+node -e "const lib = require('./dist'); console.log('Exports:', Object.keys(lib));"
+git diff --check
+```
+
+The production audit is blocking. The full-tree audit is informational under
+the existing project policy; any dev-only advisory must still be reported.
+Real-provider E2E tests are not required because no provider adapter or request
+shape changes.
+
+## Documentation Ownership
+
+- `genai-lite-docs/prepared-calls-and-accounting.md` owns consumer setup,
+  injected/default peer behavior, provenance, caching, and bundler guidance.
+- `genai-lite-docs/typescript-reference.md` owns the exact public type surface.
+- `genai-lite-docs/llm-service.md` owns capability degradation visible through
+  `LLMService`.
+- `genai-lite-docs/prompting-utilities.md` owns legacy `countTokens()` behavior.
+- `docs/dev/token-bound-certificates.md` owns built-in rank/certificate
+  maintenance and fail-closed invariants.
+- The archived issue and this plan own problem history, implementation
+  decisions, acceptance evidence, and why the v0.17.0 externalization constraint
+  was superseded. No additional durable document is needed.
+
+## Risks and Mitigations
+
+- **Static literal requires increase bundle reachability**: verify actual Rollup
+  execution and module graphs; promise analyzability/evaluation behavior rather
+  than universal pruning.
+- **Lite construction drifts from `getEncoding()`**: run adversarial parity
+  fixtures and stop if any count differs; do not silently change profile
+  revisions or certificates.
+- **Caller asserts a false injected version**: document the assertion boundary,
+  validate the supported range, preserve model-quality classification, and keep
+  certificate APIs closed.
+- **Graceful failure accidentally weakens ID integrity**: reserve built-in IDs
+  independently of runtime availability and test the failure environment.
+- **Strict options validation becomes fragile**: validate allowed/required keys
+  compositionally and test every optional-key combination plus unknown fields.
+- **Module caches hide failure tests**: use a dedicated isolated-module suite and
+  child processes for packed cache/evaluation assertions.
+- **The root already reaches base64-js through Google's auth SDK**: assert the
+  absence of `js-tiktoken` at the root and the absence of `base64-js` only on
+  focused prompting/recipes/loader imports; do not misattribute that SDK edge.
+- **Transient Rollup verification drifts**: install exact tested versions in the
+  temporary consumer and execute it in CI; update deliberately when necessary.
+- **Packed verification adds CI time/network work**: run it once in the Ubuntu
+  package-validation job, not in the OS/Node unit matrix.
+
+## Rollback
+
+- The injection field is additive; omitting it always retains the current
+  installed-peer path.
+- Internal identity/profile/prompting refactors can be reverted independently
+  because no stored data or serialized prepared handle changes.
+- If lite parity fails, retain existing exact profile implementation and land
+  only injection/guarding after amending this plan and its bundle guarantees.
+- If Rollup integration is unstable, do not replace it with a source-string
+  assertion; keep the issue open and revisit the test harness.
+- No rollback requires data migration. Publication rollback is outside this
+  plan because publication is not authorized.
+
+## Approval Decisions
+
+Approval of this plan accepts these recommended choices:
+
+1. Use `tokenizersPeer: { module, packageVersion }`, not an asynchronous resolver
+   callback.
+2. Treat an injected version as validated caller-asserted runtime provenance.
+3. Include the independent `src/prompting/content.ts` eager import so root
+   imports become runtime-lazy, while keeping js-tiktoken a production
+   dependency.
+4. Extract semantic identity into a rank-free internal module so loader-only
+   bundles do not traverse tiktoken code.
+5. Add an actual packed Rollup regression and run the existing packed verifier
+   in the single package-validation CI job.
+6. Target repository version 0.17.2, but do not publish, commit, push, or tag
+   without separate authorization.
+
+---
+
+**Please review. Edit directly if needed, then confirm to proceed.**
+
+## Resolution
+
+Completed on 2026-08-05 for v0.17.2. All six phases were implemented: semantic
+identity was separated from rank loading; built-in profiles became literal,
+lazy, defensive, and fail-closed; prompting stopped eagerly evaluating the full
+js-tiktoken runtime; the optional tokenizer peer became structurally
+injectable; and the packed verifier now exercises declaration isolation,
+module evaluation, real Rollup bundling, both rank families, and a statically
+imported real peer namespace.
+
+Final verification passed 49 Jest suites (1,134 tests), the TypeScript build,
+the packed/Rollup consumer gate, package dry-run, compiled export smoke test,
+production dependency audit, version checks, and whitespace checks. The
+informational full-tree audit reports only the known dev-only
+`brace-expansion` advisory. The required doublecheck found one malformed
+injected-runtime error-boundary gap and four evidence/documentation gaps; all
+were corrected and independently rechecked with no remaining findings. Release
+operations and real-provider E2E calls remained out of scope.
+
+A final manual inspection after archival confirmed that all changed local
+Markdown paths, cross-file anchors, and the archived issue/plan references
+resolve from their final locations.

--- a/docs/dev/token-bound-certificates.md
+++ b/docs/dev/token-bound-certificates.md
@@ -16,8 +16,17 @@ For every profile revision, pin and verify:
 - affine constants and overflow behavior.
 
 Keep the tokenizer profile revision separate from the model-to-profile mapping
-revision. If an installed rank hash differs, the profile and its certificates
-must become unavailable rather than silently using the new data.
+revision. If a rank module cannot be loaded/evaluated, has the wrong shape or
+hash, or fails byte-completeness validation, the profile and its certificates
+must become unavailable rather than throwing or silently using different data.
+The built-in IDs remain permanently reserved even while unavailable.
+
+After validation, copy rank primitives and clone/freeze `special_tokens` into a
+canonical snapshot. Tokenizer construction must use that snapshot, not the
+shared mutable module export, so later mutation cannot separate counts from the
+hash and certificate identity that authorized them. Runtime construction or
+encoding failure likewise returns unavailable count evidence; it never enables
+a heuristic certificate path.
 
 The parallel `ContentTokenProfile` registry is not a certificate registry.
 Built-in exact content profiles may wrap the canonical certified profiles for
@@ -32,6 +41,12 @@ package provenance to this trust boundary.
 The `cl100k_base` and `o200k_base` profiles are pinned to the bundled
 `js-tiktoken@1.0.21` rank/config hashes. The registry derives byte completeness
 and the maximum token byte length from those artifacts.
+
+Keep each rank specifier as a separate literal lazy load and construct the
+runtime through `js-tiktoken/lite`. The lite construction must remain count-
+for-count equivalent to the full `getEncoding()` implementation across the
+adversarial parity fixtures before hashes, revisions, or certificates may be
+left unchanged.
 
 The Unicode code-point certificate uses:
 

--- a/genai-lite-docs/llm-service.md
+++ b/genai-lite-docs/llm-service.md
@@ -163,6 +163,11 @@ identifies the complete registry snapshot used for that capability result and
 may change after unrelated additions. See
 [Content-token profiles](prepared-calls-and-accounting.md#content-token-profiles).
 
+Built-in rank loading and validation also fail closed to `unavailable` rather
+than throwing from capability inspection. If that profile remains unavailable
+when a response is processed, genai-lite preserves provider-output accounting
+but omits library-generated raw-content token accounting.
+
 `validateRequestCapabilities()` returns the same validation diagnostic shape as `sendMessage()` where possible. For example, Gemini-hosted Gemma models return `type: 'validation_error'` and `code: 'structured_output_not_supported'` when structured output is requested.
 
 ---

--- a/genai-lite-docs/prepared-calls-and-accounting.md
+++ b/genai-lite-docs/prepared-calls-and-accounting.md
@@ -197,6 +197,12 @@ The content API has two trust levels:
 - `model`: host-registered synchronous tokenizers, including recipe-loaded
   tokenizers.
 
+The built-in cl100k/o200k rank modules and lite runtime are loaded only when a
+matching profile is resolved or counted. Rank-module evaluation, shape, hash,
+byte-completeness, tokenizer construction, and encoding failures fail closed:
+the relevant resolution or count is `unavailable`, and certificate APIs remain
+unavailable rather than substituting a heuristic.
+
 `ContentTokenProfile` is intentionally separate from the certified
 `TokenProfile` type. Registered profiles are always forced to `model` quality
 and certificate functions reject them, including through runtime casts. A
@@ -289,6 +295,41 @@ The loader runtime is an optional peer:
 npm install @huggingface/tokenizers@^0.1.3
 ```
 
+By default, the loader discovers the installed peer relative to its own package
+location and proves the version from the nearest package manifest. Bundled
+applications may instead inject a statically imported namespace:
+
+```typescript
+import * as tokenizersModule from "@huggingface/tokenizers";
+import {
+  loadContentTokenizerProfile,
+} from "genai-lite/tokenizer-loader";
+import {
+  GEMMA_4_IT_CONTENT_TOKENIZER_RECIPE,
+} from "genai-lite/tokenizer-recipes";
+
+const backend = await loadContentTokenizerProfile(
+  GEMMA_4_IT_CONTENT_TOKENIZER_RECIPE,
+  {
+    cacheDir: "/application-owned/tokenizer-cache",
+    allowDownload: false,
+    tokenizersPeer: {
+      module: tokenizersModule,
+      packageVersion: "0.1.3",
+    },
+  }
+);
+```
+
+For injection, `packageVersion` is the caller's assertion about the supplied
+namespace. The loader validates it against `^0.1.3` and records it in runtime
+provenance, but it cannot prove it from a package path. Recipe-loaded backends
+remain model-quality evidence and cannot enter certificate APIs.
+Unsupported or indeterminate asserted versions fail with
+`TOKENIZER_PEER_VERSION_UNSUPPORTED`; malformed injected modules and tokenizer
+construction failures use `TOKENIZER_LOAD_FAILED`. Unknown fields in the
+options or `tokenizersPeer` wrapper remain strict recipe-validation errors.
+
 Importing `genai-lite`, `genai-lite/tokenizer-recipes`, or
 `genai-lite/tokenizer-loader` does not load that peer. Only
 `loadContentTokenizerProfile()` resolves it. A missing, indeterminate, or
@@ -317,10 +358,20 @@ endpoint using no BOS and no special parsing. Continue to prefer
 llama.cpp's active-template prepared count as hard prompt evidence; a local
 content profile remains model evidence.
 
-For Vite/esbuild-style application bundles, externalize
-`@huggingface/tokenizers` and preserve the loader's runtime import.
-Externalizing `genai-lite/tokenizer-loader` itself is the simplest safe option
-when the bundler cannot preserve optional dynamic dependencies.
+For Rollup/Vite/esbuild-style application bundles, prefer the injected form so
+the application owns a statically analyzable peer import. The injected path
+does not evaluate the loader's `createRequire(__filename)` discovery branch and
+does not require `dynamicRequireTargets`. Externalizing
+`genai-lite/tokenizer-loader` and preserving the installed-peer path remains a
+fallback when injection is unsuitable.
+
+The loader and recipes subpaths do not traverse js-tiktoken. Built-in ranks use
+separate literal lazy loads, and ordinary root/prompting imports do not evaluate
+js-tiktoken. This is an evaluation and bundler-analyzability guarantee, not a
+promise that every bundler will prune the same bytes: `js-tiktoken@1.0.21`
+remains an exact production dependency and therefore remains in npm's installed
+dependency graph. The package root may also evaluate `base64-js` independently
+through Google's authentication SDK; that is not the removed tiktoken chain.
 
 ## Certified structural bounds and margins
 

--- a/genai-lite-docs/prompting-utilities.md
+++ b/genai-lite-docs/prompting-utilities.md
@@ -157,7 +157,14 @@ while (countTokens(prompt) > maxTokens) {
 }
 ```
 
-**Note**: Uses `js-tiktoken` library. Supports all models with tiktoken encodings.
+**Note**: Uses `js-tiktoken` and supports all models with tiktoken encodings.
+Mapped cl100k/o200k models use the verified built-in profiles first, loading
+only the selected rank and lite runtime when counting begins. Other supported
+legacy models load the full js-tiktoken model-mapping entry lazily. Importing
+the root or prompting subpath does not itself evaluate js-tiktoken. If exact
+counting fails, this compatibility wrapper still returns
+`Math.ceil(text.length / 4)`; evidence-bearing and certificate APIs instead
+return `unavailable` and never manufacture a heuristic result.
 
 ### Registered content tokenizers
 

--- a/genai-lite-docs/typescript-reference.md
+++ b/genai-lite-docs/typescript-reference.md
@@ -157,12 +157,14 @@ import type {
   ContentTokenizerRecipeLoaderInput,
   ContentTokenizerRecipeSelfTest,
   ContentTokenizerRecipeSelfTestName,
-  ContentTokenizerCoverageEvidence,
-  LoadContentTokenizerProfileOptions
+  ContentTokenizerCoverageEvidence
 } from 'genai-lite/tokenizer-recipes';
 
 import type {
-  ContentTokenizerLoaderErrorCode
+  ContentTokenizerLoaderErrorCode,
+  ContentTokenizerPeer,
+  ContentTokenizerRuntimeModule,
+  LoadContentTokenizerProfileOptions
 } from 'genai-lite/tokenizer-loader';
 
 // Retry utilities (runtime + types)
@@ -592,11 +594,40 @@ interface ContentTokenizerRecipe {
   coverageEvidence: ContentTokenizerCoverageEvidence[];
 }
 
+interface ContentTokenizerRuntimeModule {
+  readonly Tokenizer: unknown;
+}
+
+interface ContentTokenizerPeer {
+  readonly module: ContentTokenizerRuntimeModule;
+  readonly packageVersion: string;
+}
+
+interface LoadContentTokenizerProfileOptions {
+  cacheDir: string;
+  allowDownload: boolean;
+  signal?: AbortSignal;
+  tokenizersPeer?: ContentTokenizerPeer;
+}
+
 loadContentTokenizerProfile(
   recipe: ContentTokenizerRecipe,
   options: LoadContentTokenizerProfileOptions
 ): Promise<RegisteredContentTokenizerBackend>;
 ```
+
+The loader and recipes subpaths both export all three loader-facing interfaces
+above; the loader re-export keeps them discoverable beside the loading
+function, while the recipes export preserves the existing options-type path.
+Public declarations use only genai-lite-owned structural types, so installing
+the optional peer is not required to typecheck ordinary consumers. A real
+`import * as tokenizersModule from '@huggingface/tokenizers'` namespace is
+directly assignable to `module`.
+
+When `tokenizersPeer` is omitted, the loader discovers the installed peer and
+proves its version from its package manifest. When supplied, discovery is
+bypassed and `packageVersion` is a caller assertion validated against `^0.1.3`
+and recorded in runtime provenance.
 
 `ContentTokenizerRecipeArtifact`, `ContentTokenizerRecipeLoaderInput`,
 `ContentTokenizerRecipeSelfTest`, and `ContentTokenizerCoverageEvidence`
@@ -610,6 +641,11 @@ the six required test categories.
 `TOKENIZER_RECIPE_INVALID`, `TOKENIZER_ARTIFACT_UNAVAILABLE`,
 `TOKENIZER_ARTIFACT_INTEGRITY`, `TOKENIZER_LOAD_FAILED`,
 `TOKENIZER_SELF_TEST_FAILED`, or `TOKENIZER_ABORTED`.
+
+An unsupported or indeterminate asserted version produces
+`TOKENIZER_PEER_VERSION_UNSUPPORTED`. A malformed injected module or tokenizer
+constructor failure produces `TOKENIZER_LOAD_FAILED`; unknown option or peer
+wrapper fields produce `TOKENIZER_RECIPE_INVALID`.
 
 See [Prepared Calls and Token Accounting](prepared-calls-and-accounting.md#content-token-profiles)
 for registration timing, exact aliases, cache guarantees, recipes, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-lite",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-lite",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-lite",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A lightweight, portable toolkit for interacting with various Generative AI APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/verify-packed-prepared-api.js
+++ b/scripts/verify-packed-prepared-api.js
@@ -14,11 +14,21 @@ function runNpm(args, options) {
   return execFileSync(process.execPath, [npmCli, ...args], options);
 }
 
-function runNode(script, cwd, env = {}) {
-  return execFileSync(process.execPath, [script], {
+function runNode(script, cwd, env = {}, args = []) {
+  return execFileSync(process.execPath, [script, ...args], {
     cwd,
     stdio: "inherit",
     env: { ...process.env, ...env },
+  });
+}
+
+function collectDeclarationFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return collectDeclarationFiles(entryPath);
+    }
+    return entry.isFile() && entry.name.endsWith(".d.ts") ? [entryPath] : [];
   });
 }
 
@@ -84,6 +94,9 @@ import {
 import {
   ContentTokenizerLoaderError,
   loadContentTokenizerProfile,
+  type ContentTokenizerPeer,
+  type ContentTokenizerRuntimeModule,
+  type LoadContentTokenizerProfileOptions,
 } from "genai-lite/tokenizer-loader";
 import type {
   ContentTokenProfile,
@@ -177,6 +190,9 @@ void (null as unknown as ContentTokenProfile);
 void (null as unknown as RegisteredContentTokenizerBackend);
 void ContentTokenizerLoaderError;
 void loadContentTokenizerProfile;
+void (null as unknown as ContentTokenizerPeer);
+void (null as unknown as ContentTokenizerRuntimeModule);
+void (null as unknown as LoadContentTokenizerProfileOptions);
 `
   );
 
@@ -190,14 +206,106 @@ void loadContentTokenizerProfile;
     ],
     { cwd: consumer, stdio: "inherit" }
   );
+  const packedDeclarationRoot = path.join(
+    consumer,
+    "node_modules",
+    "genai-lite",
+    "dist"
+  );
+  const peerDeclarationLeaks = collectDeclarationFiles(packedDeclarationRoot)
+    .filter((file) =>
+      fs.readFileSync(file, "utf8").includes("@huggingface/tokenizers")
+    );
+  if (peerDeclarationLeaks.length > 0) {
+    throw new Error(
+      "Packed genai-lite declarations leaked optional-peer imports:\n" +
+        peerDeclarationLeaks.join("\n")
+    );
+  }
   execFileSync(
     process.execPath,
-    [path.join(consumer, "node_modules", "typescript", "bin", "tsc"), "--noEmit"],
+    [
+      path.join(consumer, "node_modules", "typescript", "bin", "tsc"),
+      "--noEmit",
+      "-p",
+      "tsconfig.json",
+    ],
     {
       cwd: consumer,
       stdio: "inherit",
     }
   );
+
+  const importCacheCheck = path.join(consumer, "import-cache-check.cjs");
+  fs.writeFileSync(
+    importCacheCheck,
+    `
+const path = require("node:path");
+const requested = process.argv[2];
+require(requested);
+const loaded = Object.keys(require.cache).map((id) =>
+  id.split(path.sep).join("/")
+);
+const eager = loaded.filter((id) => {
+  if (id.includes("/node_modules/js-tiktoken/")) return true;
+  return requested !== "genai-lite" &&
+    id.includes("/node_modules/base64-js/");
+});
+if (eager.length > 0) {
+  throw new Error(
+    requested + " eagerly evaluated tokenizer dependencies:\\n" +
+      eager.join("\\n")
+  );
+}
+`
+  );
+  for (const entry of [
+    "genai-lite",
+    "genai-lite/prompting",
+    "genai-lite/tokenizer-recipes",
+    "genai-lite/tokenizer-loader",
+  ]) {
+    runNode(importCacheCheck, consumer, {}, [entry]);
+  }
+
+  const builtinCacheCheck = path.join(consumer, "builtin-cache-check.cjs");
+  fs.writeFileSync(
+    builtinCacheCheck,
+    `
+const { countTextTokens, resolveTokenProfile } = require("genai-lite");
+const model = process.argv[2];
+const expectedRank = process.argv[3];
+const unexpectedRank = process.argv[4];
+const resolution = resolveTokenProfile("openai", model);
+if (resolution.status !== "available") {
+  throw new Error("Built-in profile did not resolve for " + model);
+}
+const counted = countTextTokens("packed cache assertion", resolution.profile);
+if (counted.status !== "available") {
+  throw new Error("Built-in profile did not count for " + model);
+}
+for (const required of [expectedRank, "js-tiktoken/lite", "base64-js"]) {
+  if (!require.cache[require.resolve(required)]) {
+    throw new Error("Expected module was not evaluated: " + required);
+  }
+}
+for (const forbidden of [unexpectedRank, "js-tiktoken"]) {
+  if (require.cache[require.resolve(forbidden)]) {
+    throw new Error("Unrelated tokenizer module was evaluated: " + forbidden);
+  }
+}
+`
+  );
+  runNode(builtinCacheCheck, consumer, {}, [
+    "gpt-4",
+    "js-tiktoken/ranks/cl100k_base",
+    "js-tiktoken/ranks/o200k_base",
+  ]);
+  runNode(builtinCacheCheck, consumer, {}, [
+    "gpt-5.1",
+    "js-tiktoken/ranks/o200k_base",
+    "js-tiktoken/ranks/cl100k_base",
+  ]);
 
   const missingCjs = path.join(consumer, "missing-peer.cjs");
   fs.writeFileSync(
@@ -275,19 +383,6 @@ try {
   }
   runNode(missingCjs, consumer);
   runNode(missingEsm, consumer);
-
-  runNpm(
-    [
-      "install",
-      "--ignore-scripts",
-      "--package-lock=false",
-      "--no-audit",
-      "--no-fund",
-      "--no-save",
-      "@huggingface/tokenizers@0.1.3",
-    ],
-    { cwd: consumer, stdio: "inherit" }
-  );
 
   const fixture = path.join(consumer, "tokenizer-fixture.cjs");
   fs.writeFileSync(
@@ -385,6 +480,139 @@ fs.writeFileSync(path.join(blobDir, sha256), bytes);
 module.exports = { cacheDir, recipe };
 `
   );
+
+  const injectedCjs = path.join(consumer, "injected-peer.cjs");
+  fs.writeFileSync(
+    injectedCjs,
+    `
+const { cacheDir, recipe } = require("./tokenizer-fixture.cjs");
+const {
+  loadContentTokenizerProfile,
+} = require("genai-lite/tokenizer-loader");
+class Tokenizer {
+  encode(text) {
+    const fixture = recipe.selfTest.find((item) => item.text === text);
+    const count = fixture ? fixture.expectedTokens : 0;
+    return { ids: Array.from({ length: count }, (_, index) => index) };
+  }
+}
+(async () => {
+  const backend = await loadContentTokenizerProfile(recipe, {
+    cacheDir,
+    allowDownload: false,
+    tokenizersPeer: {
+      module: { Tokenizer },
+      packageVersion: "0.1.3",
+    },
+  });
+  if (
+    backend.provenance.runtime.packageVersion !== "0.1.3" ||
+    backend.countTextTokens("<special>") !== 3
+  ) {
+    throw new Error("CJS injected-peer verification failed.");
+  }
+})();
+`
+  );
+  const injectedEsm = path.join(consumer, "injected-peer.mjs");
+  fs.writeFileSync(
+    injectedEsm,
+    `
+import fixture from "./tokenizer-fixture.cjs";
+import {
+  loadContentTokenizerProfile,
+} from "genai-lite/tokenizer-loader";
+class Tokenizer {
+  encode(text) {
+    const selfTest = fixture.recipe.selfTest.find((item) => item.text === text);
+    const count = selfTest ? selfTest.expectedTokens : 0;
+    return { ids: Array.from({ length: count }, (_, index) => index) };
+  }
+}
+const backend = await loadContentTokenizerProfile(fixture.recipe, {
+  cacheDir: fixture.cacheDir,
+  allowDownload: false,
+  tokenizersPeer: {
+    module: { Tokenizer },
+    packageVersion: "0.1.3",
+  },
+});
+if (
+  backend.provenance.runtime.packageVersion !== "0.1.3" ||
+  backend.countTextTokens("<special>") !== 3
+) {
+  throw new Error("ESM injected-peer verification failed.");
+}
+`
+  );
+  runNode(injectedCjs, consumer);
+  runNode(injectedEsm, consumer);
+
+  runNpm(
+    [
+      "install",
+      "--ignore-scripts",
+      "--package-lock=false",
+      "--no-audit",
+      "--no-fund",
+      "--no-save",
+      "@huggingface/tokenizers@0.1.3",
+      "rollup@4.62.4",
+      "@rollup/plugin-node-resolve@16.0.3",
+      "@rollup/plugin-commonjs@29.0.3",
+      "@rollup/plugin-json@6.1.0",
+    ],
+    { cwd: consumer, stdio: "inherit" }
+  );
+
+  fs.writeFileSync(
+    path.join(consumer, "tsconfig.injected.json"),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        module: "Node16",
+        moduleResolution: "Node16",
+        target: "ES2020",
+        skipLibCheck: true,
+      },
+      include: ["injected-consumer.mts"],
+    })
+  );
+  fs.writeFileSync(
+    path.join(consumer, "injected-consumer.mts"),
+    `
+import * as tokenizersModule from "@huggingface/tokenizers";
+import {
+  GEMMA_4_IT_CONTENT_TOKENIZER_RECIPE,
+} from "genai-lite/tokenizer-recipes";
+import {
+  loadContentTokenizerProfile,
+  type ContentTokenizerPeer,
+} from "genai-lite/tokenizer-loader";
+
+const tokenizersPeer: ContentTokenizerPeer = {
+  module: tokenizersModule,
+  packageVersion: "0.1.3",
+};
+void loadContentTokenizerProfile(GEMMA_4_IT_CONTENT_TOKENIZER_RECIPE, {
+  cacheDir: ".cache",
+  allowDownload: false,
+  tokenizersPeer,
+});
+`
+  );
+  execFileSync(
+    process.execPath,
+    [
+      path.join(consumer, "node_modules", "typescript", "bin", "tsc"),
+      "--noEmit",
+      "-p",
+      "tsconfig.injected.json",
+    ],
+    { cwd: consumer, stdio: "inherit" }
+  );
+
   const withPeerCjs = path.join(consumer, "with-peer.cjs");
   fs.writeFileSync(
     withPeerCjs,
@@ -429,6 +657,129 @@ if (
   );
   runNode(withPeerCjs, consumer);
   runNode(withPeerEsm, consumer);
+
+  const rollupEntry = path.join(consumer, "rollup-entry.mjs");
+  fs.writeFileSync(
+    rollupEntry,
+    `
+import * as tokenizersModule from "@huggingface/tokenizers";
+import {
+  countTextTokens,
+  resolveTokenProfile,
+} from "genai-lite";
+import fixture from "./tokenizer-fixture.cjs";
+import {
+  loadContentTokenizerProfile,
+} from "genai-lite/tokenizer-loader";
+
+for (const model of ["gpt-4", "gpt-5.1"]) {
+  const resolution = resolveTokenProfile("openai", model);
+  if (resolution.status !== "available") {
+    throw new Error("Bundled profile did not resolve for " + model);
+  }
+  const counted = countTextTokens("bundled rank execution", resolution.profile);
+  if (counted.status !== "available" || counted.count.tokens <= 0) {
+    throw new Error("Bundled profile did not count for " + model);
+  }
+}
+
+const backend = await loadContentTokenizerProfile(fixture.recipe, {
+  cacheDir: fixture.cacheDir,
+  allowDownload: false,
+  tokenizersPeer: {
+    module: tokenizersModule,
+    packageVersion: "0.1.3",
+  },
+});
+if (
+  backend.provenance.runtime.packageVersion !== "0.1.3" ||
+  backend.countTextTokens("<special>") !== 3
+) {
+  throw new Error("Bundled injected-peer loader verification failed.");
+}
+`
+  );
+  fs.writeFileSync(
+    path.join(consumer, "graph-loader.mjs"),
+    `
+import { loadContentTokenizerProfile } from "genai-lite/tokenizer-loader";
+console.log(typeof loadContentTokenizerProfile);
+`
+  );
+  fs.writeFileSync(
+    path.join(consumer, "graph-recipes.mjs"),
+    `
+import { GEMMA_4_IT_CONTENT_TOKENIZER_RECIPE } from "genai-lite/tokenizer-recipes";
+console.log(GEMMA_4_IT_CONTENT_TOKENIZER_RECIPE.id);
+`
+  );
+  const rollupConfig = path.join(consumer, "rollup.config.mjs");
+  fs.writeFileSync(
+    rollupConfig,
+    `
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const plugins = () => [
+  nodeResolve({ preferBuiltins: true }),
+  json(),
+  commonjs(),
+];
+const assertRankFreeGraph = {
+  name: "assert-rank-free-loader-graph",
+  generateBundle() {
+    const forbidden = [...this.getModuleIds()].filter((id) => {
+      const normalized = id.split(path.sep).join("/");
+      return normalized.includes("/node_modules/js-tiktoken/") ||
+        normalized.includes("/node_modules/base64-js/");
+    });
+    if (forbidden.length > 0) {
+      this.error(
+        "Loader/recipes graph reached tokenizer dependencies: " +
+          forbidden.join(", ")
+      );
+    }
+  },
+};
+
+export default [
+  {
+    input: path.join(directory, "rollup-entry.mjs"),
+    external: (id) => id.endsWith("tokenizer-fixture.cjs"),
+    output: {
+      file: path.join(directory, "rollup-bundle.mjs"),
+      format: "esm",
+    },
+    plugins: plugins(),
+  },
+  {
+    input: {
+      loader: path.join(directory, "graph-loader.mjs"),
+      recipes: path.join(directory, "graph-recipes.mjs"),
+    },
+    output: {
+      dir: path.join(directory, "rollup-graphs"),
+      format: "esm",
+    },
+    plugins: [...plugins(), assertRankFreeGraph],
+  },
+];
+`
+  );
+  execFileSync(
+    process.execPath,
+    [
+      path.join(consumer, "node_modules", "rollup", "dist", "bin", "rollup"),
+      "--config",
+      rollupConfig,
+    ],
+    { cwd: consumer, stdio: "inherit" }
+  );
+  runNode(path.join(consumer, "rollup-bundle.mjs"), consumer);
 
   const peerValidation = path.join(consumer, "peer-validation.cjs");
   fs.writeFileSync(

--- a/scripts/verify-packed-prepared-api.js
+++ b/scripts/verify-packed-prepared-api.js
@@ -805,27 +805,32 @@ loadContentTokenizerProfile(recipe, {
 );
 `
   );
-  const peerEntry = require.resolve("@huggingface/tokenizers", {
-    paths: [consumer],
-  });
-  let peerPackageDir = path.dirname(peerEntry);
-  let peerManifestPath;
-  while (peerPackageDir !== path.parse(peerPackageDir).root) {
-    const candidate = path.join(peerPackageDir, "package.json");
-    if (fs.existsSync(candidate)) {
-      const candidateManifest = JSON.parse(fs.readFileSync(candidate, "utf8"));
-      if (candidateManifest.name === "@huggingface/tokenizers") {
-        peerManifestPath = candidate;
-        break;
-      }
-    }
-    peerPackageDir = path.dirname(peerPackageDir);
-  }
-  if (!peerManifestPath) {
+  const peerManifestPath = path.join(
+    consumer,
+    "node_modules",
+    "@huggingface",
+    "tokenizers",
+    "package.json"
+  );
+  if (!fs.existsSync(peerManifestPath)) {
     throw new Error("Packed test could not locate the optional peer manifest.");
   }
   const originalPeerManifest = fs.readFileSync(peerManifestPath, "utf8");
   const parsedPeerManifest = JSON.parse(originalPeerManifest);
+  if (parsedPeerManifest.name !== "@huggingface/tokenizers") {
+    throw new Error("Packed test located an unexpected optional peer manifest.");
+  }
+  const peerRequireTarget = parsedPeerManifest.exports?.["."]?.node?.require;
+  if (typeof peerRequireTarget !== "string") {
+    throw new Error("Packed test could not locate the optional peer CJS entry.");
+  }
+  const peerEntry = path.resolve(
+    path.dirname(peerManifestPath),
+    peerRequireTarget
+  );
+  if (!fs.existsSync(peerEntry)) {
+    throw new Error("Packed test optional peer CJS entry does not exist.");
+  }
   try {
     fs.writeFileSync(
       peerManifestPath,

--- a/src/.summary_long.md
+++ b/src/.summary_long.md
@@ -21,7 +21,10 @@ canonical semantic-revision computation, transactional append-only
 registration, exact alias resolution, synchronous content counting, and
 point-in-time runtime mapping revision inspection. Optional loader and recipe
 values intentionally live on separate package subpaths so importing the root
-never loads the optional tokenizer peer.
+never loads the optional tokenizer peer. Those subpaths expose genai-lite-owned
+injected-peer option types without leaking optional-peer declarations. Root and
+prompting imports also leave js-tiktoken unevaluated until token counting needs
+a verified built-in or legacy tokenizer.
 
 ## Key Components
 ### index.ts

--- a/src/llm/.summary_long.md
+++ b/src/llm/.summary_long.md
@@ -29,10 +29,12 @@ usage provenance, independent `rawContent` and `providerOutput` answer
 accounting, and termination evidence. The deprecated `rawAnswerAccounting`
 field mirrors only the canonical raw-content scope.
 
-`tokenization/` provides hash-verified cl100k/o200k content profiles and
-structural certificate arithmetic. Cloud prepared counts remain unavailable
-without verified framing; llama.cpp uses its active chat-template count
-endpoint and state fingerprints.
+`tokenization/` provides lazy, literal-loaded, defensively snapshotted
+hash-verified cl100k/o200k content profiles and structural certificate
+arithmetic. Rank/runtime failures become unavailable evidence rather than
+escaping through capabilities or response processing. Cloud prepared counts
+remain unavailable without verified framing; llama.cpp uses its active
+chat-template count endpoint and state fingerprints.
 
 It also provides a separate generic content-profile layer. Built-in profiles
 remain exact; registered synchronous backends are model-quality and are bound
@@ -42,7 +44,8 @@ answer accounting is missing, without disturbing provider-output evidence.
 Optional recipe loading and artifact I/O stay outside the service and may finish
 during startup or a later model-install workflow. Reads are point-in-time
 snapshots and do not close registration; successful profile identities remain
-immutable.
+immutable. The loader accepts either its existing installed optional peer or a
+statically imported peer namespace with a validated caller-asserted version.
 
 ## Key Components
 ### LLMService.ts

--- a/src/llm/LLMService.contentProfiles.failure.test.ts
+++ b/src/llm/LLMService.contentProfiles.failure.test.ts
@@ -1,0 +1,75 @@
+import type { LLMResponse } from "./types";
+
+const O200K_RANK_MODULE = "js-tiktoken/ranks/o200k_base";
+
+afterEach(() => {
+  jest.resetModules();
+  jest.dontMock(O200K_RANK_MODULE);
+  jest.restoreAllMocks();
+});
+
+describe("LLMService built-in content-tokenizer failure", () => {
+  it("degrades capability and response accounting when rank loading fails", async () => {
+    jest.doMock(O200K_RANK_MODULE, () => {
+      throw new Error("simulated bundled rank failure");
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { LLMService } = require("./LLMService") as
+        typeof import("./LLMService");
+      const { OpenAIClientAdapter } = require(
+        "./clients/OpenAIClientAdapter"
+      ) as typeof import("./clients/OpenAIClientAdapter");
+      const providerResponse: LLMResponse = {
+        id: "rank-failure-response",
+        object: "chat.completion",
+        created: 1,
+        model: "gpt-5.1",
+        provider: "openai",
+        choices: [{
+          index: 0,
+          message: { role: "assistant", content: "answer" },
+          finish_reason: "stop",
+          answerAccounting: {
+            providerOutput: {
+              tokens: 9,
+              method: "exact",
+              source: "provider",
+              reasoning: "unknown",
+            },
+          },
+        }],
+      };
+      jest.spyOn(OpenAIClientAdapter.prototype, "sendPrepared")
+        .mockResolvedValue(providerResponse);
+      const service = new LLMService(
+        async () => "sk-test-key-12345678901234567890",
+        { logLevel: "silent" }
+      );
+
+      await expect(
+        service.getModelCapabilities("openai", "gpt-5.1")
+      ).resolves.toMatchObject({
+        capabilities: { contentTokenCounting: "unavailable" },
+      });
+
+      const response = await service.sendMessage({
+        providerId: "openai",
+        modelId: "gpt-5.1",
+        messages: [{ role: "user", content: "question" }],
+      });
+      expect(response.object).toBe("chat.completion");
+      if (response.object === "chat.completion") {
+        expect(response.choices[0].answerAccounting).toEqual({
+          providerOutput: {
+            tokens: 9,
+            method: "exact",
+            source: "provider",
+            reasoning: "unknown",
+          },
+        });
+        expect(response.choices[0].rawAnswerAccounting).toBeUndefined();
+      }
+    });
+  });
+});

--- a/src/llm/tokenization/.summary_long.md
+++ b/src/llm/tokenization/.summary_long.md
@@ -1,9 +1,12 @@
 # Tokenization Architecture
 
 The tokenization directory separates content point counts from fully prepared
-message accounting. Profiles are available only when bundled js-tiktoken rank
-data matches pinned SHA-256 revisions and proves all 256 byte values are
-ordinary tokens. Model-to-profile mapping has its own revision.
+message accounting. Profiles lazily load statically visible js-tiktoken rank
+modules and are available only when a defensive snapshot matches pinned
+SHA-256 revisions and proves all 256 byte values are ordinary tokens. Rank,
+lite-runtime, constructor, and encode failures return unavailable evidence
+rather than escaping. Model-to-profile mapping has its own revision, and
+built-in IDs remain reserved independently of artifact availability.
 
 `countTextTokens()` treats special-token literals as ordinary text and returns
 exact evidence for verified profiles. `estimateTextTokens()` is explicitly
@@ -19,13 +22,16 @@ A parallel content-profile registry exposes the built-ins as exact profiles and
 accepts arbitrary synchronous host backends as model-quality profiles.
 Registration is transactional and append-only; reads do not close it, while
 existing backend IDs and exact case-sensitive aliases remain immutable.
-Canonical semantic provenance, optional runtime package provenance, and a
-deterministic point-in-time mapping revision are kept distinct from the
-certified profile identity. Certificate functions reject registered profiles.
+Canonical semantic provenance lives in rank-free `contentProfileIdentity.ts`.
+It, optional runtime package provenance, and a deterministic point-in-time
+mapping revision are kept distinct from the certified profile identity.
+Certificate functions reject registered profiles.
 
-`loader/` dynamically resolves optional peer
-`@huggingface/tokenizers@^0.1.3` only when called. It validates recipes before
-I/O, rehashes every cache use, quarantines corrupt blobs, atomically publishes
-downloads, strips special added-token recognition for ordinary-text parity, and
-runs fixed self-tests. `recipes/` stays peer-free and ships the Gemma 4 IT
-recipe without tokenizer artifact bytes.
+`loader/` accepts a caller-injected `@huggingface/tokenizers` namespace plus
+validated asserted version, or dynamically discovers
+`@huggingface/tokenizers@^0.1.3` only when injection is omitted. It validates
+recipes before I/O, rehashes every cache use, quarantines corrupt blobs,
+atomically publishes downloads, strips special added-token recognition for
+ordinary-text parity, and runs fixed self-tests. `recipes/` stays peer-free and
+ships the Gemma 4 IT recipe without tokenizer artifact bytes; both subpaths use
+the rank-free semantic identity module.

--- a/src/llm/tokenization/.summary_short.md
+++ b/src/llm/tokenization/.summary_short.md
@@ -7,10 +7,12 @@ local loader, and peer-free recipes.
 ## Files
 
 - `types.ts`: Profile, resolution, count, and bound result types.
-- `profiles.ts`: Hash-verified cl100k/o200k profiles, model mapping, exact content counting, and explicit heuristic estimation.
-- `contentProfiles.ts`: Transactional append-only registry, canonical semantic revisions, exact aliases, model-quality callbacks, and deterministic snapshot mapping provenance.
+- `profiles.ts`: Lazy literal rank loading, defensive hash-verified cl100k/o200k snapshots, lite-runtime exact counting, fail-closed resolution, model mapping, and explicit heuristic estimation.
+- `contentProfileIdentity.ts`: Rank-free canonical semantic provenance and stable revision computation shared by registries, recipes, and the loader.
+- `contentProfiles.ts`: Transactional append-only registry, exact aliases, model-quality callbacks, built-in ID reservation, and deterministic snapshot mapping provenance.
 - `bounds.ts`: Safe-integer certificate arithmetic for retokenization and Unicode code-point bounds.
-- `loader/`: Optional-peer artifact loader with hash-verified atomic caching, no-special sanitization, runtime-version validation, and self-tests.
+- `loader/`: Installed or caller-injected optional-peer artifact loader with hash-verified atomic caching, no-special sanitization, runtime-version validation, and self-tests.
 - `recipes/`: Peer-free recipe schema and immutable Gemma 4 IT recipe/coverage evidence.
 - `index.ts`: Public tokenization barrel.
 - `tokenization.test.ts`: Hash, adversarial text, decoded-token, overflow, exact-zero-margin, and numeric double-margin tests.
+- `profiles.failure.test.ts`: Isolated rank/runtime failure, terminal-cache, defensive-snapshot, and built-in-ID reservation regressions.

--- a/src/llm/tokenization/contentProfileIdentity.ts
+++ b/src/llm/tokenization/contentProfileIdentity.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import type {
+  ContentTokenizerSemanticArtifact,
+  ContentTokenizerSemanticProvenance,
+} from "./types";
+
+const SEMANTIC_REVISION_DOMAIN =
+  "genai-lite-content-token-profile-semantic-v1\u0000";
+const TEXT_POLICY = "ordinary-text-no-specials-v1" as const;
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,127}$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[]
+): boolean {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length &&
+    actual.every((key, index) => key === wanted[index]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function compareCanonicalStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function assertIdentifier(value: unknown, name: string): asserts value is string {
+  if (typeof value !== "string" || !IDENTIFIER_PATTERN.test(value)) {
+    throw new TypeError(
+      `${name} must be a nonempty canonical identifier of at most 128 characters.`
+    );
+  }
+}
+
+export function canonicalizeContentTokenizerSemanticProvenance(
+  value: unknown
+): ContentTokenizerSemanticProvenance {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "tokenizerImplementation",
+      "textPolicy",
+      "artifacts",
+    ])
+  ) {
+    throw new TypeError(
+      "provenance.semantic must contain exactly tokenizerImplementation, textPolicy, and artifacts."
+    );
+  }
+  assertIdentifier(
+    value.tokenizerImplementation,
+    "provenance.semantic.tokenizerImplementation"
+  );
+  if (value.textPolicy !== TEXT_POLICY) {
+    throw new TypeError(
+      `provenance.semantic.textPolicy must be '${TEXT_POLICY}'.`
+    );
+  }
+  if (!Array.isArray(value.artifacts)) {
+    throw new TypeError("provenance.semantic.artifacts must be an array.");
+  }
+
+  const seenRoles = new Set<string>();
+  const artifacts: ContentTokenizerSemanticArtifact[] = value.artifacts.map(
+    (artifact, index) => {
+      if (
+        !isRecord(artifact) ||
+        !hasExactKeys(artifact, ["role", "sha256"])
+      ) {
+        throw new TypeError(
+          `provenance.semantic.artifacts[${index}] must contain exactly role and sha256.`
+        );
+      }
+      assertIdentifier(
+        artifact.role,
+        `provenance.semantic.artifacts[${index}].role`
+      );
+      if (
+        typeof artifact.sha256 !== "string" ||
+        !SHA256_PATTERN.test(artifact.sha256)
+      ) {
+        throw new TypeError(
+          `provenance.semantic.artifacts[${index}].sha256 must be a lowercase SHA-256 digest.`
+        );
+      }
+      if (seenRoles.has(artifact.role)) {
+        throw new TypeError(
+          `provenance.semantic artifact role '${artifact.role}' is duplicated.`
+        );
+      }
+      seenRoles.add(artifact.role);
+      return Object.freeze({
+        role: artifact.role,
+        sha256: artifact.sha256,
+      });
+    }
+  );
+  artifacts.sort((left, right) =>
+    compareCanonicalStrings(left.role, right.role)
+  );
+  return Object.freeze({
+    tokenizerImplementation: value.tokenizerImplementation,
+    textPolicy: TEXT_POLICY,
+    artifacts: Object.freeze(artifacts) as unknown as ContentTokenizerSemanticArtifact[],
+  });
+}
+
+function semanticRevisionInput(
+  provenance: ContentTokenizerSemanticProvenance
+): string {
+  return JSON.stringify({
+    tokenizerImplementation: provenance.tokenizerImplementation,
+    textPolicy: provenance.textPolicy,
+    artifacts: provenance.artifacts.map(({ role, sha256 }) => ({
+      role,
+      sha256,
+    })),
+  });
+}
+
+/**
+ * Computes the stable semantic identity for a content-tokenizer backend.
+ * Runtime package details, aliases, cache paths, and callbacks are excluded.
+ */
+export function computeContentTokenizerSemanticRevision(
+  provenance: ContentTokenizerSemanticProvenance
+): string {
+  const canonical = canonicalizeContentTokenizerSemanticProvenance(provenance);
+  return createHash("sha256")
+    .update(SEMANTIC_REVISION_DOMAIN)
+    .update(semanticRevisionInput(canonical))
+    .digest("hex");
+}

--- a/src/llm/tokenization/contentProfiles.ts
+++ b/src/llm/tokenization/contentProfiles.ts
@@ -2,9 +2,15 @@ import { createHash } from "node:crypto";
 import type { ApiProviderId, PreparedPromptTokenCount } from "../types";
 import {
   countTextTokens,
+  getBuiltinTokenProfileUnavailableReason,
   getMappedTokenProfileId,
   getTokenProfileById,
+  isBuiltinTokenProfileId,
 } from "./profiles";
+import {
+  canonicalizeContentTokenizerSemanticProvenance,
+  computeContentTokenizerSemanticRevision,
+} from "./contentProfileIdentity";
 import {
   TOKEN_PROFILE_MAPPING_REVISION,
   type ContentTokenProfile,
@@ -13,19 +19,16 @@ import {
   type ContentTokenProfileResolution,
   type ContentTokenizerBackendProvenance,
   type ContentTokenizerRuntimeProvenance,
-  type ContentTokenizerSemanticArtifact,
-  type ContentTokenizerSemanticProvenance,
   type RegisteredContentTokenizerBackend,
   type TokenCountResult,
+  type TokenProfileId,
 } from "./types";
 
-const SEMANTIC_REVISION_DOMAIN =
-  "genai-lite-content-token-profile-semantic-v1\u0000";
+export { computeContentTokenizerSemanticRevision };
+
 const MAPPING_REVISION_DOMAIN =
   "genai-lite-content-token-mapping-v1\u0000";
-const TEXT_POLICY = "ordinary-text-no-specials-v1" as const;
 const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,127}$/;
-const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 const PACKAGE_NAME_PATTERN =
   /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
 const SEMVER_PATTERN =
@@ -80,79 +83,6 @@ function assertCanonicalString(
   ) {
     throw new TypeError(`${name} must be a nonempty canonical string.`);
   }
-}
-
-function canonicalizeSemanticProvenance(
-  value: unknown
-): ContentTokenizerSemanticProvenance {
-  if (
-    !isRecord(value) ||
-    !hasExactKeys(value, [
-      "tokenizerImplementation",
-      "textPolicy",
-      "artifacts",
-    ])
-  ) {
-    throw new TypeError(
-      "provenance.semantic must contain exactly tokenizerImplementation, textPolicy, and artifacts."
-    );
-  }
-  assertIdentifier(
-    value.tokenizerImplementation,
-    "provenance.semantic.tokenizerImplementation"
-  );
-  if (value.textPolicy !== TEXT_POLICY) {
-    throw new TypeError(
-      `provenance.semantic.textPolicy must be '${TEXT_POLICY}'.`
-    );
-  }
-  if (!Array.isArray(value.artifacts)) {
-    throw new TypeError("provenance.semantic.artifacts must be an array.");
-  }
-
-  const seenRoles = new Set<string>();
-  const artifacts: ContentTokenizerSemanticArtifact[] = value.artifacts.map(
-    (artifact, index) => {
-      if (
-        !isRecord(artifact) ||
-        !hasExactKeys(artifact, ["role", "sha256"])
-      ) {
-        throw new TypeError(
-          `provenance.semantic.artifacts[${index}] must contain exactly role and sha256.`
-        );
-      }
-      assertIdentifier(
-        artifact.role,
-        `provenance.semantic.artifacts[${index}].role`
-      );
-      if (
-        typeof artifact.sha256 !== "string" ||
-        !SHA256_PATTERN.test(artifact.sha256)
-      ) {
-        throw new TypeError(
-          `provenance.semantic.artifacts[${index}].sha256 must be a lowercase SHA-256 digest.`
-        );
-      }
-      if (seenRoles.has(artifact.role)) {
-        throw new TypeError(
-          `provenance.semantic artifact role '${artifact.role}' is duplicated.`
-        );
-      }
-      seenRoles.add(artifact.role);
-      return Object.freeze({
-        role: artifact.role,
-        sha256: artifact.sha256,
-      });
-    }
-  );
-  artifacts.sort((left, right) =>
-    compareCanonicalStrings(left.role, right.role)
-  );
-  return Object.freeze({
-    tokenizerImplementation: value.tokenizerImplementation,
-    textPolicy: TEXT_POLICY,
-    artifacts: Object.freeze(artifacts) as unknown as ContentTokenizerSemanticArtifact[],
-  });
 }
 
 function canonicalizeRuntimeProvenance(
@@ -211,38 +141,13 @@ function canonicalizeProvenance(
       "provenance must contain exactly semantic and optional runtime."
     );
   }
-  const semantic = canonicalizeSemanticProvenance(value.semantic);
+  const semantic = canonicalizeContentTokenizerSemanticProvenance(
+    value.semantic
+  );
   const runtime = value.runtime === undefined
     ? undefined
     : canonicalizeRuntimeProvenance(value.runtime);
   return Object.freeze(runtime ? { semantic, runtime } : { semantic });
-}
-
-function semanticRevisionInput(
-  provenance: ContentTokenizerSemanticProvenance
-): string {
-  return JSON.stringify({
-    tokenizerImplementation: provenance.tokenizerImplementation,
-    textPolicy: provenance.textPolicy,
-    artifacts: provenance.artifacts.map(({ role, sha256 }) => ({
-      role,
-      sha256,
-    })),
-  });
-}
-
-/**
- * Computes the stable semantic identity for a content-tokenizer backend.
- * Runtime package details, aliases, cache paths, and callbacks are excluded.
- */
-export function computeContentTokenizerSemanticRevision(
-  provenance: ContentTokenizerSemanticProvenance
-): string {
-  const canonical = canonicalizeSemanticProvenance(provenance);
-  return createHash("sha256")
-    .update(SEMANTIC_REVISION_DOMAIN)
-    .update(semanticRevisionInput(canonical))
-    .digest("hex");
 }
 
 function aliasKey(providerId: ApiProviderId, modelId: string): string {
@@ -250,7 +155,7 @@ function aliasKey(providerId: ApiProviderId, modelId: string): string {
 }
 
 function toBuiltinContentProfile(
-  id: "cl100k_base" | "o200k_base"
+  id: TokenProfileId
 ): ContentTokenProfile | undefined {
   const certified = getTokenProfileById(id);
   if (!certified) {
@@ -300,7 +205,7 @@ export class ContentTokenProfileRegistry {
         const canonical = this.validateBackend(backend);
         if (
           nextBackends.has(canonical.profile.id) ||
-          getTokenProfileById(canonical.profile.id as "cl100k_base" | "o200k_base")
+          isBuiltinTokenProfileId(canonical.profile.id)
         ) {
           throw new Error(
             `Content-token profile id '${canonical.profile.id}' is already registered.`
@@ -352,13 +257,13 @@ export class ContentTokenProfileRegistry {
         provider: providerId,
         model: modelId,
         mappingRevision,
-        reason: `Tokenizer rank data for '${builtinId}' did not match its pinned revision.`,
+        reason: getBuiltinTokenProfileUnavailableReason(builtinId),
       };
     }
 
     const alias = this._state.aliases.get(aliasKey(providerId, modelId));
     const builtinAliasProfile = alias &&
-      (alias.profileId === "cl100k_base" || alias.profileId === "o200k_base")
+      isBuiltinTokenProfileId(alias.profileId)
       ? toBuiltinContentProfile(alias.profileId)
       : undefined;
     const profile = alias
@@ -383,7 +288,7 @@ export class ContentTokenProfileRegistry {
   }
 
   getById(profileId: string): ContentTokenProfile | undefined {
-    if (profileId === "cl100k_base" || profileId === "o200k_base") {
+    if (isBuiltinTokenProfileId(profileId)) {
       return toBuiltinContentProfile(profileId);
     }
     return this._state.backends.get(profileId)?.profile;
@@ -413,7 +318,7 @@ export class ContentTokenProfileRegistry {
     }
 
     if (profile.origin === "builtin" && profile.quality === "exact") {
-      if (profile.id !== "cl100k_base" && profile.id !== "o200k_base") {
+      if (!isBuiltinTokenProfileId(profile.id)) {
         return {
           status: "unavailable",
           reason: `Built-in content-token profile '${profile.id}' is unavailable.`,
@@ -566,10 +471,9 @@ export class ContentTokenProfileRegistry {
     assertIdentifier(alias.providerId, "alias.providerId");
     assertCanonicalString(alias.modelId, "alias.modelId");
     assertIdentifier(alias.profileId, "alias.profileId");
-    const targetIsBuiltin =
-      alias.profileId === "cl100k_base" || alias.profileId === "o200k_base"
-        ? Boolean(getTokenProfileById(alias.profileId))
-        : false;
+    const targetIsBuiltin = isBuiltinTokenProfileId(alias.profileId)
+      ? Boolean(getTokenProfileById(alias.profileId))
+      : false;
     if (!backends.has(alias.profileId) && !targetIsBuiltin) {
       throw new Error(
         `Content-token alias '${alias.providerId}/${alias.modelId}' targets unknown profile '${alias.profileId}'.`

--- a/src/llm/tokenization/index.ts
+++ b/src/llm/tokenization/index.ts
@@ -23,13 +23,13 @@ export {
   resolveTokenProfile,
 } from "./profiles";
 export {
-  computeContentTokenizerSemanticRevision,
   countContentTextTokens,
   getContentTokenProfileById,
   getContentTokenProfileMappingRevision,
   registerContentTokenProfileConfiguration,
   resolveContentTokenProfile,
 } from "./contentProfiles";
+export { computeContentTokenizerSemanticRevision } from "./contentProfileIdentity";
 export {
   codePointBoundToTokenUpperBound,
   retokenizationUpperBound,

--- a/src/llm/tokenization/loader/index.ts
+++ b/src/llm/tokenization/loader/index.ts
@@ -11,12 +11,19 @@ import { dirname, join, parse, resolve } from "node:path";
 import { createRequire } from "node:module";
 import {
   computeContentTokenizerSemanticRevision,
-} from "../contentProfiles";
+} from "../contentProfileIdentity";
 import type { RegisteredContentTokenizerBackend } from "../types";
 import type {
+  ContentTokenizerPeer,
   ContentTokenizerRecipe,
   ContentTokenizerRecipeArtifact,
   ContentTokenizerRecipeSelfTestName,
+  LoadContentTokenizerProfileOptions,
+} from "../recipes/types";
+
+export type {
+  ContentTokenizerPeer,
+  ContentTokenizerRuntimeModule,
   LoadContentTokenizerProfileOptions,
 } from "../recipes/types";
 
@@ -719,7 +726,51 @@ async function findPeerPackageVersion(entryPath: string): Promise<string> {
   );
 }
 
-async function resolvePeer(): Promise<ResolvedPeer> {
+function validateTokenizerModule(
+  value: unknown,
+  source: "installed" | "injected"
+): TokenizerModule {
+  const candidate = isRecord(value) && typeof value.Tokenizer !== "function"
+    ? value.default
+    : value;
+  if (
+    !isRecord(candidate) ||
+    typeof candidate.Tokenizer !== "function"
+  ) {
+    throw loaderError(
+      "TOKENIZER_LOAD_FAILED",
+      `The ${source} ${OPTIONAL_PEER} runtime does not export Tokenizer.`
+    );
+  }
+  return candidate as unknown as TokenizerModule;
+}
+
+function resolveInjectedPeer(peer: ContentTokenizerPeer): ResolvedPeer {
+  if (
+    !isRecord(peer) ||
+    !hasExactKeys(peer, ["module", "packageVersion"])
+  ) {
+    throw loaderError(
+      "TOKENIZER_RECIPE_INVALID",
+      "options.tokenizersPeer must contain exactly module and packageVersion."
+    );
+  }
+  if (
+    typeof peer.packageVersion !== "string" ||
+    !isSupportedPeerVersion(peer.packageVersion)
+  ) {
+    throw loaderError(
+      "TOKENIZER_PEER_VERSION_UNSUPPORTED",
+      `Injected ${OPTIONAL_PEER} runtime version '${String(peer.packageVersion)}' is unsupported; provide ${OPTIONAL_PEER}@${OPTIONAL_PEER_RANGE}.`
+    );
+  }
+  return {
+    module: validateTokenizerModule(peer.module, "injected"),
+    version: peer.packageVersion,
+  };
+}
+
+async function resolveInstalledPeer(): Promise<ResolvedPeer> {
   const localRequire = createRequire(__filename);
   let entryPath: string;
   try {
@@ -750,17 +801,8 @@ async function resolvePeer(): Promise<ResolvedPeer> {
       error
     );
   }
-  if (
-    !isRecord(loaded) ||
-    typeof loaded.Tokenizer !== "function"
-  ) {
-    throw loaderError(
-      "TOKENIZER_LOAD_FAILED",
-      `The installed ${OPTIONAL_PEER} runtime does not export Tokenizer.`
-    );
-  }
   return {
-    module: loaded as unknown as TokenizerModule,
+    module: validateTokenizerModule(loaded, "installed"),
     version,
   };
 }
@@ -799,8 +841,9 @@ function initializeTokenizer(
       error
     );
   }
+  let tokenizer: unknown;
   try {
-    return new Tokenizer(sanitizeTokenizerJson(parsed), {});
+    tokenizer = new Tokenizer(sanitizeTokenizerJson(parsed), {});
   } catch (error) {
     if (error instanceof ContentTokenizerLoaderError) {
       throw error;
@@ -811,13 +854,35 @@ function initializeTokenizer(
       error
     );
   }
+  if (!isRecord(tokenizer) || typeof tokenizer.encode !== "function") {
+    throw loaderError(
+      "TOKENIZER_LOAD_FAILED",
+      "The tokenizer runtime did not create an instance with an encode method."
+    );
+  }
+  return tokenizer as unknown as TokenizerInstance;
 }
 
 function countOrdinaryText(
   tokenizer: TokenizerInstance,
   text: string
 ): number {
-  const encoding = tokenizer.encode(text, { add_special_tokens: false });
+  let encoding: unknown;
+  try {
+    encoding = tokenizer.encode(text, { add_special_tokens: false });
+  } catch (error) {
+    throw loaderError(
+      "TOKENIZER_LOAD_FAILED",
+      "The tokenizer runtime failed to encode ordinary text.",
+      error
+    );
+  }
+  if (!isRecord(encoding) || !Array.isArray(encoding.ids)) {
+    throw loaderError(
+      "TOKENIZER_LOAD_FAILED",
+      "The tokenizer runtime returned an invalid encoding result."
+    );
+  }
   const count = encoding.ids.length;
   if (!Number.isSafeInteger(count) || count < 0) {
     throw new Error(
@@ -842,6 +907,34 @@ function runSelfTests(
   }
 }
 
+function validateLoaderOptions(
+  value: unknown
+): LoadContentTokenizerProfileOptions {
+  const allowedKeys = new Set([
+    "allowDownload",
+    "cacheDir",
+    "signal",
+    "tokenizersPeer",
+  ]);
+  if (
+    !isRecord(value) ||
+    !Object.prototype.hasOwnProperty.call(value, "allowDownload") ||
+    !Object.prototype.hasOwnProperty.call(value, "cacheDir") ||
+    Object.keys(value).some((key) => !allowedKeys.has(key)) ||
+    typeof value.cacheDir !== "string" ||
+    value.cacheDir.length === 0 ||
+    typeof value.allowDownload !== "boolean" ||
+    (value.signal !== undefined && !(value.signal instanceof AbortSignal)) ||
+    (value.tokenizersPeer !== undefined && !isRecord(value.tokenizersPeer))
+  ) {
+    throw loaderError(
+      "TOKENIZER_RECIPE_INVALID",
+      "Loader options must contain cacheDir, allowDownload, and only optional signal and tokenizersPeer."
+    );
+  }
+  return value as unknown as LoadContentTokenizerProfileOptions;
+}
+
 /**
  * Provisions and verifies an explicit recipe, then returns a synchronous local
  * model-quality backend. Ordinary counting performs no I/O or dynamic import.
@@ -851,28 +944,16 @@ export async function loadContentTokenizerProfile(
   options: LoadContentTokenizerProfileOptions
 ): Promise<RegisteredContentTokenizerBackend> {
   const validated = validateRecipe(recipe);
-  if (
-    !isRecord(options) ||
-    !hasExactKeys(
-      options,
-      options.signal === undefined
-        ? ["allowDownload", "cacheDir"]
-        : ["allowDownload", "cacheDir", "signal"]
-    ) ||
-    typeof options.cacheDir !== "string" ||
-    options.cacheDir.length === 0 ||
-    typeof options.allowDownload !== "boolean" ||
-    (options.signal !== undefined && !(options.signal instanceof AbortSignal))
-  ) {
-    throw loaderError(
-      "TOKENIZER_RECIPE_INVALID",
-      "Loader options must contain cacheDir, allowDownload, and optional signal."
-    );
-  }
-  assertNotAborted(options.signal);
-  const { module, version } = await resolvePeer();
-  const artifact = await provisionArtifact(validated.artifacts[0], options);
-  assertNotAborted(options.signal);
+  const validatedOptions = validateLoaderOptions(options);
+  assertNotAborted(validatedOptions.signal);
+  const { module, version } = validatedOptions.tokenizersPeer !== undefined
+    ? resolveInjectedPeer(validatedOptions.tokenizersPeer)
+    : await resolveInstalledPeer();
+  const artifact = await provisionArtifact(
+    validated.artifacts[0],
+    validatedOptions
+  );
+  assertNotAborted(validatedOptions.signal);
   const tokenizer = initializeTokenizer(module.Tokenizer, artifact);
   runSelfTests(tokenizer, validated.recipe);
   const semanticArtifacts = validated.artifacts.map(({ role, sha256 }) =>

--- a/src/llm/tokenization/loader/tokenizerLoader.test.ts
+++ b/src/llm/tokenization/loader/tokenizerLoader.test.ts
@@ -2,10 +2,12 @@ import { createHash } from "node:crypto";
 import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { computeContentTokenizerSemanticRevision } from "../contentProfiles";
+import { computeContentTokenizerSemanticRevision } from "../contentProfileIdentity";
 import type {
+  ContentTokenizerPeer,
   ContentTokenizerRecipe,
   ContentTokenizerRecipeSelfTest,
+  LoadContentTokenizerProfileOptions,
 } from "../recipes/types";
 import {
   ContentTokenizerLoaderError,
@@ -70,6 +72,22 @@ const SELF_TESTS: ContentTokenizerRecipeSelfTest[] = [
     expectedTokens: 3,
   },
 ];
+
+const FIXTURE_COUNTS = new Map(
+  SELF_TESTS.map(({ text, expectedTokens }) => [text, expectedTokens])
+);
+
+class InjectedFixtureTokenizer {
+  encode(text: string): { ids: number[] } {
+    const count = FIXTURE_COUNTS.get(text) ?? (text === "hello" ? 1 : 0);
+    return { ids: Array.from({ length: count }, (_, index) => index) };
+  }
+}
+
+const INJECTED_PEER: ContentTokenizerPeer = Object.freeze({
+  module: Object.freeze({ Tokenizer: InjectedFixtureTokenizer }),
+  packageVersion: "0.1.3",
+});
 
 function createRecipe(
   overrides: Partial<ContentTokenizerRecipe> = {}
@@ -159,6 +177,146 @@ describe("optional content-tokenizer loader", () => {
     expect(backend.countTextTokens("hello world")).toBe(2);
     expect(backend.countTextTokens("<special>")).toBe(3);
     expect(backend.countTextTokens("hello")).toBe(1);
+  });
+
+  it("loads a warm cache through an injected peer with asserted provenance", async () => {
+    await seedCache(cacheDir);
+    const backend = await loadContentTokenizerProfile(createRecipe(), {
+      cacheDir,
+      allowDownload: false,
+      tokenizersPeer: INJECTED_PEER,
+    });
+
+    expect(backend.provenance.runtime).toMatchObject({
+      packageName: "@huggingface/tokenizers",
+      packageVersion: "0.1.3",
+    });
+    expect(backend.countTextTokens("hello world")).toBe(2);
+    expect(backend.countTextTokens("<special>")).toBe(3);
+  });
+
+  it("accepts every signal and injected-peer option combination", async () => {
+    await seedCache(cacheDir);
+    const signal = new AbortController().signal;
+    for (const optionals of [
+      {},
+      { signal },
+      { tokenizersPeer: INJECTED_PEER },
+      { signal, tokenizersPeer: INJECTED_PEER },
+    ]) {
+      const options: LoadContentTokenizerProfileOptions = {
+        cacheDir,
+        allowDownload: false,
+        ...optionals,
+      };
+      await expect(
+        loadContentTokenizerProfile(createRecipe(), options)
+      ).resolves.toMatchObject({ id: "synthetic-tokenizer" });
+    }
+  });
+
+  it("rejects malformed injected peers with precise loader errors", async () => {
+    for (const packageVersion of ["0.2.0", "not-semver"]) {
+      await expect(
+        loadContentTokenizerProfile(createRecipe(), {
+          cacheDir,
+          allowDownload: false,
+          tokenizersPeer: {
+            module: INJECTED_PEER.module,
+            packageVersion,
+          },
+        })
+      ).rejects.toMatchObject({
+        code: "TOKENIZER_PEER_VERSION_UNSUPPORTED",
+        message: expect.stringContaining("Injected"),
+      });
+    }
+
+    await expect(
+      loadContentTokenizerProfile(createRecipe(), {
+        cacheDir,
+        allowDownload: false,
+        tokenizersPeer: {
+          module: { Tokenizer: null },
+          packageVersion: "0.1.3",
+        },
+      })
+    ).rejects.toMatchObject({ code: "TOKENIZER_LOAD_FAILED" });
+
+    await expect(
+      loadContentTokenizerProfile(createRecipe(), {
+        cacheDir,
+        allowDownload: false,
+        tokenizersPeer: {
+          ...INJECTED_PEER,
+          extra: true,
+        } as unknown as ContentTokenizerPeer,
+      })
+    ).rejects.toMatchObject({ code: "TOKENIZER_RECIPE_INVALID" });
+  });
+
+  it("maps an injected tokenizer constructor failure", async () => {
+    await seedCache(cacheDir);
+    class FailingTokenizer {
+      constructor() {
+        throw new Error("fixture constructor failure");
+      }
+    }
+    await expect(
+      loadContentTokenizerProfile(createRecipe(), {
+        cacheDir,
+        allowDownload: false,
+        tokenizersPeer: {
+          module: { Tokenizer: FailingTokenizer },
+          packageVersion: "0.1.3",
+        },
+      })
+    ).rejects.toMatchObject({ code: "TOKENIZER_LOAD_FAILED" });
+  });
+
+  it.each([
+    {
+      name: "missing encode method",
+      Tokenizer: class MissingEncodeTokenizer {},
+    },
+    {
+      name: "throwing encode method",
+      Tokenizer: class ThrowingEncodeTokenizer {
+        encode(): never {
+          throw new Error("fixture encode failure");
+        }
+      },
+    },
+    {
+      name: "malformed encoding result",
+      Tokenizer: class MalformedEncodingTokenizer {
+        encode(): object {
+          return {};
+        }
+      },
+    },
+  ])("maps an injected runtime with $name", async ({ Tokenizer }) => {
+    await seedCache(cacheDir);
+    await expect(
+      loadContentTokenizerProfile(createRecipe(), {
+        cacheDir,
+        allowDownload: false,
+        tokenizersPeer: {
+          module: { Tokenizer },
+          packageVersion: "0.1.3",
+        },
+      })
+    ).rejects.toMatchObject({ code: "TOKENIZER_LOAD_FAILED" });
+  });
+
+  it("rejects unknown top-level loader options", async () => {
+    await expect(
+      loadContentTokenizerProfile(createRecipe(), {
+        cacheDir,
+        allowDownload: false,
+        unknown: true,
+      } as unknown as LoadContentTokenizerProfileOptions)
+    ).rejects.toMatchObject({ code: "TOKENIZER_RECIPE_INVALID" });
   });
 
   it("fails late and clearly when an offline artifact is absent", async () => {
@@ -419,6 +577,12 @@ describe("optional content-tokenizer loader", () => {
     const controller = new AbortController();
     controller.abort(new Error("stop"));
     const fetchSpy = jest.spyOn(globalThis, "fetch");
+    const moduleGetter = jest.fn(() => INJECTED_PEER.module);
+    const versionGetter = jest.fn(() => INJECTED_PEER.packageVersion);
+    const injectedPeer = Object.defineProperties({}, {
+      module: { enumerable: true, get: moduleGetter },
+      packageVersion: { enumerable: true, get: versionGetter },
+    }) as ContentTokenizerPeer;
 
     await expect(
       loadContentTokenizerProfile(createRecipe(), {
@@ -427,6 +591,16 @@ describe("optional content-tokenizer loader", () => {
         signal: controller.signal,
       })
     ).rejects.toMatchObject({ code: "TOKENIZER_ABORTED" });
+    await expect(
+      loadContentTokenizerProfile(createRecipe(), {
+        cacheDir,
+        allowDownload: true,
+        signal: controller.signal,
+        tokenizersPeer: injectedPeer,
+      })
+    ).rejects.toMatchObject({ code: "TOKENIZER_ABORTED" });
+    expect(moduleGetter).not.toHaveBeenCalled();
+    expect(versionGetter).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/src/llm/tokenization/profiles.failure.test.ts
+++ b/src/llm/tokenization/profiles.failure.test.ts
@@ -1,0 +1,256 @@
+import type { TokenProfile } from "./types";
+
+const O200K_RANK_MODULE = "js-tiktoken/ranks/o200k_base";
+const CL100K_RANK_MODULE = "js-tiktoken/ranks/cl100k_base";
+const LITE_RUNTIME_MODULE = "js-tiktoken/lite";
+
+interface MutableRankData {
+  pat_str: string;
+  special_tokens: Record<string, number>;
+  bpe_ranks: string;
+}
+
+function asRankData(value: unknown): MutableRankData {
+  const candidate =
+    typeof value === "object" && value !== null && "default" in value
+      ? (value as { default: unknown }).default
+      : value;
+  return candidate as MutableRankData;
+}
+
+afterEach(() => {
+  jest.resetModules();
+  jest.dontMock(O200K_RANK_MODULE);
+  jest.dontMock(CL100K_RANK_MODULE);
+  jest.dontMock(LITE_RUNTIME_MODULE);
+});
+
+describe("built-in token profile failures", () => {
+  it.each([
+    {
+      name: "rank evaluation",
+      moduleFactory: (): never => {
+        throw new Error("consumer bundler dynamic-require stub");
+      },
+    },
+    {
+      name: "rank module shape",
+      moduleFactory: (): object => ({ default: { pat_str: "invalid" } }),
+    },
+    {
+      name: "rank hash",
+      moduleFactory: (): MutableRankData => ({
+        pat_str: ".",
+        special_tokens: {},
+        bpe_ranks: "IQ== 0",
+      }),
+    },
+  ])("fails closed for $name failure", ({ moduleFactory }) => {
+    jest.doMock(O200K_RANK_MODULE, moduleFactory);
+
+    jest.isolateModules(() => {
+      const profiles = require("./profiles") as typeof import("./profiles");
+      const contentProfiles = require("./contentProfiles") as
+        typeof import("./contentProfiles");
+      const bounds = require("./bounds") as typeof import("./bounds");
+
+      expect(() =>
+        profiles.resolveTokenProfile("openai", "gpt-5.1")
+      ).not.toThrow();
+      const resolution = profiles.resolveTokenProfile(
+        "openai",
+        "gpt-5.1"
+      );
+      expect(resolution).toMatchObject({
+        status: "unavailable",
+        reason: expect.stringContaining("could not be loaded and verified"),
+      });
+      if (resolution.status === "unavailable") {
+        expect(resolution.reason).not.toContain("dynamic-require stub");
+      }
+
+      expect(
+        contentProfiles.resolveContentTokenProfile("openai", "gpt-5.1")
+      ).toMatchObject({ status: "unavailable" });
+
+      const forgedProfile = {
+        id: "o200k_base",
+        tokenizerId: "js-tiktoken:o200k_base",
+        revision: "js-tiktoken-1.0.21:o200k:de7eb511338b",
+        encoding: "o200k_base",
+        rankHash:
+          "de7eb511338b0e23589a3cae2dceb8dd66c2a9fd70dbf7ea778fd9df9f175d45",
+        ordinaryTextOnly: true,
+        byteComplete: true,
+        maximumDecodedBytesPerToken: 128,
+      } satisfies TokenProfile;
+      expect(
+        bounds.codePointBoundToTokenUpperBound(10, forgedProfile)
+      ).toMatchObject({ status: "unavailable" });
+
+      const semantic = {
+        tokenizerImplementation: "test-reserved-profile-v1",
+        textPolicy: "ordinary-text-no-specials-v1" as const,
+        artifacts: [{ role: "tokenizer", sha256: "a".repeat(64) }],
+      };
+      const registry = new contentProfiles.ContentTokenProfileRegistry();
+      expect(() =>
+        registry.register({
+          backends: [{
+            id: "o200k_base",
+            tokenizerId: "test:reserved",
+            revision:
+              contentProfiles.computeContentTokenizerSemanticRevision(semantic),
+            provenance: { semantic },
+            countTextTokens: (text: string): number => text.length,
+          }],
+          aliases: [],
+        })
+      ).toThrow(/already registered/);
+    });
+  });
+
+  it("caches a terminal rank failure without retrying module evaluation", () => {
+    let evaluations = 0;
+    jest.doMock(O200K_RANK_MODULE, () => {
+      evaluations += 1;
+      throw new Error("rank evaluation failed");
+    });
+
+    jest.isolateModules(() => {
+      const profiles = require("./profiles") as typeof import("./profiles");
+      expect(profiles.getTokenProfileById("o200k_base")).toBeUndefined();
+      expect(profiles.getTokenProfileById("o200k_base")).toBeUndefined();
+      expect(
+        profiles.resolveTokenProfile("openai", "gpt-5.1")
+      ).toMatchObject({ status: "unavailable" });
+    });
+    expect(evaluations).toBe(1);
+  });
+
+  it.each([
+    ["cl100k_base", CL100K_RANK_MODULE],
+    ["o200k_base", O200K_RANK_MODULE],
+  ] as const)("reserves built-in id %s during rank failure", (
+    profileId,
+    rankModule
+  ) => {
+    jest.doMock(rankModule, () => {
+      throw new Error("rank unavailable");
+    });
+
+    jest.isolateModules(() => {
+      const contentProfiles = require("./contentProfiles") as
+        typeof import("./contentProfiles");
+      const semantic = {
+        tokenizerImplementation: "test-reserved-profile-v1",
+        textPolicy: "ordinary-text-no-specials-v1" as const,
+        artifacts: [{ role: "tokenizer", sha256: "b".repeat(64) }],
+      };
+      const registry = new contentProfiles.ContentTokenProfileRegistry();
+      expect(() =>
+        registry.register({
+          backends: [{
+            id: profileId,
+            tokenizerId: "test:reserved",
+            revision:
+              contentProfiles.computeContentTokenizerSemanticRevision(semantic),
+            provenance: { semantic },
+            countTextTokens: (text: string): number => text.length,
+          }],
+          aliases: [],
+        })
+      ).toThrow(/already registered/);
+    });
+  });
+
+  it("counts from the verified defensive rank snapshot", () => {
+    const fullRuntime = jest.requireActual<typeof import("js-tiktoken")>(
+      "js-tiktoken"
+    );
+    const text = "snapshot mutation regression";
+    const expected = fullRuntime.getEncoding("o200k_base")
+      .encode(text, [], []).length;
+    let mutableRanks: MutableRankData | undefined;
+    jest.doMock(O200K_RANK_MODULE, () => {
+      const actual = asRankData(jest.requireActual(O200K_RANK_MODULE));
+      mutableRanks = {
+        pat_str: actual.pat_str,
+        special_tokens: { ...actual.special_tokens },
+        bpe_ranks: actual.bpe_ranks,
+      };
+      return mutableRanks;
+    });
+
+    jest.isolateModules(() => {
+      const profiles = require("./profiles") as typeof import("./profiles");
+      const profile = profiles.getTokenProfileById("o200k_base");
+      expect(profile).toBeDefined();
+      if (!profile || !mutableRanks) {
+        throw new Error("Expected the mocked o200k profile to resolve.");
+      }
+      mutableRanks.pat_str = "(";
+      mutableRanks.bpe_ranks = "corrupted after verification";
+      mutableRanks.special_tokens["<|endoftext|>"] = 1;
+
+      expect(profiles.countTextTokens(text, profile)).toMatchObject({
+        status: "available",
+        count: { tokens: expected, method: "exact" },
+      });
+    });
+  });
+
+  it.each([
+    {
+      name: "module evaluation",
+      moduleFactory: (): never => {
+        throw new Error("lite evaluation detail must stay internal");
+      },
+    },
+    {
+      name: "module shape",
+      moduleFactory: (): object => ({ default: {} }),
+    },
+    {
+      name: "constructor",
+      moduleFactory: (): object => ({
+        Tiktoken: class {
+          constructor() {
+            throw new Error("constructor detail must stay internal");
+          }
+        },
+      }),
+    },
+    {
+      name: "encode",
+      moduleFactory: (): object => ({
+        Tiktoken: class {
+          encode(): never {
+            throw new Error("encode detail must stay internal");
+          }
+        },
+      }),
+    },
+  ])("returns unavailable evidence for lite runtime $name failure", ({
+    moduleFactory,
+  }) => {
+    jest.doMock(LITE_RUNTIME_MODULE, moduleFactory);
+
+    jest.isolateModules(() => {
+      const profiles = require("./profiles") as typeof import("./profiles");
+      const profile = profiles.getTokenProfileById("o200k_base");
+      expect(profile).toBeDefined();
+      if (!profile) {
+        throw new Error("Expected the real o200k rank data to resolve.");
+      }
+      const result = profiles.countTextTokens("ordinary text", profile);
+      expect(result).toMatchObject({
+        status: "unavailable",
+        reason: expect.stringContaining("failed to count ordinary text"),
+      });
+      if (result.status === "unavailable") {
+        expect(result.reason).not.toContain("must stay internal");
+      }
+    });
+  });
+});

--- a/src/llm/tokenization/profiles.ts
+++ b/src/llm/tokenization/profiles.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { getEncoding, type Tiktoken } from "js-tiktoken";
+import type { Tiktoken, TiktokenBPE } from "js-tiktoken/lite";
 import type { ApiProviderId, PreparedPromptTokenCount } from "../types";
 import {
   TOKEN_PROFILE_MAPPING_REVISION,
@@ -9,22 +9,32 @@ import {
   type TokenProfileResolution,
 } from "./types";
 
-interface RankData {
-  pat_str: string;
-  special_tokens: Record<string, number>;
-  bpe_ranks: string;
+type RankData = TiktokenBPE;
+
+interface TiktokenConstructor {
+  new(
+    ranks: TiktokenBPE,
+    extendedSpecialTokens?: Record<string, number>
+  ): Tiktoken;
+}
+
+interface LiteRuntimeModule {
+  Tiktoken: TiktokenConstructor;
 }
 
 interface ProfileDefinition {
   id: TokenProfileId;
   expectedHash: string;
   revision: string;
-  loadRanks: () => RankData;
+  loadRanks: () => unknown;
 }
 
-function loadRankData(moduleId: string): RankData {
-  const loaded = require(moduleId) as RankData | { default: RankData };
-  return "default" in loaded ? loaded.default : loaded;
+function loadCl100kRanks(): unknown {
+  return require("js-tiktoken/ranks/cl100k_base") as unknown;
+}
+
+function loadO200kRanks(): unknown {
+  return require("js-tiktoken/ranks/o200k_base") as unknown;
 }
 
 const DEFINITIONS: Record<TokenProfileId, ProfileDefinition> = {
@@ -33,19 +43,110 @@ const DEFINITIONS: Record<TokenProfileId, ProfileDefinition> = {
     expectedHash:
       "9b9ea7feb9945beda9196f3691a3cc2d0f339aec498bbae285ce6aded387455c",
     revision: "js-tiktoken-1.0.21:cl100k:9b9ea7feb994",
-    loadRanks: () => loadRankData("js-tiktoken/ranks/cl100k_base"),
+    loadRanks: loadCl100kRanks,
   },
   o200k_base: {
     id: "o200k_base",
     expectedHash:
       "de7eb511338b0e23589a3cae2dceb8dd66c2a9fd70dbf7ea778fd9df9f175d45",
     revision: "js-tiktoken-1.0.21:o200k:de7eb511338b",
-    loadRanks: () => loadRankData("js-tiktoken/ranks/o200k_base"),
+    loadRanks: loadO200kRanks,
   },
 };
 
-const profileCache = new Map<TokenProfileId, TokenProfile | null>();
+const BUILTIN_TOKEN_PROFILE_IDS: ReadonlySet<string> = new Set([
+  "cl100k_base",
+  "o200k_base",
+]);
+
+const profileCache = new Map<TokenProfileId, TokenProfile>();
+const profileFailureCache = new Set<TokenProfileId>();
+const rankCache = new Map<TokenProfileId, RankData>();
 const tokenizerCache = new Map<TokenProfileId, Tiktoken>();
+let liteRuntimeCache: LiteRuntimeModule | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[]
+): boolean {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length &&
+    actual.every((key, index) => key === wanted[index]);
+}
+
+function unwrapDefaultExport(value: unknown): unknown {
+  return isRecord(value) && Object.prototype.hasOwnProperty.call(value, "default")
+    ? value.default
+    : value;
+}
+
+function snapshotRankData(value: unknown): RankData {
+  const ranks = unwrapDefaultExport(value);
+  if (
+    !isRecord(ranks) ||
+    !hasExactKeys(ranks, ["bpe_ranks", "pat_str", "special_tokens"]) ||
+    typeof ranks.pat_str !== "string" ||
+    ranks.pat_str.length === 0 ||
+    typeof ranks.bpe_ranks !== "string" ||
+    ranks.bpe_ranks.length === 0 ||
+    !isRecord(ranks.special_tokens)
+  ) {
+    throw new TypeError("Tokenizer rank module has an invalid shape.");
+  }
+  const specialTokenEntries = Object.entries(ranks.special_tokens);
+  for (const [token, id] of specialTokenEntries) {
+    if (
+      token.length === 0 ||
+      typeof id !== "number" ||
+      !Number.isSafeInteger(id) ||
+      id < 0
+    ) {
+      throw new TypeError("Tokenizer rank module has invalid special tokens.");
+    }
+  }
+  const specialTokens = Object.freeze(
+    Object.fromEntries(specialTokenEntries) as Record<string, number>
+  );
+  return Object.freeze({
+    pat_str: ranks.pat_str,
+    special_tokens: specialTokens,
+    bpe_ranks: ranks.bpe_ranks,
+  });
+}
+
+function loadLiteRuntime(): LiteRuntimeModule {
+  if (liteRuntimeCache) {
+    return liteRuntimeCache;
+  }
+  const loaded = require("js-tiktoken/lite") as unknown;
+  const runtime = unwrapDefaultExport(loaded);
+  if (!isRecord(runtime) || typeof runtime.Tiktoken !== "function") {
+    throw new TypeError("js-tiktoken/lite does not export Tiktoken.");
+  }
+  liteRuntimeCache = Object.freeze({
+    Tiktoken: runtime.Tiktoken as unknown as TiktokenConstructor,
+  });
+  return liteRuntimeCache;
+}
+
+/** Returns whether an ID belongs to the permanently reserved built-in set. */
+export function isBuiltinTokenProfileId(
+  value: string
+): value is TokenProfileId {
+  return BUILTIN_TOKEN_PROFILE_IDS.has(value);
+}
+
+/** Returns the stable public reason for an unavailable built-in profile. */
+export function getBuiltinTokenProfileUnavailableReason(
+  id: TokenProfileId
+): string {
+  return `Tokenizer profile '${id}' is unavailable because its pinned rank data could not be loaded and verified.`;
+}
 
 function hashRankData(ranks: RankData): string {
   return createHash("sha256")
@@ -84,36 +185,46 @@ function deriveRankProperties(
 export function getTokenProfileById(
   id: TokenProfileId
 ): TokenProfile | undefined {
-  if (profileCache.has(id)) {
-    return profileCache.get(id) ?? undefined;
+  const cached = profileCache.get(id);
+  if (cached) {
+    return cached;
+  }
+  if (profileFailureCache.has(id)) {
+    return undefined;
   }
   const definition = DEFINITIONS[id];
   if (!definition) {
     return undefined;
   }
-  const ranks = definition.loadRanks();
-  const rankHash = hashRankData(ranks);
-  const properties = deriveRankProperties(ranks);
-  if (
-    rankHash !== definition.expectedHash ||
-    !properties.byteComplete ||
-    properties.maximumDecodedBytesPerToken <= 0
-  ) {
-    profileCache.set(id, null);
+  try {
+    const ranks = snapshotRankData(definition.loadRanks());
+    const rankHash = hashRankData(ranks);
+    const properties = deriveRankProperties(ranks);
+    if (
+      rankHash !== definition.expectedHash ||
+      !properties.byteComplete ||
+      properties.maximumDecodedBytesPerToken <= 0
+    ) {
+      profileFailureCache.add(id);
+      return undefined;
+    }
+    const profile: TokenProfile = Object.freeze({
+      id,
+      tokenizerId: `js-tiktoken:${id}`,
+      revision: definition.revision,
+      encoding: id,
+      rankHash,
+      ordinaryTextOnly: true,
+      byteComplete: true,
+      maximumDecodedBytesPerToken: properties.maximumDecodedBytesPerToken,
+    });
+    rankCache.set(id, ranks);
+    profileCache.set(id, profile);
+    return profile;
+  } catch {
+    profileFailureCache.add(id);
     return undefined;
   }
-  const profile: TokenProfile = Object.freeze({
-    id,
-    tokenizerId: `js-tiktoken:${id}`,
-    revision: definition.revision,
-    encoding: id,
-    rankHash,
-    ordinaryTextOnly: true,
-    byteComplete: true,
-    maximumDecodedBytesPerToken: properties.maximumDecodedBytesPerToken,
-  });
-  profileCache.set(id, profile);
-  return profile;
 }
 
 export function getMappedTokenProfileId(
@@ -166,7 +277,7 @@ export function resolveTokenProfile(
       model,
       mappingRevision: TOKEN_PROFILE_MAPPING_REVISION,
       reason: id
-        ? `Tokenizer rank data for '${id}' did not match its pinned revision.`
+        ? getBuiltinTokenProfileUnavailableReason(id)
         : `No verified token profile is registered for ${provider}/${model}.`,
     };
   }
@@ -182,7 +293,12 @@ export function resolveTokenProfile(
 function getTokenizer(profile: TokenProfile): Tiktoken {
   let tokenizer = tokenizerCache.get(profile.id);
   if (!tokenizer) {
-    tokenizer = getEncoding(profile.encoding);
+    const ranks = rankCache.get(profile.id);
+    if (!ranks) {
+      throw new Error("Verified tokenizer ranks are unavailable.");
+    }
+    const { Tiktoken: TiktokenRuntime } = loadLiteRuntime();
+    tokenizer = new TiktokenRuntime(ranks);
     tokenizerCache.set(profile.id, tokenizer);
   }
   return tokenizer;
@@ -200,13 +316,24 @@ export function countTextTokens(
       reason: `Token profile '${profile.id}' is not available at revision '${profile.revision}'.`,
     };
   }
-  const count: PreparedPromptTokenCount = {
-    tokens: getTokenizer(current).encode(text, [], []).length,
-    method: "exact",
-    tokenizerId: current.tokenizerId,
-    tokenProfileRevision: current.revision,
-  };
-  return { status: "available", count };
+  try {
+    const tokens = getTokenizer(current).encode(text, [], []).length;
+    if (!Number.isSafeInteger(tokens) || tokens < 0) {
+      throw new Error("Tokenizer returned an invalid count.");
+    }
+    const count: PreparedPromptTokenCount = {
+      tokens,
+      method: "exact",
+      tokenizerId: current.tokenizerId,
+      tokenProfileRevision: current.revision,
+    };
+    return { status: "available", count };
+  } catch {
+    return {
+      status: "unavailable",
+      reason: `Token profile '${profile.id}' failed to count ordinary text.`,
+    };
+  }
 }
 
 /** Explicit generic estimate; never returned as an exact or certified bound. */

--- a/src/llm/tokenization/recipes/gemma4.ts
+++ b/src/llm/tokenization/recipes/gemma4.ts
@@ -1,4 +1,4 @@
-import { computeContentTokenizerSemanticRevision } from "../contentProfiles";
+import { computeContentTokenizerSemanticRevision } from "../contentProfileIdentity";
 import type { ContentTokenizerRecipe } from "./types";
 
 const TOKENIZER_SHA256 =

--- a/src/llm/tokenization/recipes/index.ts
+++ b/src/llm/tokenization/recipes/index.ts
@@ -7,5 +7,7 @@ export type {
   ContentTokenizerRecipeLoaderInput,
   ContentTokenizerRecipeSelfTest,
   ContentTokenizerRecipeSelfTestName,
+  ContentTokenizerPeer,
+  ContentTokenizerRuntimeModule,
   LoadContentTokenizerProfileOptions,
 } from "./types";

--- a/src/llm/tokenization/recipes/recipes.test.ts
+++ b/src/llm/tokenization/recipes/recipes.test.ts
@@ -1,4 +1,4 @@
-import { computeContentTokenizerSemanticRevision } from "../contentProfiles";
+import { computeContentTokenizerSemanticRevision } from "../contentProfileIdentity";
 import { GEMMA_4_IT_CONTENT_TOKENIZER_RECIPE } from "./gemma4";
 
 describe("content-tokenizer recipes", () => {

--- a/src/llm/tokenization/recipes/types.ts
+++ b/src/llm/tokenization/recipes/types.ts
@@ -49,8 +49,34 @@ export interface ContentTokenizerRecipe {
   coverageEvidence: ContentTokenizerCoverageEvidence[];
 }
 
+/**
+ * Minimal genai-lite-owned shape required from an injected tokenizer runtime.
+ * This deliberately avoids optional-peer-owned public declaration types.
+ */
+export interface ContentTokenizerRuntimeModule {
+  /** Runtime constructor; its callable shape is validated by the loader. */
+  readonly Tokenizer: unknown;
+}
+
+/**
+ * Caller-supplied optional peer for bundlers that statically import the module.
+ * `packageVersion` is a caller assertion validated against the supported range.
+ */
+export interface ContentTokenizerPeer {
+  /** Statically imported runtime namespace or compatible structural module. */
+  readonly module: ContentTokenizerRuntimeModule;
+  /** Caller-asserted runtime version, validated against the supported range. */
+  readonly packageVersion: string;
+}
+
+/** Artifact/cache controls and optional runtime injection for recipe loading. */
 export interface LoadContentTokenizerProfileOptions {
+  /** Application-owned tokenizer artifact cache directory. */
   cacheDir: string;
+  /** Whether a missing verified artifact may be downloaded. */
   allowDownload: boolean;
+  /** Cancels peer resolution or artifact provisioning before publication. */
   signal?: AbortSignal;
+  /** Statically supplied optional peer; omission retains installed discovery. */
+  tokenizersPeer?: ContentTokenizerPeer;
 }

--- a/src/llm/tokenization/tokenization.test.ts
+++ b/src/llm/tokenization/tokenization.test.ts
@@ -14,8 +14,16 @@ describe("token profiles and certified structural bounds", () => {
   const o200k = getTokenProfileById("o200k_base")!;
 
   it("loads only hash-verified byte-complete profiles", () => {
-    expect(cl100k.rankHash).toHaveLength(64);
-    expect(o200k.rankHash).toHaveLength(64);
+    expect(cl100k).toMatchObject({
+      rankHash:
+        "9b9ea7feb9945beda9196f3691a3cc2d0f339aec498bbae285ce6aded387455c",
+      revision: "js-tiktoken-1.0.21:cl100k:9b9ea7feb994",
+    });
+    expect(o200k).toMatchObject({
+      rankHash:
+        "de7eb511338b0e23589a3cae2dceb8dd66c2a9fd70dbf7ea778fd9df9f175d45",
+      revision: "js-tiktoken-1.0.21:o200k:de7eb511338b",
+    });
     expect(cl100k.byteComplete).toBe(true);
     expect(o200k.byteComplete).toBe(true);
     expect(cl100k.maximumDecodedBytesPerToken).toBe(128);
@@ -55,6 +63,37 @@ describe("token profiles and certified structural bounds", () => {
       expect(result.count.method).toBe("exact");
       expect(result.count.uncertaintyTokens).toBeUndefined();
       expect(result.count.tokens).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it.each([
+    ["cl100k_base", cl100k],
+    ["o200k_base", o200k],
+  ] as const)("matches the full runtime for %s adversarial fixtures", (
+    encoding,
+    profile
+  ) => {
+    const reference = getEncoding(encoding);
+    const fixtures = [
+      "",
+      "plain ASCII with spaces and\nnewlines",
+      "漢字かなカナ dense script",
+      "e\u0301 versus é",
+      "👨‍👩‍👧‍👦 ✈️ 🧑🏽‍💻",
+      "control \u0000 \u001f text",
+      "<|endoftext|> remains ordinary literal text",
+      "\ud800 lone surrogate",
+      "long ordinary text with punctuation, numbers 12345, and emoji 🧪. "
+        .repeat(2_000),
+    ];
+    for (const text of fixtures) {
+      const result = countTextTokens(text, profile);
+      expect(result.status).toBe("available");
+      if (result.status === "available") {
+        expect(result.count.tokens).toBe(
+          reference.encode(text, [], []).length
+        );
+      }
     }
   });
 

--- a/src/prompting/.summary_long.md
+++ b/src/prompting/.summary_long.md
@@ -6,7 +6,10 @@ The prompting directory provides a comprehensive suite of utilities for advanced
 `content.ts` retains the numeric `countTokens()` contract while routing verified
 cl100k/o200k models through the profile registry. The evidence-bearing APIs and
 certified bounds live in `src/llm/tokenization/`; heuristic fallback remains
-visible only through the legacy wrapper or explicit estimator.
+visible only through the legacy wrapper or explicit estimator. The full
+js-tiktoken model-mapping entry is loaded lazily only for legacy models or when
+a mapped built-in cannot count, so importing the root or prompting subpath does
+not evaluate js-tiktoken.
 
 ## Key Components
 
@@ -83,14 +86,14 @@ This module consolidates content preparation utilities from the original prompt.
 
 ## Architecture & Design
 The module implements several optimization strategies:
-- **Tokenizer Caching**: Reuses tokenizer instances for performance
+- **Tokenizer Caching**: Reuses verified lite and legacy tokenizer instances for performance
 - **Graceful Fallback**: Falls back to character estimation if tokenization fails
 - **Natural Boundaries**: Preview function seeks empty lines for clean truncation
 - **Fisher-Yates Shuffle**: Implements proper randomization for examples
 
 ## Dependencies
-- **Internal**: None
-- **External**: `js-tiktoken` for accurate token counting
+- **Internal**: Verified built-in profiles from `src/llm/tokenization/`
+- **External**: Lazily loaded `js-tiktoken` for accurate legacy-model counting
 
 ## Integration Points
 Used throughout the library for:
@@ -182,7 +185,7 @@ The prompting module follows these principles:
 
 ## Dependencies
 - **Internal**: The parser module depends on LLM types for message structures
-- **External**: Only js-tiktoken for token counting
+- **External**: Lazily loaded js-tiktoken runtime paths for token counting
 
 ## Integration Points
 The prompting module serves as a foundational layer for:

--- a/src/prompting/.summary_short.md
+++ b/src/prompting/.summary_short.md
@@ -7,7 +7,7 @@ Purpose: Contains sophisticated utilities for prompt engineering, including temp
 - `index.ts`: Central export point for all prompting utilities, providing a clean API for template rendering, content preparation, and response parsing.
 - `template.ts`: Implements a sophisticated micro-templating engine with variable substitution, conditional ternary logic, and intelligent newline handling.
 - `template.test.ts`: Comprehensive test suite for the template engine, validating variable substitution, ternary expressions, nested templates, and newline trimming behavior.
-- `content.ts`: Provides the compatible numeric `countTokens` wrapper over verified encoding profiles (with legacy heuristic fallback), smart previews, and random-variable extraction.
+- `content.ts`: Provides the compatible numeric `countTokens` wrapper using lazy verified cl100k/o200k profiles first, lazy full-runtime legacy models second, and the legacy heuristic fallback, plus smart previews and random-variable extraction.
 - `content.test.ts`: Tests content preparation utilities including token counting accuracy across models, smart preview truncation logic, and random variable extraction.
 - `parser.ts`: Provides utilities for parsing structured content from LLM responses using XML-style tags, role tags for message creation, extracting thinking blocks from responses, extracting content between arbitrary open/close markers (extractMarkerDelimitedContent, used for local-model reasoning traces), and parsing template metadata from <META> blocks.
 - `parser.test.ts`: Tests structured content parsing functionality, including tag extraction, handling of missing tags, and multiline content parsing.

--- a/src/prompting/content.test.ts
+++ b/src/prompting/content.test.ts
@@ -5,6 +5,11 @@
 import { countTokens, getSmartPreview, extractRandomVariables } from './content';
 import type { TiktokenModel } from 'js-tiktoken';
 
+afterEach(() => {
+  jest.resetModules();
+  jest.dontMock("js-tiktoken");
+});
+
 describe('Content Utilities', () => {
   describe('countTokens', () => {
     it('should return 0 for empty string', () => {
@@ -31,6 +36,36 @@ describe('Content Utilities', () => {
       
       expect(gpt4Count).toBeGreaterThan(0);
       expect(gpt35Count).toBeGreaterThan(0);
+    });
+
+    it("uses a verified built-in profile before loading the full runtime", () => {
+      let fullRuntimeEvaluations = 0;
+      jest.doMock("js-tiktoken", () => {
+        fullRuntimeEvaluations += 1;
+        throw new Error("full runtime should remain lazy");
+      });
+
+      jest.isolateModules(() => {
+        const isolated = require("./content") as typeof import("./content");
+        expect(isolated.countTokens("mapped model text", "gpt-4"))
+          .toBeGreaterThan(0);
+      });
+      expect(fullRuntimeEvaluations).toBe(0);
+    });
+
+    it("loads the full runtime lazily for a supported legacy model", () => {
+      const encodingForModel = jest.fn(() => ({
+        encode: (): number[] => [1, 2, 3, 4, 5, 6, 7],
+      }));
+      jest.doMock("js-tiktoken", () => ({ encodingForModel }));
+
+      jest.isolateModules(() => {
+        const isolated = require("./content") as typeof import("./content");
+        expect(
+          isolated.countTokens("legacy model text", "text-davinci-003")
+        ).toBe(7);
+      });
+      expect(encodingForModel).toHaveBeenCalledWith("text-davinci-003");
     });
 
     it('should handle special characters and emojis', () => {

--- a/src/prompting/content.ts
+++ b/src/prompting/content.ts
@@ -6,25 +6,47 @@
  * help prepare the "ingredients" that will be used in prompt construction.
  */
 
-import {
-  Tiktoken,
-  encodingForModel,
-  getEncodingNameForModel,
-  TiktokenModel,
-} from 'js-tiktoken';
+import type { Tiktoken, TiktokenModel } from "js-tiktoken";
 import {
   countTextTokens,
   getTokenProfileById,
-  type TokenProfileId,
 } from "../llm/tokenization";
+import { getMappedTokenProfileId } from "../llm/tokenization/profiles";
+
+interface LegacyTiktokenModule {
+  encodingForModel(model: TiktokenModel): Tiktoken;
+}
 
 const tokenizerCache = new Map<TiktokenModel, Tiktoken>();
+let legacyTiktokenModule: LegacyTiktokenModule | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getLegacyTiktokenModule(): LegacyTiktokenModule {
+  if (legacyTiktokenModule) {
+    return legacyTiktokenModule;
+  }
+  const loaded = require("js-tiktoken") as unknown;
+  const candidate = isRecord(loaded) && "default" in loaded
+    ? loaded.default
+    : loaded;
+  if (!isRecord(candidate) || typeof candidate.encodingForModel !== "function") {
+    throw new TypeError("js-tiktoken does not export encodingForModel.");
+  }
+  legacyTiktokenModule = Object.freeze({
+    encodingForModel: candidate.encodingForModel as
+      LegacyTiktokenModule["encodingForModel"],
+  });
+  return legacyTiktokenModule;
+}
 
 function getTokenizer(model: TiktokenModel): Tiktoken {
   if (tokenizerCache.has(model)) {
     return tokenizerCache.get(model)!;
   }
-  const tokenizer = encodingForModel(model);
+  const tokenizer = getLegacyTiktokenModule().encodingForModel(model);
   tokenizerCache.set(model, tokenizer);
   return tokenizer;
 }
@@ -39,9 +61,9 @@ function getTokenizer(model: TiktokenModel): Tiktoken {
 export function countTokens(text: string, model: TiktokenModel = 'gpt-4'): number {
   if (!text) return 0;
   try {
-    const encoding = getEncodingNameForModel(model);
-    if (encoding === "cl100k_base" || encoding === "o200k_base") {
-      const profile = getTokenProfileById(encoding as TokenProfileId);
+    const profileId = getMappedTokenProfileId("openai", model);
+    if (profileId) {
+      const profile = getTokenProfileById(profileId);
       if (profile) {
         const result = countTextTokens(text, profile);
         if (result.status === "available") {


### PR DESCRIPTION
Release v0.17.2.

Summary:
- add validated caller-injected tokenizer peer support while preserving installed discovery
- make built-in ranks lazy, literal, defensively snapshotted, and fail-closed through js-tiktoken/lite
- remove eager prompting/root tokenizer evaluation and add packed Rollup/CI verification
- update public documentation, release metadata, and archived issue/plan records

Verification:
- npm test (49 suites, 1,134 tests)
- npm run build
- npm run test:packed-api
- npm audit --omit=dev --audit-level=high
- npm pack --dry-run